### PR TITLE
fix(web): eliminate cascading re-renders causing CreatePod dropdown flicker

### DIFF
--- a/web/src/app/(dashboard)/[org]/tickets/page.tsx
+++ b/web/src/app/(dashboard)/[org]/tickets/page.tsx
@@ -14,12 +14,12 @@ export default function TicketsPage() {
   const t = useTranslations();
   const router = useRouter();
   const { currentOrg } = useAuthStore();
-  const {
-    loading,
-    viewMode,
-    fetchTickets,
-    updateTicketStatus,
-  } = useTicketStore();
+
+  // Use individual selectors to prevent re-renders from unrelated store changes
+  const loading = useTicketStore(state => state.loading);
+  const viewMode = useTicketStore(state => state.viewMode);
+  const fetchTickets = useTicketStore(state => state.fetchTickets);
+  const updateTicketStatus = useTicketStore(state => state.updateTicketStatus);
 
   const tickets = useFilteredTickets();
 

--- a/web/src/components/tickets/TicketDetail.tsx
+++ b/web/src/components/tickets/TicketDetail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useCallback, useRef, lazy, Suspense } from "react";
+import { useEffect, useCallback, useRef, lazy, Suspense, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
@@ -22,7 +22,20 @@ export function TicketDetail({ slug }: TicketDetailProps) {
   const router = useRouter();
   const t = useTranslations();
   const { currentOrg } = useAuthStore();
-  const { currentTicket, fetchTicket, updateTicket, updateTicketStatus, deleteTicket, loading, error } = useTicketStore();
+
+  // Use individual selectors to prevent re-renders from unrelated store changes
+  // (e.g., fetchTickets() triggered by WebSocket events sets shared `loading`)
+  const currentTicket = useTicketStore(state => state.currentTicket);
+  const fetchTicket = useTicketStore(state => state.fetchTicket);
+  const updateTicket = useTicketStore(state => state.updateTicket);
+  const updateTicketStatus = useTicketStore(state => state.updateTicketStatus);
+  const deleteTicket = useTicketStore(state => state.deleteTicket);
+  const error = useTicketStore(state => state.error);
+
+  // Local loading state to avoid re-renders from shared store `loading`
+  // Derived from whether we've loaded the current slug (avoids setState in effect)
+  const [loadedSlug, setLoadedSlug] = useState<string | null>(null);
+  const initialLoading = loadedSlug !== slug;
 
   const { dialogProps, confirm } = useConfirmDialog();
   const { subTickets, relations, commits, comments, addComment, updateComment, deleteComment } = useTicketExtraData(slug, !!currentTicket);
@@ -38,7 +51,7 @@ export function TicketDetail({ slug }: TicketDetailProps) {
   }, []);
 
   useEffect(() => {
-    fetchTicket(slug);
+    fetchTicket(slug).finally(() => setLoadedSlug(slug));
   }, [slug, fetchTicket]);
 
   const handleTitleSave = useCallback(async (newTitle: string) => {
@@ -98,7 +111,7 @@ export function TicketDetail({ slug }: TicketDetailProps) {
     }
   }, [confirm, deleteTicket, slug, router, currentOrg, t]);
 
-  if (loading && !currentTicket) {
+  if (initialLoading && !currentTicket) {
     return <TicketDetailSkeleton />;
   }
 

--- a/web/src/components/tickets/TicketDetailSidebar.tsx
+++ b/web/src/components/tickets/TicketDetailSidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { Ticket, TicketStatus, TicketPriority } from "@/stores/ticket";
@@ -252,22 +252,26 @@ function SidebarPodSection({
     (p) => p.status !== "running" && p.status !== "initializing"
   );
 
+  // Memoize ticketContext to prevent CreatePodModal re-renders on parent re-render
+  const ticketContext = useMemo(() =>
+    ticket.id
+      ? {
+          id: ticket.id,
+          slug: ticketSlug,
+          title: ticket.title,
+          repositoryId: ticket.repository_id,
+        }
+      : undefined,
+    [ticket.id, ticketSlug, ticket.title, ticket.repository_id]
+  );
+
   return (
     <>
       <CreatePodModal
         open={showCreateModal}
         onClose={() => setShowCreateModal(false)}
         onCreated={handlePodCreated}
-        ticketContext={
-          ticket.id
-            ? {
-                id: ticket.id,
-                slug: ticketSlug,
-                title: ticket.title,
-                repositoryId: ticket.repository_id,
-              }
-            : undefined
-        }
+        ticketContext={ticketContext}
       />
 
       <div className="rounded-xl border border-border/60 bg-card shadow-sm overflow-hidden">

--- a/web/src/components/tickets/__tests__/TicketDetail.test.tsx
+++ b/web/src/components/tickets/__tests__/TicketDetail.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@/test/test-utils'
 import { TicketDetail } from '../TicketDetail'
-import { useTicketStore } from '@/stores/ticket'
 import { ticketApi } from '@/lib/api'
 
 // Mock next/navigation
@@ -22,9 +21,12 @@ vi.mock('@/stores/auth', () => ({
   }),
 }))
 
-// Mock ticket store
+// Mock ticket store — supports both selector and no-selector calls
+const mockTicketStoreState: Record<string, unknown> = {}
 vi.mock('@/stores/ticket', () => ({
-  useTicketStore: vi.fn(),
+  useTicketStore: vi.fn((selector?: (state: Record<string, unknown>) => unknown) =>
+    selector ? selector(mockTicketStoreState) : mockTicketStoreState
+  ),
   getStatusInfo: (status: string) => ({
     label: status.replace('_', ' ').replace(/\b\w/g, l => l.toUpperCase()),
     color: 'text-gray-700',
@@ -111,7 +113,7 @@ describe('TicketDetail Component', () => {
     repository: { id: 1, name: 'my-repo' },
   }
 
-  const mockFetchTicket = vi.fn()
+  const mockFetchTicket = vi.fn().mockResolvedValue(undefined)
   const mockUpdateTicket = vi.fn()
   const mockUpdateTicketStatus = vi.fn()
   const mockDeleteTicket = vi.fn()
@@ -119,7 +121,8 @@ describe('TicketDetail Component', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    ;(useTicketStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+    // Update mutable store state (shared with the mock)
+    Object.assign(mockTicketStoreState, {
       currentTicket: mockTicket,
       fetchTicket: mockFetchTicket,
       updateTicket: mockUpdateTicket,
@@ -179,12 +182,8 @@ describe('TicketDetail Component', () => {
 
   describe('loading state', () => {
     it('should render skeleton when loading', () => {
-      ;(useTicketStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      Object.assign(mockTicketStoreState, {
         currentTicket: null,
-        fetchTicket: mockFetchTicket,
-        updateTicket: mockUpdateTicket,
-        updateTicketStatus: mockUpdateTicketStatus,
-        deleteTicket: mockDeleteTicket,
         loading: true,
         error: null,
       })
@@ -195,70 +194,62 @@ describe('TicketDetail Component', () => {
   })
 
   describe('error state', () => {
-    it('should render error message', () => {
-      ;(useTicketStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+    it('should render error message', async () => {
+      Object.assign(mockTicketStoreState, {
         currentTicket: null,
-        fetchTicket: mockFetchTicket,
-        updateTicket: mockUpdateTicket,
-        updateTicketStatus: mockUpdateTicketStatus,
-        deleteTicket: mockDeleteTicket,
         loading: false,
         error: 'Failed to load ticket',
       })
 
       render(<TicketDetail slug="PROJ-42" />)
-      expect(screen.getByText('Failed to load ticket')).toBeInTheDocument()
+      await waitFor(() => {
+        expect(screen.getByText('Failed to load ticket')).toBeInTheDocument()
+      })
     })
 
-    it('should render retry button on error', () => {
-      ;(useTicketStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+    it('should render retry button on error', async () => {
+      Object.assign(mockTicketStoreState, {
         currentTicket: null,
-        fetchTicket: mockFetchTicket,
-        updateTicket: mockUpdateTicket,
-        updateTicketStatus: mockUpdateTicketStatus,
-        deleteTicket: mockDeleteTicket,
         loading: false,
         error: 'Failed to load ticket',
       })
 
       render(<TicketDetail slug="PROJ-42" />)
-      const retryButton = screen.getByText('Retry')
-      expect(retryButton).toBeInTheDocument()
+      await waitFor(() => {
+        const retryButton = screen.getByText('Retry')
+        expect(retryButton).toBeInTheDocument()
+      })
     })
 
-    it('should call fetchTicket when retry is clicked', () => {
-      ;(useTicketStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+    it('should call fetchTicket when retry is clicked', async () => {
+      Object.assign(mockTicketStoreState, {
         currentTicket: null,
-        fetchTicket: mockFetchTicket,
-        updateTicket: mockUpdateTicket,
-        updateTicketStatus: mockUpdateTicketStatus,
-        deleteTicket: mockDeleteTicket,
         loading: false,
         error: 'Failed to load ticket',
       })
 
       render(<TicketDetail slug="PROJ-42" />)
-      const retryButton = screen.getByText('Retry')
-      fireEvent.click(retryButton)
+      await waitFor(() => {
+        const retryButton = screen.getByText('Retry')
+        fireEvent.click(retryButton)
+      })
 
       expect(mockFetchTicket).toHaveBeenCalledTimes(2)
     })
   })
 
   describe('not found state', () => {
-    it('should render not found message when ticket is null', () => {
-      ;(useTicketStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+    it('should render not found message when ticket is null', async () => {
+      Object.assign(mockTicketStoreState, {
         currentTicket: null,
-        fetchTicket: mockFetchTicket,
-        updateTicket: mockUpdateTicket,
-        updateTicketStatus: mockUpdateTicketStatus,
-        deleteTicket: mockDeleteTicket,
         loading: false,
         error: null,
       })
 
       render(<TicketDetail slug="PROJ-42" />)
-      expect(screen.getByText('Ticket not found')).toBeInTheDocument()
+      await waitFor(() => {
+        expect(screen.getByText('Ticket not found')).toBeInTheDocument()
+      })
     })
   })
 
@@ -288,14 +279,8 @@ describe('TicketDetail Component', () => {
     })
 
     it('should show no assignees message when empty', async () => {
-      ;(useTicketStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      Object.assign(mockTicketStoreState, {
         currentTicket: { ...mockTicket, assignees: [] },
-        fetchTicket: mockFetchTicket,
-        updateTicket: mockUpdateTicket,
-        updateTicketStatus: mockUpdateTicketStatus,
-        deleteTicket: mockDeleteTicket,
-        loading: false,
-        error: null,
       })
 
       render(<TicketDetail slug="PROJ-42" />)

--- a/web/src/providers/RealtimeProvider.tsx
+++ b/web/src/providers/RealtimeProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { createContext, useContext, useEffect, useCallback, useRef } from "react";
+import React, { createContext, useContext, useEffect, useCallback, useRef, useMemo } from "react";
 import { useRealtimeConnection, useAllEventsSubscription } from "@/hooks/useRealtimeEvents";
 import { usePodStore } from "@/stores/pod";
 import { useRunnerStore } from "@/stores/runner";
@@ -57,15 +57,11 @@ export function RealtimeProvider({
   // within seconds) are coalesced into a single API refresh cycle.
   const loopDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Get store actions
-  const podStore = usePodStore();
-  const runnerStore = useRunnerStore();
-  const ticketStore = useTicketStore();
-  const meshStore = useMeshStore();
-  const workspaceStore = useWorkspaceStore();
-  const channelStore = useChannelStore();
-  const autopilotStore = useAutopilotStore();
-  const loopStore = useLoopStore();
+  // NOTE: All store access uses getState() inside the event handler to avoid
+  // subscribing RealtimeProvider to store state changes. Reactive subscriptions
+  // would cause RealtimeProvider to re-render on every store update, creating
+  // cascading re-renders that cause UI flicker (e.g., native <select> dropdowns
+  // closing when the component tree re-renders).
 
   // Handle all events and route to appropriate stores
   const handleEvent = useCallback(
@@ -75,24 +71,25 @@ export function RealtimeProvider({
         case "pod:created": {
           const data = event.data as PodCreatedData;
           // Fetch the individual pod to avoid resetting pagination state
-          podStore.fetchPod?.(data.pod_key);
+          usePodStore.getState().fetchPod?.(data.pod_key);
           // Also refresh Mesh topology since a new pod affects the mesh
-          meshStore.fetchTopology?.();
+          useMeshStore.getState().fetchTopology?.();
           console.log("[Realtime] Pod created:", data.pod_key);
           break;
         }
 
         case "pod:status_changed": {
           const data = event.data as PodStatusChangedData;
+          const podState = usePodStore.getState();
           // Check if pod exists in store - if not, fetch the individual pod
-          const existingPod = podStore.pods.find(p => p.pod_key === data.pod_key);
+          const existingPod = podState.pods.find(p => p.pod_key === data.pod_key);
           if (!existingPod) {
             // Pod not in list, might be newly created - fetch individual pod
-            podStore.fetchPod?.(data.pod_key);
+            podState.fetchPod?.(data.pod_key);
             console.log("[Realtime] Pod not found, fetching:", data.pod_key);
-          } else if (podStore.updatePodStatus) {
+          } else if (podState.updatePodStatus) {
             // Update existing pod status (including error details if present)
-            podStore.updatePodStatus(
+            podState.updatePodStatus(
               data.pod_key,
               data.status as "running" | "initializing" | "failed" | "paused" | "terminated" | "error",
               data.agent_status,
@@ -101,7 +98,7 @@ export function RealtimeProvider({
             );
           }
           // Also refresh Mesh topology since pod status affects the mesh
-          meshStore.fetchTopology?.();
+          useMeshStore.getState().fetchTopology?.();
           console.log("[Realtime] Pod status changed:", data.pod_key, data.status);
           break;
         }
@@ -109,7 +106,7 @@ export function RealtimeProvider({
         case "pod:agent_status_changed": {
           const data = event.data as PodStatusChangedData;
           if (data.agent_status) {
-            podStore.updateAgentStatus(data.pod_key, data.agent_status);
+            usePodStore.getState().updateAgentStatus(data.pod_key, data.agent_status);
           }
           console.log("[Realtime] Pod agent status changed:", data.pod_key, data.agent_status);
           break;
@@ -118,11 +115,9 @@ export function RealtimeProvider({
         case "pod:terminated": {
           const data = event.data as PodStatusChangedData;
           // Update pod status to terminated
-          if (podStore.updatePodStatus) {
-            podStore.updatePodStatus(data.pod_key, "terminated");
-          }
+          usePodStore.getState().updatePodStatus?.(data.pod_key, "terminated");
           // Also refresh Mesh topology since termination removes the pod from mesh
-          meshStore.fetchTopology?.();
+          useMeshStore.getState().fetchTopology?.();
           console.log("[Realtime] Pod terminated:", data.pod_key);
           break;
         }
@@ -130,11 +125,11 @@ export function RealtimeProvider({
         case "pod:title_changed": {
           const data = event.data as PodTitleChangedData;
           // Update terminal pane title in workspace store
-          workspaceStore.updatePaneTitle(data.pod_key, data.title);
+          useWorkspaceStore.getState().updatePaneTitle(data.pod_key, data.title);
           // Also update pod title in podStore for sidebar display
-          podStore.updatePodTitle(data.pod_key, data.title);
+          usePodStore.getState().updatePodTitle(data.pod_key, data.title);
           // Also update node title in meshStore for mesh view display
-          meshStore.updateNodeTitle(data.pod_key, data.title);
+          useMeshStore.getState().updateNodeTitle(data.pod_key, data.title);
           console.log("[Realtime] Pod title changed:", data.pod_key, data.title);
           break;
         }
@@ -142,7 +137,7 @@ export function RealtimeProvider({
         case "pod:init_progress": {
           const data = event.data as PodInitProgressData;
           // Update pod init progress in podStore
-          podStore.updatePodInitProgress(data.pod_key, data.phase, data.progress, data.message);
+          usePodStore.getState().updatePodInitProgress(data.pod_key, data.phase, data.progress, data.message);
           console.log("[Realtime] Pod init progress:", data.pod_key, data.phase, data.progress);
           break;
         }
@@ -152,13 +147,10 @@ export function RealtimeProvider({
         case "runner:offline":
         case "runner:updated": {
           const data = event.data as RunnerStatusData;
-          // Update runner status in store
-          if (runnerStore.updateRunnerStatus) {
-            runnerStore.updateRunnerStatus(
-              data.runner_id,
-              data.status as "online" | "offline" | "maintenance" | "busy"
-            );
-          }
+          useRunnerStore.getState().updateRunnerStatus(
+            data.runner_id,
+            data.status as "online" | "offline" | "maintenance" | "busy"
+          );
           console.log("[Realtime] Runner status:", data.runner_id, data.status);
           break;
         }
@@ -171,7 +163,7 @@ export function RealtimeProvider({
         case "ticket:deleted": {
           const data = event.data as TicketStatusChangedData;
           // Refresh tickets list
-          ticketStore.fetchTickets?.();
+          useTicketStore.getState().fetchTickets?.();
           console.log("[Realtime] Ticket event:", event.type, data.slug);
           break;
         }
@@ -179,10 +171,11 @@ export function RealtimeProvider({
         // Channel events
         case "channel:message": {
           const data = event.data as ChannelMessageData;
+          const channelState = useChannelStore.getState();
           // Only add message if it belongs to the current channel
-          const currentChannel = channelStore.currentChannel;
+          const currentChannel = channelState.currentChannel;
           if (currentChannel && currentChannel.id === data.channel_id) {
-            channelStore.addMessage({
+            channelState.addMessage({
               id: data.id,
               channel_id: data.channel_id,
               sender_pod: data.sender_pod,
@@ -215,7 +208,7 @@ export function RealtimeProvider({
         // AutopilotController events
         case "autopilot:status_changed": {
           const data = event.data as AutopilotStatusChangedData;
-          autopilotStore.updateAutopilotControllerStatus(
+          useAutopilotStore.getState().updateAutopilotControllerStatus(
             data.autopilot_controller_key,
             data.phase,
             data.current_iteration,
@@ -229,7 +222,7 @@ export function RealtimeProvider({
 
         case "autopilot:iteration": {
           const data = event.data as AutopilotIterationData;
-          autopilotStore.addIteration(data.autopilot_controller_key, {
+          useAutopilotStore.getState().addIteration(data.autopilot_controller_key, {
             id: 0, // Will be assigned by server
             autopilot_controller_id: 0,
             iteration: data.iteration,
@@ -246,21 +239,21 @@ export function RealtimeProvider({
         case "autopilot:created": {
           const data = event.data as AutopilotCreatedData;
           // Refresh autopilot controllers list to include the new one
-          autopilotStore.fetchAutopilotControllers?.();
+          useAutopilotStore.getState().fetchAutopilotControllers?.();
           console.log("[Realtime] Autopilot created:", data.autopilot_controller_key);
           break;
         }
 
         case "autopilot:terminated": {
           const data = event.data as AutopilotTerminatedData;
-          autopilotStore.removeAutopilotController(data.autopilot_controller_key);
+          useAutopilotStore.getState().removeAutopilotController(data.autopilot_controller_key);
           console.log("[Realtime] Autopilot terminated:", data.autopilot_controller_key, data.reason);
           break;
         }
 
         case "autopilot:thinking": {
           const data = event.data as AutopilotThinkingData;
-          autopilotStore.updateThinking(data.autopilot_controller_key, data);
+          useAutopilotStore.getState().updateThinking(data.autopilot_controller_key, data);
           console.log("[Realtime] Autopilot thinking:", data.autopilot_controller_key, data.decision_type);
           break;
         }
@@ -273,11 +266,11 @@ export function RealtimeProvider({
           const data = event.data as MREventData;
           // Refresh tickets if this MR is associated with a ticket
           if (data.ticket_slug || data.ticket_id) {
-            ticketStore.fetchTickets?.();
+            useTicketStore.getState().fetchTickets?.();
           }
           // Refresh pods if this MR is associated with a pod
           if (data.pod_id) {
-            podStore.fetchPods?.();
+            usePodStore.getState().fetchPods?.();
           }
           console.log("[Realtime] MR event:", event.type, data.mr_iid, data.state);
           break;
@@ -288,11 +281,11 @@ export function RealtimeProvider({
           const data = event.data as PipelineEventData;
           // Refresh tickets if this pipeline is associated with a ticket
           if (data.ticket_slug || data.ticket_id) {
-            ticketStore.fetchTickets?.();
+            useTicketStore.getState().fetchTickets?.();
           }
           // Refresh pods if this pipeline is associated with a pod
           if (data.pod_id) {
-            podStore.fetchPods?.();
+            usePodStore.getState().fetchPods?.();
           }
           console.log("[Realtime] Pipeline event:", data.pipeline_id, data.pipeline_status);
           break;
@@ -336,9 +329,9 @@ export function RealtimeProvider({
           console.log("[Realtime] Unknown event:", event.type);
       }
     },
-    // loopStore is accessed via useLoopStore.getState() to avoid stale closures
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [podStore, runnerStore, ticketStore, meshStore, workspaceStore, channelStore, autopilotStore, onTerminalNotification, onTaskCompleted, t]
+    // Only external callbacks and translation function are dependencies.
+    // All stores are accessed via getState() to avoid reactive subscriptions.
+    [onTerminalNotification, onTaskCompleted, t]
   );
 
   // Subscribe to all events
@@ -356,21 +349,21 @@ export function RealtimeProvider({
   // Refresh data when reconnected
   useEffect(() => {
     if (connectionState === "connected") {
-      // Refresh all stores after reconnection
-      podStore.fetchSidebarPods?.(usePodStore.getState().currentSidebarFilter);
-      runnerStore.fetchRunners?.();
-      ticketStore.fetchTickets?.();
-      meshStore.fetchTopology?.();
-      autopilotStore.fetchAutopilotControllers?.();
-      loopStore.fetchLoops?.();
+      // Refresh all stores after reconnection (using getState to avoid subscriptions)
+      usePodStore.getState().fetchSidebarPods?.(usePodStore.getState().currentSidebarFilter);
+      useRunnerStore.getState().fetchRunners?.();
+      useTicketStore.getState().fetchTickets?.();
+      useMeshStore.getState().fetchTopology?.();
+      useAutopilotStore.getState().fetchAutopilotControllers?.();
+      useLoopStore.getState().fetchLoops?.();
     }
-    // Store objects are stable, only connectionState changes trigger refresh
-  }, [connectionState]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [connectionState]);
 
-  const value: RealtimeContextValue = {
+  // Memoize context value to prevent unnecessary consumer re-renders
+  const value = useMemo<RealtimeContextValue>(() => ({
     connectionState,
     reconnect,
-  };
+  }), [connectionState, reconnect]);
 
   return (
     <RealtimeContext.Provider value={value}>


### PR DESCRIPTION
## Summary

- Replace 8 reactive Zustand store subscriptions in `RealtimeProvider` with `getState()` to prevent re-renders on every WebSocket event
- Use individual Zustand selectors in `TicketDetail` and `TicketsPage` instead of full store destructuring
- Memoize `ticketContext` in `TicketDetailSidebar` to prevent unnecessary `CreatePodModal` prop changes
- Add local `loadedSlug` derived loading state in `TicketDetail` to avoid shared store `loading` interference

## Root Cause

`RealtimeProvider` subscribed to 8 full Zustand stores reactively, causing re-renders on every WebSocket event. This cascaded through the component tree to `CreatePodForm`'s native `<select>` dropdown (RunnerSelect), causing the browser to close the dropdown immediately after opening.

## Test plan

- [x] All 1218 tests pass (`pnpm test:run`)
- [x] TypeScript check passes (`pnpm tsc --noEmit`)
- [x] ESLint passes (`pnpm lint`)
- [ ] Manual: Open CreatePod modal on ticket detail page, verify runner dropdown stays open
- [ ] Manual: Verify WebSocket events still update stores correctly (pod status, ticket updates)