### PR TITLE
feat: add post_comment MCP tool and update README contact links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
   <a href="https://agentsmesh.ai">Website</a> ·
   <a href="https://agentsmesh.ai/docs">Docs</a> ·
   <a href="#quick-start">Quick Start</a> ·
-  <a href="https://discord.gg/agentsmesh">Discord</a>
+  <a href="https://discord.gg/Rgq4m4jE">Discord</a> ·
+  <a href="https://www.linkedin.com/company/agentsmesh">LinkedIn</a>
 </p>
 
 <p align="center">

--- a/backend/internal/api/grpc/runner_adapter_mcp.go
+++ b/backend/internal/api/grpc/runner_adapter_mcp.go
@@ -131,6 +131,8 @@ func (a *GRPCRunnerAdapter) dispatchMcpMethod(ctx context.Context, tc *middlewar
 		return a.mcpCreateTicket(ctx, tc, req.Payload)
 	case "update_ticket":
 		return a.mcpUpdateTicket(ctx, tc, req.Payload)
+	case "post_comment":
+		return a.mcpPostComment(ctx, tc, req.Payload)
 
 	// Terminal methods
 	case "observe_terminal":

--- a/backend/internal/api/grpc/runner_adapter_mcp_ticket.go
+++ b/backend/internal/api/grpc/runner_adapter_mcp_ticket.go
@@ -275,6 +275,37 @@ func (a *GRPCRunnerAdapter) mcpUpdateTicket(ctx context.Context, tc *middleware.
 	return map[string]interface{}{"ticket": a.enrichTicketForMCP(ctx, tc.OrganizationID, t, nil)}, nil
 }
 
+// mcpPostComment handles the "post_comment" MCP method.
+func (a *GRPCRunnerAdapter) mcpPostComment(ctx context.Context, tc *middleware.TenantContext, payload []byte) (interface{}, *mcpError) {
+	var params struct {
+		TicketSlug string  `json:"ticket_slug"`
+		Content    string  `json:"content"`
+		ParentID   *int64  `json:"parent_id"`
+	}
+	if err := unmarshalPayload(payload, &params); err != nil {
+		return nil, err
+	}
+
+	if params.TicketSlug == "" {
+		return nil, newMcpError(400, "ticket_slug is required")
+	}
+	if params.Content == "" {
+		return nil, newMcpError(400, "content is required")
+	}
+
+	t, err := a.ticketService.GetTicketByIDOrSlug(ctx, tc.OrganizationID, params.TicketSlug)
+	if err != nil {
+		return nil, newMcpError(404, "ticket not found")
+	}
+
+	comment, err := a.ticketService.CreateComment(ctx, t.ID, tc.UserID, params.Content, params.ParentID, nil)
+	if err != nil {
+		return nil, newMcpError(500, "failed to post comment")
+	}
+
+	return map[string]interface{}{"comment": comment}, nil
+}
+
 // ==================== Pod MCP Methods ====================
 
 // mcpCreatePod handles the "create_pod" MCP method.

--- a/runner/internal/mcp/grpc_client.go
+++ b/runner/internal/mcp/grpc_client.go
@@ -449,6 +449,24 @@ func (c *GRPCCollaborationClient) UpdateTicket(ctx context.Context, ticketSlug s
 	return &result.Ticket, nil
 }
 
+// PostComment posts a comment on a ticket.
+func (c *GRPCCollaborationClient) PostComment(ctx context.Context, ticketSlug, content string, parentID *int64) (*tools.TicketComment, error) {
+	params := map[string]interface{}{
+		"ticket_slug": ticketSlug,
+		"content":     content,
+	}
+	if parentID != nil {
+		params["parent_id"] = *parentID
+	}
+	var result struct {
+		Comment tools.TicketComment `json:"comment"`
+	}
+	if err := c.call(ctx, "post_comment", params, &result); err != nil {
+		return nil, err
+	}
+	return &result.Comment, nil
+}
+
 // ==================== PodClient ====================
 
 // CreatePod creates a new AgentPod.

--- a/runner/internal/mcp/http_server.go
+++ b/runner/internal/mcp/http_server.go
@@ -254,6 +254,7 @@ func (s *HTTPServer) registerTools() {
 		s.createGetTicketTool(),
 		s.createCreateTicketTool(),
 		s.createUpdateTicketTool(),
+		s.createPostCommentTool(),
 
 		// Pod tools
 		s.createCreatePodTool(),

--- a/runner/internal/mcp/http_tools_format_integration_test.go
+++ b/runner/internal/mcp/http_tools_format_integration_test.go
@@ -176,6 +176,10 @@ func (m *mockFormatClient) CreatePod(_ context.Context, _ *tools.PodCreateReques
 	return &tools.PodCreateResponse{PodKey: "new-pod", Status: "initializing"}, nil
 }
 
+func (m *mockFormatClient) PostComment(_ context.Context, _ string, _ string, _ *int64) (*tools.TicketComment, error) {
+	return &tools.TicketComment{ID: 1, Content: "test comment"}, nil
+}
+
 // --- Helper: register pod with mock client ---
 
 func setupServerWithMockClient(t *testing.T) *HTTPServer {

--- a/runner/internal/mcp/http_tools_ticket.go
+++ b/runner/internal/mcp/http_tools_ticket.go
@@ -174,6 +174,43 @@ func (s *HTTPServer) createCreateTicketTool() *MCPTool {
 	}
 }
 
+func (s *HTTPServer) createPostCommentTool() *MCPTool {
+	return &MCPTool{
+		Name:        "post_comment",
+		Description: "Post a comment on a ticket. Optionally reply to an existing comment by providing parent_id.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"ticket_slug": map[string]interface{}{
+					"type":        "string",
+					"description": "Ticket slug (e.g., 'AM-123')",
+				},
+				"content": map[string]interface{}{
+					"type":        "string",
+					"description": "Comment content",
+				},
+				"parent_id": map[string]interface{}{
+					"type":        "integer",
+					"description": "ID of the parent comment to reply to (optional)",
+				},
+			},
+			"required": []string{"ticket_slug", "content"},
+		},
+		Handler: func(ctx context.Context, client tools.CollaborationClient, args map[string]interface{}) (interface{}, error) {
+			ticketSlug := getStringArg(args, "ticket_slug")
+			if ticketSlug == "" {
+				return nil, fmt.Errorf("ticket_slug is required")
+			}
+			content := getStringArg(args, "content")
+			if content == "" {
+				return nil, fmt.Errorf("content is required")
+			}
+			parentID := getInt64PtrArg(args, "parent_id")
+			return client.PostComment(ctx, ticketSlug, content, parentID)
+		},
+	}
+}
+
 func (s *HTTPServer) createUpdateTicketTool() *MCPTool {
 	return &MCPTool{
 		Name:        "update_ticket",

--- a/runner/internal/mcp/tools/types_client.go
+++ b/runner/internal/mcp/tools/types_client.go
@@ -46,6 +46,7 @@ type TicketClient interface {
 	GetTicket(ctx context.Context, ticketSlug string, contentOffset, contentLimit *int) (*Ticket, error)
 	CreateTicket(ctx context.Context, repositoryID *int64, title, content string, priority TicketPriority, parentTicketSlug *string) (*Ticket, error)
 	UpdateTicket(ctx context.Context, ticketSlug string, title, content *string, status *TicketStatus, priority *TicketPriority) (*Ticket, error)
+	PostComment(ctx context.Context, ticketSlug, content string, parentID *int64) (*TicketComment, error)
 }
 
 // PodClient defines the interface for pod creation.

--- a/runner/internal/mcp/tools/types_entity.go
+++ b/runner/internal/mcp/tools/types_entity.go
@@ -113,6 +113,17 @@ type Ticket struct {
 	UpdatedAt         string         `json:"updated_at"`
 }
 
+// TicketComment represents a comment on a ticket.
+type TicketComment struct {
+	ID        int64  `json:"id"`
+	TicketID  int64  `json:"ticket_id"`
+	Content   string `json:"content"`
+	ParentID  *int64 `json:"parent_id,omitempty"`
+	AuthorID  int64  `json:"author_id"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
 // ConfigFieldSummary is a simplified config field for LLM consumption.
 // Removes validation and show_when fields that are only used by frontend.
 type ConfigFieldSummary struct {


### PR DESCRIPTION
- Add MCP tool for posting comments on tickets (with optional reply support via parent_id)
- Update Discord invite link to https://discord.gg/Rgq4m4jE
- Add LinkedIn link https://www.linkedin.com/company/agentsmesh

## Summary

- What changed?
- Why was this change needed?

## Changes

- 

## Validation

- [ ] Backend tests (`cd backend && go test ./...`)
- [ ] Web checks (`cd web && pnpm run lint && pnpm run type-check && pnpm run test:coverage`)
- [ ] Runner checks (`cd runner && go test ./...`)
- [ ] Manual validation performed (if applicable)

## Documentation

- [ ] Docs updated (README/docs/inline comments)
- [ ] No docs changes needed

## Risk and Rollback

- Risk level: Low / Medium / High
- Rollback plan:
