### PR TITLE
feat: add Windows ConPTY support for terminal

### DIFF
--- a/runner/go.mod
+++ b/runner/go.mod
@@ -6,6 +6,7 @@ replace github.com/anthropics/agentsmesh/proto => ../proto
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
+	github.com/UserExistsError/conpty v0.1.4
 	github.com/anthropics/agentsmesh/proto v0.0.0
 	github.com/creack/pty v1.1.21
 	github.com/creativeprojects/go-selfupdate v1.5.2

--- a/runner/go.sum
+++ b/runner/go.sum
@@ -4,6 +4,8 @@ github.com/42wim/httpsig v1.2.3 h1:xb0YyWhkYj57SPtfSttIobJUPJZB9as1nsfo7KWVcEs=
 github.com/42wim/httpsig v1.2.3/go.mod h1:nZq9OlYKDrUBhptd77IHx4/sZZD+IxTBADvAPI9G/EM=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/UserExistsError/conpty v0.1.4 h1:+3FhJhiqhyEJa+K5qaK3/w6w+sN3Nh9O9VbJyBS02to=
+github.com/UserExistsError/conpty v0.1.4/go.mod h1:PDglKIkX3O/2xVk0MV9a6bCWxRmPVfxqZoTG/5sSd9I=
 github.com/creack/pty v1.1.21 h1:1/QdRyBaHHJP61QkWMXlOIBfsgdDeeKfK8SYVUWJKf0=
 github.com/creack/pty v1.1.21/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/creativeprojects/go-selfupdate v1.5.2 h1:3KR3JLrq70oplb9yZzbmJ89qRP78D1AN/9u+l3k0LJ4=
@@ -144,6 +146,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
 golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/runner/internal/terminal/terminal.go
+++ b/runner/internal/terminal/terminal.go
@@ -3,13 +3,10 @@ package terminal
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
-	"github.com/creack/pty"
 	"golang.org/x/term"
 
 	"github.com/anthropics/agentsmesh/runner/internal/logger"
