### PR TITLE
fix(grpc): use chain-only TLS verification and add dynamic server cert SANs

### DIFF
--- a/backend/cmd/server/grpc_init.go
+++ b/backend/cmd/server/grpc_init.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"log/slog"
+	"net/url"
+	"strings"
 
 	grpcserver "github.com/anthropics/agentsmesh/backend/internal/api/grpc"
 	v1 "github.com/anthropics/agentsmesh/backend/internal/api/rest/v1"
@@ -35,6 +37,7 @@ func initializePKIAndGRPC(
 		ServerCertFile: cfg.PKI.ServerCertFile,
 		ServerKeyFile:  cfg.PKI.ServerKeyFile,
 		ValidityDays:   cfg.PKI.ValidityDays,
+		ServerCertSANs: deriveServerCertSANs(cfg),
 	})
 	if err != nil {
 		slog.Error("Failed to initialize PKI service", "error", err)
@@ -219,4 +222,38 @@ func createDNSProvider(relayCfg config.RelayConfig) dns.Provider {
 	default:
 		return nil
 	}
+}
+
+// deriveServerCertSANs extracts domain names from PrimaryDomain and GRPC.Endpoint
+// to include as SANs in the auto-generated server certificate.
+//
+// Examples:
+//   - PrimaryDomain="agentsmesh.cn"       → ["agentsmesh.cn"]
+//   - PrimaryDomain="localhost:10000"      → ["localhost"] (already a default SAN)
+//   - GRPC.Endpoint="grpcs://api.agentsmesh.cn:9443" → ["api.agentsmesh.cn"]
+func deriveServerCertSANs(cfg *config.Config) []string {
+	var sans []string
+
+	// Extract hostname from PrimaryDomain (strip port if present)
+	if cfg.PrimaryDomain != "" {
+		host := cfg.PrimaryDomain
+		if idx := strings.LastIndex(host, ":"); idx != -1 {
+			host = host[:idx]
+		}
+		if host != "" {
+			sans = append(sans, host)
+		}
+	}
+
+	// Extract hostname from GRPC public endpoint URL
+	if cfg.GRPC.Endpoint != "" {
+		if u, err := url.Parse(cfg.GRPC.Endpoint); err == nil && u.Hostname() != "" {
+			sans = append(sans, u.Hostname())
+		}
+	}
+
+	if len(sans) > 0 {
+		slog.Info("Server certificate SANs derived from config", "sans", sans)
+	}
+	return sans
 }

--- a/backend/cmd/server/grpc_init_test.go
+++ b/backend/cmd/server/grpc_init_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/anthropics/agentsmesh/backend/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeriveServerCertSANs(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      *config.Config
+		expected []string
+	}{
+		{
+			name: "both PrimaryDomain and GRPC endpoint",
+			cfg: &config.Config{
+				PrimaryDomain: "agentsmesh.cn",
+				GRPC:          config.GRPCConfig{Endpoint: "grpcs://api.agentsmesh.cn:9443"},
+			},
+			expected: []string{"agentsmesh.cn", "api.agentsmesh.cn"},
+		},
+		{
+			name: "PrimaryDomain with port",
+			cfg: &config.Config{
+				PrimaryDomain: "localhost:10000",
+			},
+			expected: []string{"localhost"},
+		},
+		{
+			name: "only GRPC endpoint",
+			cfg: &config.Config{
+				GRPC: config.GRPCConfig{Endpoint: "grpcs://grpc.example.com:9443"},
+			},
+			expected: []string{"grpc.example.com"},
+		},
+		{
+			name:     "empty config",
+			cfg:      &config.Config{},
+			expected: nil,
+		},
+		{
+			name: "invalid GRPC endpoint ignored",
+			cfg: &config.Config{
+				PrimaryDomain: "example.com",
+				GRPC:          config.GRPCConfig{Endpoint: "://invalid"},
+			},
+			expected: []string{"example.com"},
+		},
+		{
+			name: "PrimaryDomain without port",
+			cfg: &config.Config{
+				PrimaryDomain: "agentsmesh.ai",
+			},
+			expected: []string{"agentsmesh.ai"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sans := deriveServerCertSANs(tt.cfg)
+			assert.Equal(t, tt.expected, sans)
+		})
+	}
+}

--- a/backend/internal/infra/pki/service.go
+++ b/backend/internal/infra/pki/service.go
@@ -24,11 +24,12 @@ type Service struct {
 
 // Config holds PKI service configuration.
 type Config struct {
-	CACertFile     string // Path to CA certificate file
-	CAKeyFile      string // Path to CA private key file
-	ServerCertFile string // Path to server certificate file (optional)
-	ServerKeyFile  string // Path to server private key file (optional)
-	ValidityDays   int    // Certificate validity period in days (default: 365)
+	CACertFile     string   // Path to CA certificate file
+	CAKeyFile      string   // Path to CA private key file
+	ServerCertFile string   // Path to server certificate file (optional)
+	ServerKeyFile  string   // Path to server private key file (optional)
+	ValidityDays   int      // Certificate validity period in days (default: 365)
+	ServerCertSANs []string // Additional DNS SANs for auto-generated server certificate (e.g., public domain names)
 }
 
 // CertificateInfo holds information about an issued certificate.

--- a/backend/internal/infra/pki/service_server.go
+++ b/backend/internal/infra/pki/service_server.go
@@ -25,27 +25,44 @@ func (s *Service) loadOrGenerateServerCert(cfg *Config) (tls.Certificate, error)
 		// If files don't exist, generate new certificate
 	}
 
-	// Generate new server certificate
-	return s.generateServerCert()
+	// Generate new server certificate with configured SANs
+	return s.generateServerCert(cfg.ServerCertSANs)
 }
 
 // generateServerCert generates a new server certificate signed by CA.
-func (s *Service) generateServerCert() (tls.Certificate, error) {
-	// Generate ECDSA key pair
+// extraSANs are additional DNS names to include (e.g., public domain names).
+func (s *Service) generateServerCert(extraSANs []string) (tls.Certificate, error) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return tls.Certificate{}, fmt.Errorf("failed to generate server key: %w", err)
 	}
 
-	// Generate serial number
 	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
 	if err != nil {
 		return tls.Certificate{}, fmt.Errorf("failed to generate serial number: %w", err)
 	}
 
 	now := time.Now()
-	// Server certificate valid for 1 year
 	expiresAt := now.Add(365 * 24 * time.Hour)
+
+	// Default SANs for internal/development use
+	dnsNames := []string{
+		"localhost",
+		"backend",
+		"agentmesh-backend",
+	}
+
+	// Append public domain SANs (deduplicated)
+	seen := make(map[string]bool, len(dnsNames)+len(extraSANs))
+	for _, name := range dnsNames {
+		seen[name] = true
+	}
+	for _, name := range extraSANs {
+		if name != "" && !seen[name] {
+			dnsNames = append(dnsNames, name)
+			seen[name] = true
+		}
+	}
 
 	template := &x509.Certificate{
 		SerialNumber: serial,
@@ -58,21 +75,14 @@ func (s *Service) generateServerCert() (tls.Certificate, error) {
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
-		// Add DNS names for local development
-		DNSNames: []string{
-			"localhost",
-			"backend",
-			"agentmesh-backend",
-		},
+		DNSNames:              dnsNames,
 	}
 
-	// Sign with CA
 	certDER, err := x509.CreateCertificate(rand.Reader, template, s.caCert, &key.PublicKey, s.caKey)
 	if err != nil {
 		return tls.Certificate{}, fmt.Errorf("failed to create server certificate: %w", err)
 	}
 
-	// Encode to PEM
 	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
 	keyDER, _ := x509.MarshalECPrivateKey(key)
 	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})

--- a/backend/internal/infra/pki/service_test.go
+++ b/backend/internal/infra/pki/service_test.go
@@ -265,6 +265,105 @@ func TestServerCert(t *testing.T) {
 	assert.NotEmpty(t, serverCert.Certificate)
 }
 
+func TestServerCert_DefaultSANs(t *testing.T) {
+	service, tmpDir := setupTestPKI(t)
+	defer os.RemoveAll(tmpDir)
+
+	serverCert := service.ServerCert()
+	require.NotEmpty(t, serverCert.Certificate)
+
+	// Parse the leaf certificate
+	x509Cert, err := x509.ParseCertificate(serverCert.Certificate[0])
+	require.NoError(t, err)
+
+	// Default SANs should always be present
+	assert.Contains(t, x509Cert.DNSNames, "localhost")
+	assert.Contains(t, x509Cert.DNSNames, "backend")
+	assert.Contains(t, x509Cert.DNSNames, "agentmesh-backend")
+}
+
+func TestServerCert_WithExtraSANs(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pki-sans-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	certPEM, keyPEM := createTestCA(t)
+	certFile := filepath.Join(tmpDir, "ca.crt")
+	keyFile := filepath.Join(tmpDir, "ca.key")
+	require.NoError(t, os.WriteFile(certFile, certPEM, 0644))
+	require.NoError(t, os.WriteFile(keyFile, keyPEM, 0600))
+
+	cfg := &Config{
+		CACertFile:     certFile,
+		CAKeyFile:      keyFile,
+		ValidityDays:   365,
+		ServerCertSANs: []string{"api.agentsmesh.cn", "agentsmesh.cn"},
+	}
+
+	service, err := NewService(cfg)
+	require.NoError(t, err)
+
+	serverCert := service.ServerCert()
+	require.NotEmpty(t, serverCert.Certificate)
+
+	x509Cert, err := x509.ParseCertificate(serverCert.Certificate[0])
+	require.NoError(t, err)
+
+	// Default SANs
+	assert.Contains(t, x509Cert.DNSNames, "localhost")
+	assert.Contains(t, x509Cert.DNSNames, "backend")
+	assert.Contains(t, x509Cert.DNSNames, "agentmesh-backend")
+	// Extra SANs from config
+	assert.Contains(t, x509Cert.DNSNames, "api.agentsmesh.cn")
+	assert.Contains(t, x509Cert.DNSNames, "agentsmesh.cn")
+}
+
+func TestServerCert_ExtraSANs_Deduplicated(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pki-sans-dedup-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	certPEM, keyPEM := createTestCA(t)
+	certFile := filepath.Join(tmpDir, "ca.crt")
+	keyFile := filepath.Join(tmpDir, "ca.key")
+	require.NoError(t, os.WriteFile(certFile, certPEM, 0644))
+	require.NoError(t, os.WriteFile(keyFile, keyPEM, 0600))
+
+	cfg := &Config{
+		CACertFile:   certFile,
+		CAKeyFile:    keyFile,
+		ValidityDays: 365,
+		// "localhost" is already a default SAN, empty strings should be ignored
+		ServerCertSANs: []string{"localhost", "", "api.example.com", "api.example.com"},
+	}
+
+	service, err := NewService(cfg)
+	require.NoError(t, err)
+
+	serverCert := service.ServerCert()
+	require.NotEmpty(t, serverCert.Certificate)
+
+	x509Cert, err := x509.ParseCertificate(serverCert.Certificate[0])
+	require.NoError(t, err)
+
+	// Count occurrences - "localhost" should appear exactly once
+	localhostCount := 0
+	exampleCount := 0
+	for _, name := range x509Cert.DNSNames {
+		if name == "localhost" {
+			localhostCount++
+		}
+		if name == "api.example.com" {
+			exampleCount++
+		}
+	}
+	assert.Equal(t, 1, localhostCount, "localhost should not be duplicated")
+	assert.Equal(t, 1, exampleCount, "api.example.com should not be duplicated")
+
+	// Total should be 3 defaults + 1 new = 4
+	assert.Len(t, x509Cert.DNSNames, 4)
+}
+
 func TestDefaultValidityDays(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "pki-default-validity-*")
 	require.NoError(t, err)

--- a/runner/internal/client/grpc_connection.go
+++ b/runner/internal/client/grpc_connection.go
@@ -90,10 +90,6 @@ type GRPCConnection struct {
 	certRenewalDays          int // Days before expiry to trigger renewal (default 30)
 	certUrgentDays           int // Days before expiry for urgent reconnection (default 7)
 
-	// TLS server name for SNI (overrides hostname from gRPC endpoint)
-	// Required when server cert SANs don't include the public hostname
-	tlsServerName string
-
 	// RPCClient for MCP request-response over gRPC stream
 	rpcClient *RPCClient
 
@@ -128,7 +124,6 @@ func NewGRPCConnection(endpoint, nodeID, orgSlug, certFile, keyFile, caFile stri
 		certExpiryWarningDays:    30,
 		certRenewalDays:          30, // Renew 30 days before expiry
 		certUrgentDays:           7,  // Urgent reconnection 7 days before expiry
-		tlsServerName:            "agentmesh-backend", // Default SNI for server cert SAN matching
 		terminalRateLimit:        50 * 1024, // Default: 50KB/s (conservative for shared bandwidth)
 		agentProbe:               NewAgentProbe(),
 	}
@@ -223,12 +218,6 @@ func (c *GRPCConnection) Connect() error {
 			Timeout:             10 * time.Second,
 			PermitWithoutStream: true,
 		}),
-	}
-
-	// Override the authority (and TLS SNI) when server cert SANs don't include the public hostname.
-	// This replaces the deprecated creds.OverrideServerName().
-	if c.tlsServerName != "" {
-		dialOpts = append(dialOpts, grpc.WithAuthority(c.tlsServerName))
 	}
 
 	// Connect to server

--- a/runner/internal/client/grpc_connection_options.go
+++ b/runner/internal/client/grpc_connection_options.go
@@ -64,11 +64,3 @@ func WithGRPCCertUrgentDays(days int) GRPCConnectionOption {
 	}
 }
 
-// WithGRPCTLSServerName sets the TLS server name for SNI and certificate verification.
-// This is needed when the server certificate's SANs don't include the public hostname
-// (e.g., server cert is for "agentmesh-backend" but endpoint is "agentsmesh.ai:9443").
-func WithGRPCTLSServerName(name string) GRPCConnectionOption {
-	return func(c *GRPCConnection) {
-		c.tlsServerName = name
-	}
-}

--- a/runner/internal/client/grpc_tls.go
+++ b/runner/internal/client/grpc_tls.go
@@ -11,12 +11,18 @@ import (
 
 	"github.com/anthropics/agentsmesh/runner/internal/logger"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/tls/certprovider"
 	"google.golang.org/grpc/credentials/tls/certprovider/pemfile"
 	"google.golang.org/grpc/security/advancedtls"
 )
 
 // createAdvancedTLSCredentials creates TLS credentials using advancedtls package.
 // This enables automatic certificate hot-reloading when certificate files are updated.
+//
+// Uses CertVerification (chain-only, no hostname check) because:
+//   - Private PKI: both server and client certs are signed by our own CA
+//   - Server cert SANs may not include the public hostname (e.g., api.agentsmesh.cn)
+//   - SNI must remain as the dial target hostname for correct Traefik TCP routing
 func (c *GRPCConnection) createAdvancedTLSCredentials() (credentials.TransportCredentials, error) {
 	// Create identity certificate provider with file watching
 	// This provider will automatically reload certificates when files change
@@ -31,45 +37,13 @@ func (c *GRPCConnection) createAdvancedTLSCredentials() (credentials.TransportCr
 	}
 
 	// Create root certificate provider with file watching for CA
-	// This allows CA certificate rotation if needed
 	rootProvider, err := pemfile.NewProvider(pemfile.Options{
 		RootFile:        c.caFile,
 		RefreshDuration: 24 * time.Hour, // CA changes are rare, check daily
 	})
 	if err != nil {
 		logger.GRPC().Warn("Failed to create pemfile root provider, using static CA", "error", err)
-		// Fall back to static CA if file watching fails
-		caCert, readErr := os.ReadFile(c.caFile)
-		if readErr != nil {
-			return nil, fmt.Errorf("failed to read CA certificate: %w", readErr)
-		}
-		caPool := x509.NewCertPool()
-		if !caPool.AppendCertsFromPEM(caCert) {
-			return nil, fmt.Errorf("failed to parse CA certificate")
-		}
-
-		// Save identity provider for cleanup, rootProvider is nil in this path
-		c.identityProvider = identityProvider
-		c.rootProvider = nil
-
-		// Use static root certificates
-		options := &advancedtls.Options{
-			IdentityOptions: advancedtls.IdentityCertificateOptions{
-				IdentityProvider: identityProvider,
-			},
-			RootOptions: advancedtls.RootCertificateOptions{
-				RootCertificates: caPool,
-			},
-			MinTLSVersion: tls.VersionTLS13,
-			MaxTLSVersion: tls.VersionTLS13,
-			// Only verify certificate chain, not hostname (server may use IP)
-			VerificationType: advancedtls.CertVerification,
-		}
-		creds, err := advancedtls.NewClientCreds(options)
-		if err != nil {
-			return nil, err
-		}
-		return creds, nil
+		return c.createStaticCACredentials(identityProvider)
 	}
 
 	// Save providers for cleanup to prevent goroutine leaks
@@ -86,7 +60,8 @@ func (c *GRPCConnection) createAdvancedTLSCredentials() (credentials.TransportCr
 		},
 		MinTLSVersion: tls.VersionTLS13,
 		MaxTLSVersion: tls.VersionTLS13,
-		// Only verify certificate chain, not hostname (server may use IP)
+		// Only verify certificate chain, not hostname.
+		// Server cert SANs may not include the public domain; SNI must stay as dial target for routing.
 		VerificationType: advancedtls.CertVerification,
 	}
 
@@ -97,16 +72,51 @@ func (c *GRPCConnection) createAdvancedTLSCredentials() (credentials.TransportCr
 	return creds, nil
 }
 
+// createStaticCACredentials creates advancedtls credentials with a static CA pool.
+// Used when the root certificate file watcher fails to initialize.
+func (c *GRPCConnection) createStaticCACredentials(identityProvider certprovider.Provider) (credentials.TransportCredentials, error) {
+	caCert, err := os.ReadFile(c.caFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA certificate: %w", err)
+	}
+	caPool := x509.NewCertPool()
+	if !caPool.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("failed to parse CA certificate")
+	}
+
+	c.identityProvider = identityProvider
+	c.rootProvider = nil
+
+	options := &advancedtls.Options{
+		IdentityOptions: advancedtls.IdentityCertificateOptions{
+			IdentityProvider: identityProvider,
+		},
+		RootOptions: advancedtls.RootCertificateOptions{
+			RootCertificates: caPool,
+		},
+		MinTLSVersion:    tls.VersionTLS13,
+		MaxTLSVersion:    tls.VersionTLS13,
+		VerificationType: advancedtls.CertVerification,
+	}
+	creds, err := advancedtls.NewClientCreds(options)
+	if err != nil {
+		return nil, err
+	}
+	return creds, nil
+}
+
 // createFallbackTLSCredentials creates standard TLS credentials as fallback.
-// Used when advancedtls is not available or fails to initialize.
+// Used when advancedtls pemfile providers fail to initialize.
+//
+// Uses InsecureSkipVerify + VerifyConnection to verify chain without hostname check.
+// This keeps SNI as the dial target for correct proxy routing while still verifying
+// the server cert is signed by our private CA.
 func (c *GRPCConnection) createFallbackTLSCredentials() (credentials.TransportCredentials, error) {
-	// Load client certificate
 	cert, err := tls.LoadX509KeyPair(c.certFile, c.keyFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load client certificate: %w", err)
 	}
 
-	// Load CA certificate (only trust AgentMesh CA, not system CAs)
 	caCert, err := os.ReadFile(c.caFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read CA certificate: %w", err)
@@ -117,12 +127,29 @@ func (c *GRPCConnection) createFallbackTLSCredentials() (credentials.TransportCr
 		return nil, fmt.Errorf("failed to parse CA certificate")
 	}
 
-	// TLS config - only trust our private CA
 	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      caPool,
-		ServerName:   c.tlsServerName,
 		MinVersion:   tls.VersionTLS13,
+		// Skip default verification (which includes hostname check) so SNI stays as
+		// the dial target hostname for correct Traefik routing. Chain verification is
+		// performed in VerifyConnection below.
+		InsecureSkipVerify: true,
+		VerifyConnection: func(cs tls.ConnectionState) error {
+			if len(cs.PeerCertificates) == 0 {
+				return fmt.Errorf("server presented no certificates")
+			}
+			// Verify the certificate chain against our private CA (no hostname check)
+			opts := x509.VerifyOptions{
+				Roots:         caPool,
+				Intermediates: x509.NewCertPool(),
+			}
+			for _, cert := range cs.PeerCertificates[1:] {
+				opts.Intermediates.AddCert(cert)
+			}
+			_, err := cs.PeerCertificates[0].Verify(opts)
+			return err
+		},
 	}
 
 	return credentials.NewTLS(tlsConfig), nil
@@ -158,21 +185,15 @@ func (c *GRPCConnection) checkCertificateExpiry() {
 
 	logger.GRPCTrace().Trace("Certificate expiry check", "days_until_expiry", daysUntilExpiry)
 
-	// Check if renewal is needed (30 days before expiry by default)
 	if daysUntilExpiry <= float64(c.certRenewalDays) {
 		log.Info("Certificate expires soon, triggering renewal", "days_until_expiry", daysUntilExpiry)
-
-		// Attempt to renew certificate via REST API
 		if err := c.renewCertificate(); err != nil {
 			log.Error("Certificate renewal failed", "error", err)
-			// Don't return here - still check for urgent reconnection
 		} else {
 			log.Info("Certificate renewed successfully, advancedtls will auto-reload")
 		}
 	}
 
-	// Check if urgent reconnection is needed (7 days before expiry by default)
-	// This ensures long-lived connections use the new certificate
 	if daysUntilExpiry <= float64(c.certUrgentDays) {
 		log.Warn("Certificate expiring urgently, triggering reconnection", "days_until_expiry", daysUntilExpiry)
 		c.triggerReconnect()
@@ -199,7 +220,6 @@ func (c *GRPCConnection) getCertDaysUntilExpiry() (float64, error) {
 }
 
 // IsCertificateExpired checks if the certificate has expired.
-// Returns true if the certificate is expired, along with error details if any.
 func (c *GRPCConnection) IsCertificateExpired() (bool, error) {
 	daysUntilExpiry, err := c.getCertDaysUntilExpiry()
 	if err != nil {
@@ -245,7 +265,6 @@ func (c *GRPCConnection) GetCertificateExpiryInfo() (*CertificateExpiryInfo, err
 }
 
 // renewCertificate calls the Backend REST API to renew the certificate.
-// The new certificate is saved to files, and advancedtls will automatically reload them.
 func (c *GRPCConnection) renewCertificate() error {
 	if c.serverURL == "" {
 		return fmt.Errorf("server URL not configured, cannot renew certificate")
@@ -254,8 +273,6 @@ func (c *GRPCConnection) renewCertificate() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Call the renewal API using mTLS
-	// Note: This requires a working TLS connection with the current certificate
 	result, err := RenewCertificate(ctx, RenewalRequest{
 		ServerURL: c.serverURL,
 		CertFile:  c.certFile,
@@ -266,8 +283,6 @@ func (c *GRPCConnection) renewCertificate() error {
 		return fmt.Errorf("renewal API call failed: %w", err)
 	}
 
-	// Save new certificate to files
-	// advancedtls FileWatcherCertificateProvider will detect the change and reload
 	if err := os.WriteFile(c.certFile, []byte(result.Certificate), 0600); err != nil {
 		return fmt.Errorf("failed to save new certificate: %w", err)
 	}
@@ -283,7 +298,6 @@ func (c *GRPCConnection) renewCertificate() error {
 }
 
 // triggerReconnect signals the connection loop to reconnect.
-// This is used to ensure long-lived connections use the new certificate.
 func (c *GRPCConnection) triggerReconnect() {
 	select {
 	case c.reconnectCh <- struct{}{}:


### PR DESCRIPTION
## Summary

- **Fix mTLS handshake failure** caused by commit 46217dfb replacing deprecated `OverrideServerName()` with `WithAuthority()` — the latter doesn't set TLS ServerName/SNI reliably
- **Client (Runner):** switch to `advancedtls.CertVerification` (chain-only, no hostname check) with three-tier fallback; remove `WithAuthority` so SNI stays as dial target for Traefik routing; remove dead `tlsServerName` field
- **Server (Backend):** auto-derive SANs from `PrimaryDomain` and `GRPC.Endpoint` config into server cert; deduplicate with defaults
- Also resolves `staticcheck SA1019` (deprecated `OverrideServerName`)

## Test plan

- [x] Unit tests: 9 new test cases (6 for `deriveServerCertSANs`, 3 for PKI server cert SANs)
- [x] Dev environment: runner connects via gRPC mTLS, pod creation & terminal relay verified
- [x] Windows compatibility review: all pure Go APIs, no platform-specific code