### PR TITLE
fix(web): fix channel chat panel barely visible and not resizable

### DIFF
--- a/web/src/app/(dashboard)/[org]/mesh/page.tsx
+++ b/web/src/app/(dashboard)/[org]/mesh/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 import { Group, Panel, Separator } from "react-resizable-panels";
+import { GripVertical } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { CenteredSpinner } from "@/components/ui/spinner";
 import { MeshTopology } from "@/components/mesh";
@@ -163,15 +164,20 @@ export default function MeshPage() {
         /* Resizable layout when chat panel is open on desktop */
         <Group
           orientation="horizontal"
-          className="h-full hidden md:flex"
+          className="h-full hidden md:flex flex-1"
         >
           <Panel defaultSize={65} minSize={40}>
             {topologyContent}
           </Panel>
           <Separator
-            className="group relative flex items-center justify-center w-1 bg-transparent hover:bg-primary transition-colors cursor-col-resize"
+            className="group relative flex items-center justify-center w-1 bg-transparent hover:bg-primary/50 transition-colors cursor-col-resize"
           >
-            <div className="absolute z-10 w-3 h-full -left-1" />
+            {/* Expand hit area for easier grabbing */}
+            <div className="absolute w-3 h-full -left-1 pointer-events-none" />
+            {/* Grip indicator */}
+            <div className="opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground">
+              <GripVertical className="h-4 w-4" />
+            </div>
           </Separator>
           <Panel defaultSize={35} minSize={20} maxSize={50}>
             <ChannelChatPanel


### PR DESCRIPTION
## Summary
- **Channel chat panel barely visible**: The resizable `Group` component was missing `flex-1`, so it didn't fill the parent flex container — the chat panel got squeezed to ~120px on the far right
- **Cannot drag to resize**: The hit area div inside the Separator had `z-10` without `pointer-events-none`, intercepting drag events before the resize handle could process them
- **No visual feedback**: Added `GripVertical` icon on hover so users can discover the resize handle

## Test plan
- [ ] Open Mesh page, click a channel to open chat panel
- [ ] Verify chat panel takes ~35% width and messages are fully readable
- [ ] Hover over the separator between topology and chat — should see blue highlight + grip icon
- [ ] Drag the separator left/right — panel should resize smoothly (chat: 20%~50%)
- [ ] Verify mobile overlay still works on small screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)