@@ -36,8 +33,15 @@ type Options struct {
 
 // Terminal represents a PTY terminal session.
 type Terminal struct {
-	cmd      *exec.Cmd
-	pty      *os.File
+	// Command configuration (set in New, consumed in Start)
+	command string
+	args    []string
+	workDir string
+	env     []string
+
+	// PTY process handle (set in Start)
+	proc ptyProcess
+
 	mu       sync.Mutex
 	closed   bool
 	onOutput func([]byte)
@@ -69,10 +73,6 @@ func New(opts Options) (*Terminal, error) {
 		return nil, fmt.Errorf("command is required")
 	}
 
-	// Build command
-	cmd := exec.Command(opts.Command, opts.Args...)
-	cmd.Dir = opts.WorkDir
-
 	// Build environment with proper deduplication.
 	// Using a map prevents duplicate keys (e.g., TERM appearing twice)
 	// which can confuse some programs.
@@ -82,6 +82,9 @@ func New(opts Options) (*Terminal, error) {
 			envMap[e[:idx]] = e[idx+1:]
 		}
 	}
+	// Remove CLAUDECODE to prevent nested session detection when running
+	// Claude Code inside a pod - the runner intentionally spawns claude sessions.
+	delete(envMap, "CLAUDECODE")
 	// Ensure terminal supports colors (critical for CLI tools like claude, ls, etc.)
 	envMap["TERM"] = "xterm-256color"
 	envMap["COLORTERM"] = "truecolor"
@@ -93,7 +96,6 @@ func New(opts Options) (*Terminal, error) {
 	for k, v := range envMap {
 		env = append(env, k+"="+v)
 	}
-	cmd.Env = env
 
 	// Default terminal size if not specified
 	rows := opts.Rows
@@ -112,7 +114,10 @@ func New(opts Options) (*Terminal, error) {
 		"rows", rows)
 
 	return &Terminal{
-		cmd:      cmd,
+		command:  opts.Command,
+		args:     opts.Args,
+		workDir:  opts.WorkDir,
+		env:      env,
 		onOutput: opts.OnOutput,
 		onExit:   opts.OnExit,
 		rows:     rows,
@@ -132,22 +137,16 @@ func (t *Terminal) Start() error {
 	}
 
 	log := logger.Terminal()
-	log.Debug("Starting command", "path", t.cmd.Path, "args", t.cmd.Args, "dir", t.cmd.Dir, "cols", t.cols, "rows", t.rows)
+	log.Debug("Starting command", "command", t.command, "args", t.args, "dir", t.workDir, "cols", t.cols, "rows", t.rows)
 
-	// Start with PTY and initial size
-	// Use StartWithSize to set correct terminal dimensions from the beginning
-	// This is critical for TUI applications like Claude Code that render based on terminal size
-	winSize := &pty.Winsize{
-		Rows: uint16(t.rows),
-		Cols: uint16(t.cols),
-	}
-	ptmx, err := pty.StartWithSize(t.cmd, winSize)
+	// Start with PTY and initial size (platform-specific)
+	proc, err := startPTY(t.command, t.args, t.workDir, t.env, t.cols, t.rows)
 	if err != nil {
 		return fmt.Errorf("failed to start pty: %w", err)
 	}
-	t.pty = ptmx
+	t.proc = proc
 
-	log.Debug("PTY started", "pid", t.cmd.Process.Pid, "cols", t.cols, "rows", t.rows)
+	log.Debug("PTY started", "pid", t.proc.Pid(), "cols", t.cols, "rows", t.rows)
 
 	// Start output reader
 	safego.Go("pty-read", t.readOutput)
@@ -155,14 +154,14 @@ func (t *Terminal) Start() error {
 	// Wait for process exit
 	safego.Go("pty-wait", t.waitExit)
 
-	log.Info("Terminal started", "pid", t.cmd.Process.Pid, "cols", t.cols, "rows", t.rows)
+	log.Info("Terminal started", "pid", t.proc.Pid(), "cols", t.cols, "rows", t.rows)
 
 	return nil
 }
 
 // Stop stops the terminal with graceful shutdown.
-// It sends SIGTERM first and waits up to gracefulStopTimeout for the process to exit.
-// If the process doesn't exit in time, SIGKILL is sent as a last resort.
+// It sends a graceful stop signal first and waits up to gracefulStopTimeout
+// for the process to exit. If the process doesn't exit in time, it is killed.
 // This ensures AI agents (Claude Code, Aider, etc.) have time to perform cleanup
 // operations like saving state and releasing git locks.
 func (t *Terminal) Stop() {
@@ -175,31 +174,32 @@ func (t *Terminal) Stop() {
 		return
 	}
 	t.closed = true
-	proc := t.cmd.Process // nil if not started
+	proc := t.proc
 	t.mu.Unlock()
 
 	if proc != nil {
-		// Graceful shutdown: SIGTERM → wait → SIGKILL
-		log.Debug("Sending SIGTERM for graceful shutdown", "pid", proc.Pid)
-		if err := proc.Signal(syscall.SIGTERM); err != nil {
-			log.Debug("SIGTERM failed (process may have already exited)", "error", err)
+		// Graceful shutdown: signal → wait → kill
+		pid := proc.Pid()
+		log.Debug("Sending graceful stop signal", "pid", pid)
+		if err := proc.GracefulStop(); err != nil {
+			log.Debug("Graceful stop failed (process may have already exited)", "error", err)
 		}
 
 		// Wait for process to exit or timeout
 		select {
 		case <-t.doneCh:
-			log.Debug("Process exited gracefully after SIGTERM")
+			log.Debug("Process exited gracefully")
 		case <-time.After(gracefulStopTimeout):
-			log.Warn("Process did not exit after SIGTERM, sending SIGKILL",
-				"pid", proc.Pid, "timeout", gracefulStopTimeout)
+			log.Warn("Process did not exit after graceful stop, killing",
+				"pid", pid, "timeout", gracefulStopTimeout)
 			if err := proc.Kill(); err != nil {
-				log.Debug("SIGKILL failed (process may have already exited)", "error", err)
+				log.Debug("Kill failed (process may have already exited)", "error", err)
 			}
 			// Wait briefly for waitExit to detect the kill
 			select {
 			case <-t.doneCh:
 			case <-time.After(1 * time.Second):
-				log.Warn("Process did not exit after SIGKILL", "pid", proc.Pid)
+				log.Warn("Process did not exit after kill", "pid", pid)
 			}
 		}
 	}
@@ -210,20 +210,20 @@ func (t *Terminal) Stop() {
 	log.Info("Terminal stopped")
 }
 
-// closePTY closes the PTY file descriptor exactly once.
+// closePTY closes the PTY exactly once.
 // Safe to call from multiple goroutines (Stop and waitExit).
 func (t *Terminal) closePTY() {
 	t.ptyCloseOnce.Do(func() {
-		if t.pty != nil {
-			t.pty.Close()
+		if t.proc != nil {
+			t.proc.Close()
 		}
 	})
 }
 
 // PID returns the process ID
 func (t *Terminal) PID() int {
-	if t.cmd != nil && t.cmd.Process != nil {
-		return t.cmd.Process.Pid
+	if t.proc != nil {
+		return t.proc.Pid()
 	}
 	return 0
 }
@@ -265,11 +265,11 @@ func (t *Terminal) Write(data []byte) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	if t.closed || t.pty == nil {
+	if t.closed || t.proc == nil {
 		return fmt.Errorf("terminal is not running")
 	}
 
-	_, err := t.pty.Write(data)
+	_, err := t.proc.Write(data)
 	return err
 }
 

--- a/runner/internal/terminal/terminal_io.go
+++ b/runner/internal/terminal/terminal_io.go
@@ -3,7 +3,6 @@ package terminal
 import (
 	"io"
 	"os"
-	"os/exec"
 	"time"
 
 	"github.com/anthropics/agentsmesh/runner/internal/logger"
@@ -49,18 +48,18 @@ func (t *Terminal) readOutput() {
 		// Check if terminal is closed before reading
 		t.mu.Lock()
 		closed := t.closed
-		ptyFile := t.pty
+		proc := t.proc
 		t.mu.Unlock()
 
-		if closed || ptyFile == nil {
-			log.Debug("PTY read loop exiting", "closed", closed, "ptyFile_nil", ptyFile == nil, "read_count", readCount)
+		if closed || proc == nil {
+			log.Debug("PTY read loop exiting", "closed", closed, "proc_nil", proc == nil, "read_count", readCount)
 			return
 		}
 
 		// Read from PTY with timeout to allow periodic backpressure checks
 		// This ensures we can respond to pause signals even during slow output
-		ptyFile.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
-		n, err := ptyFile.Read(buf)
+		proc.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+		n, err := proc.Read(buf)
 
 		if err != nil {
 			// Check if it's just a timeout (expected during backpressure checks)
@@ -95,9 +94,10 @@ func (t *Terminal) readOutput() {
 					// Kill the process to trigger clean exit through waitExit/exitHandler.
 					// Without a working PTY, the user cannot interact with the process,
 					// so keeping it alive would only cause a frozen terminal.
-					if t.cmd != nil && t.cmd.Process != nil {
-						log.Info("Killing process after PTY read error", "pid", t.cmd.Process.Pid)
-						t.cmd.Process.Kill()
+					if proc != nil {
+						pid := proc.Pid()
+						log.Info("Killing process after PTY read error", "pid", pid)
+						proc.Kill()
 					}
 				}
 			} else {
@@ -148,16 +148,14 @@ func (t *Terminal) readOutput() {
 // waitExit waits for the process to exit
 func (t *Terminal) waitExit() {
 	log := logger.Terminal()
-	exitCode := 0
-	if err := t.cmd.Wait(); err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			exitCode = exitErr.ExitCode()
-		} else {
-			exitCode = -1
-		}
+
+	exitCode, err := t.proc.Wait()
+	if err != nil {
+		log.Error("Process wait error", "error", err)
 	}
 
-	log.Info("Process exited", "pid", t.cmd.Process.Pid, "exit_code", exitCode)
+	pid := t.proc.Pid()
+	log.Info("Process exited", "pid", pid, "exit_code", exitCode)
 
 	// Signal that the process has exited (unblocks Stop() if waiting)
 	close(t.doneCh)

--- a/runner/internal/terminal/terminal_pty.go
+++ b/runner/internal/terminal/terminal_pty.go
@@ -1,0 +1,36 @@
+package terminal
+
+import (
+	"io"
+	"time"
+)
+
+// ptyProcess abstracts platform-specific PTY operations.
+// Unix uses creack/pty + exec.Cmd, Windows uses ConPTY.
+type ptyProcess interface {
+	io.ReadWriteCloser
+
+	// Resize changes the terminal size (cols=width, rows=height).
+	Resize(cols, rows int) error
+
+	// GetSize returns the current terminal size (cols, rows).
+	// Returns (0, 0, ErrUnsupported) if not supported on the platform.
+	GetSize() (cols, rows int, err error)
+
+	// Pid returns the process ID.
+	Pid() int
+
+	// SetReadDeadline sets a deadline for Read operations.
+	// After the deadline, Read returns os.ErrDeadlineExceeded.
+	SetReadDeadline(t time.Time) error
+
+	// Wait blocks until the process exits and returns the exit code.
+	Wait() (exitCode int, err error)
+
+	// Kill forcefully terminates the process.
+	Kill() error
+
+	// GracefulStop sends a signal for graceful shutdown.
+	// On Unix, this sends SIGTERM. On Windows, this sends Ctrl+C.
+	GracefulStop() error
+}

--- a/runner/internal/terminal/terminal_pty_unix.go
+++ b/runner/internal/terminal/terminal_pty_unix.go
@@ -1,0 +1,102 @@
+//go:build !windows
+
+package terminal
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+
+	"github.com/creack/pty"
+)
+
+// unixPTY wraps creack/pty and exec.Cmd for Unix platforms.
+type unixPTY struct {
+	cmd     *exec.Cmd
+	ptyFile *os.File
+}
+
+// startPTY creates and starts a PTY process on Unix.
+func startPTY(command string, args []string, workDir string, env []string, cols, rows int) (ptyProcess, error) {
+	cmd := exec.Command(command, args...)
+	cmd.Dir = workDir
+	cmd.Env = env
+
+	winSize := &pty.Winsize{
+		Rows: uint16(rows),
+		Cols: uint16(cols),
+	}
+	ptmx, err := pty.StartWithSize(cmd, winSize)
+	if err != nil {
+		return nil, err
+	}
+
+	return &unixPTY{cmd: cmd, ptyFile: ptmx}, nil
+}
+
+func (p *unixPTY) Read(buf []byte) (int, error) {
+	return p.ptyFile.Read(buf)
+}
+
+func (p *unixPTY) Write(data []byte) (int, error) {
+	return p.ptyFile.Write(data)
+}
+
+func (p *unixPTY) Close() error {
+	return p.ptyFile.Close()
+}
+
+func (p *unixPTY) Resize(cols, rows int) error {
+	return pty.Setsize(p.ptyFile, &pty.Winsize{
+		Rows: uint16(rows),
+		Cols: uint16(cols),
+	})
+}
+
+func (p *unixPTY) GetSize() (int, int, error) {
+	size, err := pty.GetsizeFull(p.ptyFile)
+	if err != nil {
+		return 0, 0, err
+	}
+	return int(size.Cols), int(size.Rows), nil
+}
+
+func (p *unixPTY) Pid() int {
+	if p.cmd.Process != nil {
+		return p.cmd.Process.Pid
+	}
+	return 0
+}
+
+func (p *unixPTY) SetReadDeadline(t time.Time) error {
+	return p.ptyFile.SetReadDeadline(t)
+}
+
+func (p *unixPTY) Wait() (int, error) {
+	err := p.cmd.Wait()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return exitErr.ExitCode(), nil
+		}
+		return -1, err
+	}
+	return 0, nil
+}
+
+func (p *unixPTY) Kill() error {
+	if p.cmd.Process != nil {
+		return p.cmd.Process.Kill()
+	}
+	return nil
+}
+
+func (p *unixPTY) GracefulStop() error {
+	if p.cmd.Process != nil {
+		return p.cmd.Process.Signal(syscall.SIGTERM)
+	}
+	return fmt.Errorf("process not started")
+}

--- a/runner/internal/terminal/terminal_pty_windows.go
+++ b/runner/internal/terminal/terminal_pty_windows.go
@@ -1,0 +1,232 @@
+//go:build windows
+
+package terminal
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/UserExistsError/conpty"
+)
+
+// windowsPTY wraps ConPTY for Windows platforms.
+type windowsPTY struct {
+	cpty *conpty.ConPty
+	cols int
+	rows int
+
+	readCh    chan readResult
+	closedCh  chan struct{}
+	closeOnce sync.Once
+
+	readDeadline time.Time
+	deadlineMu   sync.Mutex
+}
+
+type readResult struct {
+	data []byte
+	n    int
+	err  error
+}
+
+func startPTY(command string, args []string, workDir string, env []string, cols, rows int) (ptyProcess, error) {
+	path, err := exec.LookPath(command)
+	if err != nil {
+		return nil, fmt.Errorf("command not found: %w", err)
+	}
+
+	cmdLine := buildCommandLine(path, args)
+
+	opts := []conpty.ConPtyOption{
+		conpty.ConPtyDimensions(cols, rows),
+	}
+	if workDir != "" {
+		opts = append(opts, conpty.ConPtyWorkDir(workDir))
+	}
+	if len(env) > 0 {
+		opts = append(opts, conpty.ConPtyEnv(env))
+	}
+
+	cpty, err := conpty.Start(cmdLine, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start conpty: %w", err)
+	}
+
+	wp := &windowsPTY{
+		cpty:     cpty,
+		cols:     cols,
+		rows:     rows,
+		readCh:   make(chan readResult, 4),
+		closedCh: make(chan struct{}),
+	}
+
+	go wp.backgroundReader()
+
+	return wp, nil
+}
+
+func buildCommandLine(path string, args []string) string {
+	parts := make([]string, 0, 1+len(args))
+	parts = append(parts, quoteWinArg(path))
+	for _, a := range args {
+		parts = append(parts, quoteWinArg(a))
+	}
+	return strings.Join(parts, " ")
+}
+
+// quoteWinArg quotes a Windows command line argument if needed.
+func quoteWinArg(s string) string {
+	if s == "" {
+		return `""`
+	}
+	needsQuote := false
+	for _, c := range s {
+		if c == ' ' || c == '\t' || c == '"' {
+			needsQuote = true
+			break
+		}
+	}
+	if !needsQuote {
+		return s
+	}
+	var buf strings.Builder
+	buf.WriteByte('"')
+	nSlash := 0
+	for _, c := range s {
+		switch {
+		case c == '\\':
+			nSlash++
+		case c == '"':
+			for i := 0; i < nSlash; i++ {
+				buf.WriteByte('\\')
+			}
+			buf.WriteByte('\\')
+			buf.WriteByte('"')
+			nSlash = 0
+		default:
+			for i := 0; i < nSlash; i++ {
+				buf.WriteByte('\\')
+			}
+			buf.WriteRune(c)
+			nSlash = 0
+		}
+	}
+	for i := 0; i < nSlash; i++ {
+		buf.WriteByte('\\')
+	}
+	buf.WriteByte('"')
+	return buf.String()
+}
+
+func (w *windowsPTY) backgroundReader() {
+	buf := make([]byte, 4096)
+	for {
+		n, err := w.cpty.Read(buf)
+		var result readResult
+		if n > 0 {
+			result.data = make([]byte, n)
+			copy(result.data, buf[:n])
+			result.n = n
+		}
+		if err != nil {
+			result.err = err
+		}
+		select {
+		case w.readCh <- result:
+		case <-w.closedCh:
+			return
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func (w *windowsPTY) Read(p []byte) (int, error) {
+	w.deadlineMu.Lock()
+	deadline := w.readDeadline
+	w.deadlineMu.Unlock()
+
+	var timer *time.Timer
+	var timerCh <-chan time.Time
+
+	if !deadline.IsZero() {
+		d := time.Until(deadline)
+		if d <= 0 {
+			return 0, os.ErrDeadlineExceeded
+		}
+		timer = time.NewTimer(d)
+		defer timer.Stop()
+		timerCh = timer.C
+	}
+
+	select {
+	case r, ok := <-w.readCh:
+		if !ok {
+			return 0, io.EOF
+		}
+		if r.n > 0 {
+			n := copy(p, r.data[:r.n])
+			return n, r.err
+		}
+		return 0, r.err
+	case <-timerCh:
+		return 0, os.ErrDeadlineExceeded
+	case <-w.closedCh:
+		return 0, io.EOF
+	}
+}
+
+func (w *windowsPTY) Write(data []byte) (int, error) {
+	return w.cpty.Write(data)
+}
+
+func (w *windowsPTY) Close() error {
+	var err error
+	w.closeOnce.Do(func() {
+		close(w.closedCh)
+		err = w.cpty.Close()
+	})
+	return err
+}
+
+func (w *windowsPTY) Resize(cols, rows int) error {
+	w.cols = cols
+	w.rows = rows
+	return w.cpty.Resize(cols, rows)
+}
+
+func (w *windowsPTY) GetSize() (int, int, error) {
+	return w.cols, w.rows, nil
+}
+
+func (w *windowsPTY) Pid() int {
+	return w.cpty.Pid()
+}
+
+func (w *windowsPTY) SetReadDeadline(t time.Time) error {
+	w.deadlineMu.Lock()
+	w.readDeadline = t
+	w.deadlineMu.Unlock()
+	return nil
+}
+
+func (w *windowsPTY) Wait() (int, error) {
+	exitCode, err := w.cpty.Wait(context.Background())
+	return int(exitCode), err
+}
+
+func (w *windowsPTY) Kill() error {
+	return w.Close()
+}
+
+func (w *windowsPTY) GracefulStop() error {
+	_, err := w.cpty.Write([]byte{0x03})
+	return err
+}

--- a/runner/internal/terminal/terminal_resize.go
+++ b/runner/internal/terminal/terminal_resize.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/creack/pty"
-
 	"github.com/anthropics/agentsmesh/runner/internal/logger"
 )
 
@@ -16,16 +14,13 @@ func (t *Terminal) Resize(cols, rows int) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	if t.closed || t.pty == nil {
+	if t.closed || t.proc == nil {
 		return fmt.Errorf("terminal is not running")
 	}
 
 	logger.Terminal().Debug("Terminal resize", "cols", cols, "rows", rows)
 
-	return pty.Setsize(t.pty, &pty.Winsize{
-		Rows: uint16(rows),
-		Cols: uint16(cols),
-	})
+	return t.proc.Resize(cols, rows)
 }
 
 // Redraw triggers a terminal redraw by temporarily changing the terminal size.
@@ -36,21 +31,18 @@ func (t *Terminal) Redraw() error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	if t.closed || t.pty == nil {
+	if t.closed || t.proc == nil {
 		return fmt.Errorf("terminal is not running")
 	}
 
 	// Get current size
-	size, err := pty.GetsizeFull(t.pty)
+	cols, rows, err := t.proc.GetSize()
 	if err != nil {
 		return fmt.Errorf("failed to get terminal size: %w", err)
 	}
 
 	// Resize to cols+1 to trigger redraw
-	if err := pty.Setsize(t.pty, &pty.Winsize{
-		Rows: size.Rows,
-		Cols: size.Cols + 1,
-	}); err != nil {
+	if err := t.proc.Resize(cols+1, rows); err != nil {
 		return fmt.Errorf("failed to expand terminal: %w", err)
 	}
 
@@ -58,10 +50,7 @@ func (t *Terminal) Redraw() error {
 	time.Sleep(50 * time.Millisecond)
 
 	// Resize back to original size
-	if err := pty.Setsize(t.pty, &pty.Winsize{
-		Rows: size.Rows,
-		Cols: size.Cols,
-	}); err != nil {
+	if err := t.proc.Resize(cols, rows); err != nil {
 		return fmt.Errorf("failed to restore terminal size: %w", err)
 	}
 

--- a/runner/internal/terminal/terminal_struct_test.go
+++ b/runner/internal/terminal/terminal_struct_test.go
@@ -47,8 +47,8 @@ func TestNewTerminal(t *testing.T) {
 		t.Fatal("New returned nil")
 	}
 
-	if term.cmd == nil {
-		t.Error("cmd should not be nil")
+	if term.command != "echo" {
+		t.Errorf("command should be echo, got %s", term.command)
 	}
 }
 
@@ -76,7 +76,7 @@ func TestNewTerminalWithEnv(t *testing.T) {
 
 	// Check that environment is set
 	envFound := false
-	for _, e := range term.cmd.Env {
+	for _, e := range term.env {
 		if e == "TEST_VAR=test_value" {
 			envFound = true
 			break
@@ -147,7 +147,9 @@ func TestTerminalStartClosed(t *testing.T) {
 	}
 
 	term, _ := New(opts)
+	term.mu.Lock()
 	term.closed = true
+	term.mu.Unlock()
 
 	err := term.Start()
 	if err == nil {
@@ -175,12 +177,6 @@ func TestMakeRawInvalidFd(t *testing.T) {
 }
 
 func TestRestoreInvalidFd(t *testing.T) {
-	// Create a dummy state by attempting MakeRaw on a valid-ish fd first
-	// Since we can't get a real terminal state in tests, we just verify
-	// the function handles invalid fd gracefully
-	// Note: We don't test nil state as it causes panic in the underlying term package
-	// which is expected behavior (caller's responsibility to pass valid state)
-
 	// Just verify the function exists and is callable
 	// Testing with actual terminal state would require a real terminal
 }


### PR DESCRIPTION
## Summary

- Add Windows ConPTY support so the runner can create terminal pods on Windows
- Introduce a `ptyProcess` interface to abstract platform-specific PTY operations
- Unix uses existing `creack/pty`, Windows uses `UserExistsError/conpty` (Windows ConPTY API)
- Filter `CLAUDECODE` env var to prevent nested Claude session detection

## Problem

The runner's terminal package used `creack/pty` which only supports Unix. On Windows, `pty.Start()` returns `ErrUnsupported`, making it impossible to start pods:

```
failed to start terminal: failed to start pty: unsupported
```

## Solution

Platform-abstracted PTY via build tags:

| File | Platform | Description |
|------|----------|-------------|
| `terminal_pty.go` | All | `ptyProcess` interface definition |
| `terminal_pty_unix.go` | `!windows` | Wraps `creack/pty` + `exec.Cmd` |
| `terminal_pty_windows.go` | `windows` | Wraps Windows ConPTY via `conpty` package |

Key Windows-specific details:
- Non-blocking reads via goroutine+channel pattern (ConPTY doesn't support `SetReadDeadline`)
- Proper Windows command-line argument escaping
- Graceful stop sends Ctrl+C (`0x03`) via ConPTY input

## Test plan

- [x] Tested on Windows (MSYS2/Git Bash) - terminal starts, claude process runs, output is produced
- [ ] Verify Unix builds still work (no changes to Unix behavior, only refactored to interface)
- [ ] CI build verification

?? Generated with [Claude Code](https://claude.com/claude-code)