### PR TITLE
fix(runner): bind MCP server to localhost and add macOS code signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,12 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: runner/go.sum
 
+      - name: Install rcodesign (macOS code signing)
+        run: |
+          RCODESIGN_VERSION="0.27.0"
+          curl -fsSL "https://github.com/indygreg/apple-codesign/releases/download/${RCODESIGN_VERSION}/apple-codesign-${RCODESIGN_VERSION}-x86_64-unknown-linux-musl.tar.gz" | tar xz
+          sudo cp ./apple-codesign-*/rcodesign /usr/local/bin/
+
       - name: Release with GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -107,3 +113,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}

--- a/runner/.goreleaser.yml
+++ b/runner/.goreleaser.yml
@@ -29,6 +29,12 @@ builds:
       - -s -w
       - -X main.version={{.Version}}
       - -X main.buildTime={{.Date}}
+    hooks:
+      post:
+        - cmd: sh -c '[ "{{ .Os }}" = "darwin" ] && ./build/scripts/sign-darwin.sh "{{ .Path }}" || true'
+          output: true
+          env:
+            - ENTITLEMENTS=./build/darwin/entitlements.plist
 
 archives:
   - id: cli-archive

--- a/runner/build/scripts/sign-darwin.sh
+++ b/runner/build/scripts/sign-darwin.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Sign macOS binary with Developer ID certificate using rcodesign.
+# Called by GoReleaser post-build hook for darwin targets.
+# Requires: MACOS_CERTIFICATE (base64 .p12), MACOS_CERTIFICATE_PASSWORD
+set -euo pipefail
+
+BINARY="$1"
+
+if [ -z "${MACOS_CERTIFICATE:-}" ]; then
+  echo "MACOS_CERTIFICATE not set, skipping sign"
+  exit 0
+fi
+
+RCODESIGN="${RCODESIGN:-rcodesign}"
+ENTITLEMENTS="${ENTITLEMENTS:-./build/darwin/entitlements.plist}"
+
+echo "$MACOS_CERTIFICATE" | base64 -d > /tmp/cert.p12
+trap 'rm -f /tmp/cert.p12' EXIT
+
+$RCODESIGN sign \
+  --p12-file /tmp/cert.p12 \
+  --p12-password "$MACOS_CERTIFICATE_PASSWORD" \
+  --code-signature-flags runtime \
+  --entitlements-xml-path "$ENTITLEMENTS" \
+  "$BINARY"
+
+echo "Signed: $BINARY"

--- a/runner/internal/mcp/http_server.go
+++ b/runner/internal/mcp/http_server.go
@@ -100,7 +100,7 @@ func (s *HTTPServer) Start() error {
 	mux.HandleFunc("/pods", s.handlePods)
 
 	s.httpServer = &http.Server{
-		Addr:         fmt.Sprintf(":%d", s.port),
+		Addr:         fmt.Sprintf("127.0.0.1:%d", s.port),
 		Handler:      mux,
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,


### PR DESCRIPTION
## Summary

- Bind MCP HTTP server to `127.0.0.1` instead of `0.0.0.0` to prevent macOS firewall prompts on every self-update (MCP only serves local Claude Code)
- Add macOS code signing via `rcodesign` in CI release pipeline using GoReleaser post-build hooks
- New GitHub Secrets required: `MACOS_CERTIFICATE`, `MACOS_CERTIFICATE_PASSWORD`

## Changes

| File | Change |
|------|--------|
| `runner/internal/mcp/http_server.go` | Bind to `127.0.0.1` instead of `0.0.0.0` |
| `runner/.goreleaser.yml` | Add `builds[].hooks.post` for darwin signing |
| `runner/build/scripts/sign-darwin.sh` | New signing script (skips if no cert) |
| `.github/workflows/release.yml` | Install rcodesign + pass cert env vars |

## Test plan

- [x] `go test ./internal/mcp/...` passes
- [ ] Verify MCP server binds to `127.0.0.1` locally (`netstat -an | grep 19000`)
- [ ] Signing verified on next release tag push via CI
- [ ] Post-release: `codesign -dvvv ~/.local/bin/agentsmesh-runner` on macOS