### PR TITLE
fix(runner): add relay URL fallback for local runners

### DIFF
--- a/runner/internal/relay/client.go
+++ b/runner/internal/relay/client.go
@@ -38,9 +38,10 @@ type ImagePasteHandler func(mimeType string, data []byte)
 // Note: sessionID has been removed - channels are now identified by PodKey only
 type Client struct {
 	// Configuration
-	relayURL string
-	podKey   string
-	token    string // JWT token for authentication
+	relayURL    string
+	fallbackURL string // Fallback relay URL if primary fails (e.g., Docker-internal URL → public URL)
+	podKey      string
+	token       string // JWT token for authentication
 
 	// WebSocket connection
 	conn   *websocket.Conn
@@ -137,6 +138,11 @@ func (c *Client) UpdateToken(newToken string) {
 	c.token = newToken
 	c.connMu.Unlock()
 	c.logger.Info("Token updated")
+}
+
+// SetFallbackURL sets a fallback URL to try if the primary relay URL fails.
+func (c *Client) SetFallbackURL(url string) {
+	c.fallbackURL = url
 }
 
 // GetRelayURL returns the relay URL

--- a/runner/internal/relay/client_connection.go
+++ b/runner/internal/relay/client_connection.go
@@ -10,13 +10,27 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-// Connect establishes connection to the Relay server
+// Connect establishes connection to the Relay server.
+// If the primary URL fails and a fallback URL is set, it retries with the fallback.
+// On fallback success, the primary URL is permanently updated to the fallback.
 func (c *Client) Connect() error {
 	c.reconnectMu.Lock()
 	defer c.reconnectMu.Unlock()
 
 	if err := c.connectInternal(); err != nil {
-		return err
+		// If primary URL failed and we have a fallback, try it
+		if c.fallbackURL != "" && c.fallbackURL != c.relayURL {
+			c.logger.Warn("Primary relay URL failed, trying fallback",
+				"primary", c.relayURL, "fallback", c.fallbackURL, "error", err)
+			c.relayURL = c.fallbackURL
+			c.fallbackURL = "" // Clear to prevent loops
+			if err2 := c.connectInternal(); err2 != nil {
+				return err2
+			}
+			// Fall through to success
+		} else {
+			return err
+		}
 	}
 
 	// Mark as connected after successful dial

--- a/runner/internal/relay/interface.go
+++ b/runner/internal/relay/interface.go
@@ -17,6 +17,7 @@ type RelayClient interface {
 	GetRelayURL() string
 	GetConnectedAt() int64
 	UpdateToken(newToken string)
+	SetFallbackURL(url string)
 
 	// Handler registration
 	SetInputHandler(handler InputHandler)

--- a/runner/internal/relay/mock_client.go
+++ b/runner/internal/relay/mock_client.go
@@ -144,6 +144,11 @@ func (m *MockClient) SetTokenExpiredHandler(handler func() string) {
 	m.onTokenExpired = handler
 }
 
+// SetFallbackURL implements RelayClient.
+func (m *MockClient) SetFallbackURL(url string) {
+	// No-op for mock
+}
+
 // SendOutput implements RelayClient.
 func (m *MockClient) SendOutput(data []byte) error {
 	return nil

--- a/runner/internal/runner/message_handler_relay.go
+++ b/runner/internal/runner/message_handler_relay.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"fmt"
 	"log/slog"
+	"net/url"
 	"time"
 
 	"github.com/anthropics/agentsmesh/runner/internal/client"
@@ -54,6 +55,12 @@ func (h *RunnerMessageHandler) OnSubscribeTerminal(req client.SubscribeTerminalR
 		req.RunnerToken,
 		slog.Default().With("pod_key", req.PodKey),
 	)
+
+	// Set fallback relay URL derived from server_url for local runners
+	// that can't resolve Docker-internal hostnames (e.g., ws://relay:8090)
+	if fallback := h.buildFallbackRelayURL(); fallback != "" {
+		relayClient.SetFallbackURL(fallback)
+	}
 
 	h.setupRelayClientHandlers(relayClient, pod, req)
 
@@ -180,6 +187,29 @@ func (h *RunnerMessageHandler) setupRelayClientHandlers(relayClient relay.RelayC
 			}()
 		}
 	})
+}
+
+// buildFallbackRelayURL derives a fallback relay WebSocket URL from the runner's server_url config.
+// For example, server_url "http://localhost:29400" becomes "ws://localhost:29400/relay".
+// This allows local runners to reach the relay via Traefik when the backend-provided
+// relay URL is a Docker-internal address (e.g., ws://relay:8090).
+func (h *RunnerMessageHandler) buildFallbackRelayURL() string {
+	serverURL := h.runner.cfg.ServerURL
+	if serverURL == "" {
+		return ""
+	}
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		return ""
+	}
+	switch u.Scheme {
+	case "https":
+		u.Scheme = "wss"
+	default:
+		u.Scheme = "ws"
+	}
+	u.Path = "/relay"
+	return u.String()
 }
 
 // OnUnsubscribeTerminal handles unsubscribe terminal command from server.


### PR DESCRIPTION
When the backend sends a Docker-internal relay URL (e.g., ws://relay:8090), local runners can't resolve the hostname. The relay client now falls back to a URL derived from server_url config (e.g., ws://localhost:29400/relay) which routes through Traefik to the relay service.

## Summary

- What changed?
- Why was this change needed?

## Changes

- 

## Validation

- [ ] Backend tests (`cd backend && go test ./...`)
- [ ] Web checks (`cd web && pnpm run lint && pnpm run type-check && pnpm run test:coverage`)
- [ ] Runner checks (`cd runner && go test ./...`)
- [ ] Manual validation performed (if applicable)

## Documentation

- [ ] Docs updated (README/docs/inline comments)
- [ ] No docs changes needed

## Risk and Rollback

- Risk level: Low / Medium / High
- Rollback plan:
