### PR TITLE
fix(runner): use correct binary name in CLI messages

### DIFF
--- a/runner/cmd/runner/cmd_reactivate.go
+++ b/runner/cmd/runner/cmd_reactivate.go
@@ -20,7 +20,7 @@ func runReactivate(args []string) {
 		fmt.Println(`Reactivate a runner with an expired certificate.
 
 Usage:
-  runner reactivate --token <reactivation-token>
+  agentsmesh-runner reactivate --token <reactivation-token>
 
 Options:`)
 		fs.PrintDefaults()
@@ -31,7 +31,7 @@ you can generate a reactivation token from the web UI:
 1. Go to Runner management page
 2. Find your runner and click "Reactivate"
 3. Copy the generated token
-4. Run: runner reactivate --token <token>
+4. Run: agentsmesh-runner reactivate --token <token>
 
 The runner will receive new certificates and can reconnect.`)
 	}

--- a/runner/cmd/runner/cmd_register.go
+++ b/runner/cmd/runner/cmd_register.go
@@ -23,14 +23,14 @@ func runRegister(args []string) {
 		fmt.Println(`Register this runner with the AgentsMesh server using gRPC/mTLS.
 
 Usage:
-  runner register [options]
+  agentsmesh-runner register [options]
 
 Examples:
-  runner register                    # Interactive login (opens browser)
-  runner register --headless         # Interactive without browser (for SSH)
-  runner register --token <token>    # Token-based registration
-  runner register --server <url>     # Self-hosted server
-  runner register --force            # Overwrite existing registration without confirmation
+  agentsmesh-runner register                    # Interactive login (opens browser)
+  agentsmesh-runner register --headless         # Interactive without browser (for SSH)
+  agentsmesh-runner register --token <token>    # Token-based registration
+  agentsmesh-runner register --server <url>     # Self-hosted server
+  agentsmesh-runner register --force            # Overwrite existing registration without confirmation
 
 Options:
   --server <url>     Server URL (default: https://agentsmesh.ai)

--- a/runner/cmd/runner/cmd_run.go
+++ b/runner/cmd/runner/cmd_run.go
@@ -32,12 +32,12 @@ func runRunner(args []string) {
 		fmt.Println(`Start the AgentsMesh runner.
 
 Usage:
-  runner run [options]
+  agentsmesh-runner run [options]
 
 Options:`)
 		fs.PrintDefaults()
 		fmt.Println(`
-The runner must be registered first using 'runner register'.
+The runner must be registered first using 'agentsmesh-runner register'.
 Configuration is loaded from ~/.agentsmesh/config.yaml by default.
 Log file is written to $TMPDIR/agentsmesh/runner.log by default (with rotation).
 
@@ -61,7 +61,7 @@ The runner uses gRPC/mTLS for secure communication with the server.`)
 
 	// Check if config exists
 	if _, err := os.Stat(cfgFile); os.IsNotExist(err) {
-		fmt.Fprintln(os.Stderr, "Error: Runner not registered. Please run 'runner register' first.")
+		fmt.Fprintln(os.Stderr, "Error: Runner not registered. Please run 'agentsmesh-runner register' first.")
 		os.Exit(1)
 	}
 
@@ -112,7 +112,7 @@ The runner uses gRPC/mTLS for secure communication with the server.`)
 	}
 
 	if !cfg.UsesGRPC() {
-		log.Error("gRPC configuration is required. Please re-register the runner using 'runner register'")
+		log.Error("gRPC configuration is required. Please re-register the runner using 'agentsmesh-runner register'")
 		os.Exit(1)
 	}
 

--- a/runner/cmd/runner/main.go
+++ b/runner/cmd/runner/main.go
@@ -45,7 +45,7 @@ func printUsage() {
 	fmt.Println(`AgentsMesh Runner
 
 Usage:
-  runner <command> [options]
+  agentsmesh-runner <command> [options]
 
 Commands:
   login       Login to AgentsMesh server (alias for register)
@@ -59,17 +59,17 @@ Commands:
   help        Show this help message
 
 Login Examples:
-  runner login
+  agentsmesh-runner login
       Opens browser for authorization (uses https://agentsmesh.ai)
 
-  runner login --headless
+  agentsmesh-runner login --headless
       Print URL only, don't open browser (for SSH/remote sessions)
 
-  runner login --token <token>
+  agentsmesh-runner login --token <token>
       Login using a pre-generated token
 
-  runner login --server https://self-hosted.example.com
+  agentsmesh-runner login --server https://self-hosted.example.com
       Login to a self-hosted AgentsMesh server
 
-Use "runner <command> --help" for more information about a command.`)
+Use "agentsmesh-runner <command> --help" for more information about a command.`)
 }

--- a/runner/cmd/runner/register.go
+++ b/runner/cmd/runner/register.go
@@ -50,7 +50,7 @@ func registerInteractive(ctx context.Context, serverURL, nodeID string, headless
 	fmt.Printf("✓ gRPC Endpoint: %s\n", result.GRPCEndpoint)
 	fmt.Printf("✓ Certificates saved to ~/.agentsmesh/certs/\n")
 	fmt.Println("\nYou can now start the runner with:")
-	fmt.Println("  runner run")
+	fmt.Println("  agentsmesh-runner run")
 
 	return nil
 }
@@ -75,7 +75,7 @@ func registerWithGRPCToken(ctx context.Context, serverURL, token, nodeID string)
 	fmt.Printf("✓ gRPC Endpoint: %s\n", result.GRPCEndpoint)
 	fmt.Printf("✓ Certificates saved to ~/.agentsmesh/certs/\n")
 	fmt.Println("\nYou can now start the runner with:")
-	fmt.Println("  runner run")
+	fmt.Println("  agentsmesh-runner run")
 
 	return nil
 }
@@ -104,7 +104,7 @@ func reactivateRunner(ctx context.Context, serverURL, token string) error {
 	fmt.Println("✓ Runner reactivated successfully!")
 	fmt.Println("✓ New certificates saved to ~/.agentsmesh/certs/")
 	fmt.Println("\nYou can now start the runner with:")
-	fmt.Println("  runner run")
+	fmt.Println("  agentsmesh-runner run")
 
 	return nil
 }

--- a/runner/cmd/runner/service.go
+++ b/runner/cmd/runner/service.go
@@ -46,7 +46,7 @@ func printServiceUsage() {
 	fmt.Println(`Manage AgentsMesh Runner as a system service.
 
 Usage:
-  runner service <action> [options]
+  agentsmesh-runner service <action> [options]
 
 Actions:
   install     Install runner as a system service
@@ -60,10 +60,10 @@ Options for 'install':
   --config    Path to config file (default: ~/.agentsmesh/config.yaml)
 
 Examples:
-  runner service install
-  runner service install --config /etc/agentsmesh/config.yaml
-  runner service start
-  runner service status`)
+  agentsmesh-runner service install
+  agentsmesh-runner service install --config /etc/agentsmesh/config.yaml
+  agentsmesh-runner service start
+  agentsmesh-runner service status`)
 }
 
 func runServiceInstall(args []string) {
@@ -83,7 +83,7 @@ func runServiceInstall(args []string) {
 	// Check if config exists
 	if _, err := os.Stat(cfgPath); os.IsNotExist(err) {
 		fmt.Printf("Error: Config file not found at %s\n", cfgPath)
-		fmt.Println("Please run 'runner register' first to create the configuration.")
+		fmt.Println("Please run 'agentsmesh-runner register' first to create the configuration.")
 		os.Exit(1)
 	}
 
@@ -93,7 +93,7 @@ func runServiceInstall(args []string) {
 	}
 
 	fmt.Println("Service installed successfully.")
-	fmt.Println("Use 'runner service start' to start the service.")
+	fmt.Println("Use 'agentsmesh-runner service start' to start the service.")
 }
 
 func runServiceUninstall() {

--- a/runner/cmd/runner/update.go
+++ b/runner/cmd/runner/update.go
@@ -32,18 +32,18 @@ func runUpdate(args []string) {
 		fmt.Println(`Check and install updates for the AgentsMesh Runner.
 
 Usage:
-  runner update [options]
+  agentsmesh-runner update [options]
 
 Options:`)
 		fs.PrintDefaults()
 		fmt.Println(`
 Examples:
-  runner update              # Interactive update
-  runner update --check      # Only check for updates
-  runner update -y           # Silent update (wait for pods to finish)
-  runner update -f           # Force immediate update (may interrupt pods)
-  runner update -v v1.2.3    # Update to specific version
-  runner update --pre        # Include prerelease versions`)
+  agentsmesh-runner update              # Interactive update
+  agentsmesh-runner update --check      # Only check for updates
+  agentsmesh-runner update -y           # Silent update (wait for pods to finish)
+  agentsmesh-runner update -f           # Force immediate update (may interrupt pods)
+  agentsmesh-runner update -v v1.2.3    # Update to specific version
+  agentsmesh-runner update --pre        # Include prerelease versions`)
 	}
 
 	if err := fs.Parse(args); err != nil {

--- a/runner/cmd/runner/webconsole.go
+++ b/runner/cmd/runner/webconsole.go
@@ -20,7 +20,7 @@ func runWebConsole(args []string) {
 		fmt.Println(`Open the AgentsMesh Runner web console in browser.
 
 Usage:
-  runner webconsole [options]
+  agentsmesh-runner webconsole [options]
 
 Options:`)
 		fs.PrintDefaults()
@@ -31,7 +31,7 @@ The web console provides a web-based interface to:
   - View logs
   - Manage runner configuration
 
-Note: The runner must be running ('runner run') for the web console to be accessible.`)
+Note: The runner must be running ('agentsmesh-runner run') for the web console to be accessible.`)
 	}
 
 	if err := fs.Parse(args); err != nil {
@@ -46,7 +46,7 @@ Note: The runner must be running ('runner run') for the web console to be access
 	if err != nil {
 		fmt.Println("Error: Web console is not accessible.")
 		fmt.Println("")
-		fmt.Println("Make sure the runner is running with 'runner run' first.")
+		fmt.Println("Make sure the runner is running with 'agentsmesh-runner run' first.")
 		fmt.Printf("The web console should be available at %s\n", url)
 		os.Exit(1)
 	}

--- a/runner/internal/client/grpc_connection.go
+++ b/runner/internal/client/grpc_connection.go
@@ -300,9 +300,9 @@ func isFatalStreamError(err error) (bool, string) {
 	case codes.Unauthenticated:
 		msg := st.Message()
 		if strings.Contains(msg, "runner not found") {
-			return true, "This runner has been deleted from the server. Please re-register with: runner register --server <SERVER> --token <TOKEN> --force"
+			return true, "This runner has been deleted from the server. Please re-register with: agentsmesh-runner register --server <SERVER> --token <TOKEN> --force"
 		}
-		return true, "Authentication failed: " + msg + ". Please re-register with: runner register --server <SERVER> --token <TOKEN> --force"
+		return true, "Authentication failed: " + msg + ". Please re-register with: agentsmesh-runner register --server <SERVER> --token <TOKEN> --force"
 
 	case codes.PermissionDenied:
 		msg := st.Message()

--- a/runner/internal/runner/runner.go
+++ b/runner/internal/runner/runner.go
@@ -60,7 +60,7 @@ func New(cfg *config.Config) (*Runner, error) {
 
 	// Load gRPC config (certificates)
 	if err := cfg.LoadGRPCConfig(); err != nil {
-		return nil, fmt.Errorf("failed to load gRPC config: %w - please register the runner first using 'runner register'", err)
+		return nil, fmt.Errorf("failed to load gRPC config: %w - please register the runner first using 'agentsmesh-runner register'", err)
 	}
 
 	// Validate required configuration
@@ -69,7 +69,7 @@ func New(cfg *config.Config) (*Runner, error) {
 	}
 
 	if !cfg.UsesGRPC() {
-		return nil, fmt.Errorf("gRPC configuration is required - please re-register the runner using 'runner register'")
+		return nil, fmt.Errorf("gRPC configuration is required - please re-register the runner using 'agentsmesh-runner register'")
 	}
 
 	// Create workspace manager
@@ -99,7 +99,7 @@ func New(cfg *config.Config) (*Runner, error) {
 	}
 
 	if certInfo.IsExpired {
-		return nil, fmt.Errorf("certificate has expired on %s. Please reactivate the runner using:\n  runner reactivate --token <token>\nGet a reactivation token from the web UI", certInfo.ExpiresAt.Format("2006-01-02"))
+		return nil, fmt.Errorf("certificate has expired on %s. Please reactivate the runner using:\n  agentsmesh-runner reactivate --token <token>\nGet a reactivation token from the web UI", certInfo.ExpiresAt.Format("2006-01-02"))
 	}
 
 	if certInfo.NeedsRenewal {


### PR DESCRIPTION
## Summary
- Replace all `runner <command>` references with `agentsmesh-runner <command>` in usage text, help output, and error messages
- The binary is distributed as `agentsmesh-runner`, so user-facing messages should reference the correct executable name
- Affects 10 files across `cmd/runner/` and `internal/` packages

## Test plan
- [x] `go build ./cmd/runner` passes
- [x] `go test ./internal/...` passes
- [x] Grep confirms no remaining `runner <command>` patterns in user-facing strings