### PR TITLE
fix(relay): resolve concurrency issues causing heartbeat deadlock and 503 errors

### DIFF
--- a/relay/internal/backend/client.go
+++ b/relay/internal/backend/client.go
@@ -454,17 +454,46 @@ func (c *Client) Unregister(ctx context.Context, reason string) error {
 	return nil
 }
 
-// StartHeartbeat starts the heartbeat loop
+// StartHeartbeat starts the heartbeat loop.
+// It logs lifecycle events and recovers from panics to provide diagnostics.
+// The getConnections callback has a 5-second timeout to prevent deadlock propagation.
 func (c *Client) StartHeartbeat(ctx context.Context, interval time.Duration, getConnections func() int) {
+	c.logger.Info("Heartbeat goroutine started", "interval", interval)
+	defer func() {
+		if r := recover(); r != nil {
+			c.logger.Error("Heartbeat goroutine panicked", "panic", r)
+		}
+		c.logger.Info("Heartbeat goroutine stopped")
+	}()
+
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
+			c.logger.Info("Heartbeat stopping: context cancelled")
 			return
 		case <-ticker.C:
-			connections := getConnections()
+			// Get connections with timeout to prevent deadlock propagation
+			// (e.g., if Stats() is blocked by a lock held by a slow WebSocket write)
+			connCh := make(chan int, 1)
+			go func() {
+				connCh <- getConnections()
+			}()
+
+			var connections int
+			select {
+			case connections = <-connCh:
+				// Success
+			case <-time.After(5 * time.Second):
+				c.logger.Warn("getConnections callback timed out, using 0")
+				connections = 0
+			case <-ctx.Done():
+				c.logger.Info("Heartbeat stopping: context cancelled during getConnections")
+				return
+			}
+
 			if err := c.SendHeartbeat(ctx, connections); err != nil {
 				c.logger.Warn("Heartbeat failed", "error", err)
 

--- a/relay/internal/channel/terminal_channel.go
+++ b/relay/internal/channel/terminal_channel.go
@@ -10,10 +10,45 @@ import (
 	"github.com/anthropics/agentsmesh/relay/internal/protocol"
 )
 
+// writeWait is the maximum time allowed for a WebSocket write to complete.
+// Prevents dead/slow connections from blocking indefinitely and causing lock contention.
+const writeWait = 5 * time.Second
+
+// writeToConn writes a binary message to a WebSocket connection with a write deadline.
+func writeToConn(conn *websocket.Conn, data []byte) error {
+	_ = conn.SetWriteDeadline(time.Now().Add(writeWait))
+	return conn.WriteMessage(websocket.BinaryMessage, data)
+}
+
+// writeToPublisher writes data to the publisher connection with serialization.
+// Returns nil silently if no publisher is connected (normal during reconnection).
+func (c *TerminalChannel) writeToPublisher(data []byte) error {
+	c.publisherWriteMu.Lock()
+	defer c.publisherWriteMu.Unlock()
+
+	c.publisherMu.RLock()
+	pub := c.publisher
+	c.publisherMu.RUnlock()
+
+	if pub == nil {
+		return nil
+	}
+	return writeToConn(pub, data)
+}
+
 // Subscriber represents a browser WebSocket connection (observer)
 type Subscriber struct {
-	ID   string
-	Conn *websocket.Conn
+	ID      string
+	Conn    *websocket.Conn
+	writeMu sync.Mutex // Serializes writes (gorilla/websocket is not concurrent-write safe)
+}
+
+// WriteMessage writes a binary message to the subscriber with a write deadline.
+// Serializes concurrent writes since gorilla/websocket does not support them.
+func (s *Subscriber) WriteMessage(data []byte) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	return writeToConn(s.Conn, data)
 }
 
 // ChannelConfig holds configuration for a terminal channel
@@ -48,8 +83,9 @@ type TerminalChannel struct {
 	config ChannelConfig
 
 	// Publisher: Runner connection (1)
-	publisher   *websocket.Conn
-	publisherMu sync.RWMutex
+	publisher        *websocket.Conn
+	publisherMu      sync.RWMutex
+	publisherWriteMu sync.Mutex // Serializes writes to publisher (gorilla/websocket is not concurrent-write safe)
 
 	// Subscribers: Browser connections (N)
 	subscribers   map[string]*Subscriber // subscriberID -> conn
@@ -104,9 +140,11 @@ func NewTerminalChannelWithConfig(podKey string, cfg ChannelConfig, onAllSubscri
 	}
 }
 
-// SetPublisher sets the publisher (runner) connection
+// SetPublisher sets the publisher (runner) connection.
+// If an old publisher connection exists, it is closed so its forwarding goroutine exits cleanly.
 func (c *TerminalChannel) SetPublisher(conn *websocket.Conn) {
 	c.publisherMu.Lock()
+	oldConn := c.publisher
 	wasDisconnected := c.publisherDisconnected
 	c.publisher = conn
 	c.publisherDisconnected = false
@@ -117,6 +155,12 @@ func (c *TerminalChannel) SetPublisher(conn *websocket.Conn) {
 		c.publisherReconnectTimer = nil
 	}
 	c.publisherMu.Unlock()
+
+	// Close old publisher connection so its forwarding goroutine exits via ReadMessage error.
+	// The old goroutine's handlePublisherDisconnect will see c.publisher != oldConn and return early.
+	if oldConn != nil && oldConn != conn {
+		oldConn.Close()
+	}
 
 	if wasDisconnected {
 		c.logger.Info("Publisher reconnected")
@@ -146,17 +190,20 @@ func (c *TerminalChannel) IsPublisherDisconnected() bool {
 
 // AddSubscriber adds a subscriber (browser observer)
 func (c *TerminalChannel) AddSubscriber(subscriberID string, conn *websocket.Conn) {
+	subscriber := &Subscriber{ID: subscriberID, Conn: conn}
+
 	c.subscribersMu.Lock()
-	c.subscribers[subscriberID] = &Subscriber{ID: subscriberID, Conn: conn}
+	c.subscribers[subscriberID] = subscriber
 
 	// Cancel keep-alive timer if exists
 	if c.keepAliveTimer != nil {
 		c.keepAliveTimer.Stop()
 		c.keepAliveTimer = nil
 	}
+	count := len(c.subscribers)
 	c.subscribersMu.Unlock()
 
-	c.logger.Info("Subscriber connected", "subscriber_id", subscriberID, "total_subscribers", len(c.subscribers))
+	c.logger.Info("Subscriber connected", "subscriber_id", subscriberID, "total_subscribers", count)
 
 	// Send buffered Output messages to new subscriber
 	// This allows new observers to see recent terminal output they missed
@@ -165,7 +212,7 @@ func (c *TerminalChannel) AddSubscriber(subscriberID string, conn *websocket.Con
 		c.logger.Debug("Sending buffered output to new subscriber",
 			"subscriber_id", subscriberID, "count", len(bufferedOutput))
 		for _, data := range bufferedOutput {
-			if err := conn.WriteMessage(websocket.BinaryMessage, data); err != nil {
+			if err := subscriber.WriteMessage(data); err != nil {
 				c.logger.Warn("Failed to send buffered output to new subscriber",
 					"subscriber_id", subscriberID, "error", err)
 				break // Stop sending if connection has issues
@@ -175,7 +222,7 @@ func (c *TerminalChannel) AddSubscriber(subscriberID string, conn *websocket.Con
 
 	// Notify new subscriber if publisher is currently disconnected
 	if c.IsPublisherDisconnected() {
-		if err := conn.WriteMessage(websocket.BinaryMessage, protocol.EncodeRunnerDisconnected()); err != nil {
+		if err := subscriber.WriteMessage(protocol.EncodeRunnerDisconnected()); err != nil {
 			c.logger.Warn("Failed to send publisher disconnected status to new subscriber",
 				"subscriber_id", subscriberID, "error", err)
 		}
@@ -232,20 +279,36 @@ func (c *TerminalChannel) SubscriberCount() int {
 	return len(c.subscribers)
 }
 
-// Broadcast sends data to all connected subscribers
+// Broadcast sends data to all connected subscribers.
+// Uses snapshot-then-write pattern: subscribers are copied under lock, then
+// writes happen without holding the lock. This prevents a slow/dead subscriber
+// from blocking SubscriberCount(), Stats(), and the heartbeat goroutine.
 func (c *TerminalChannel) Broadcast(data []byte) {
+	// Snapshot subscribers under lock
 	c.subscribersMu.RLock()
-	defer c.subscribersMu.RUnlock()
+	subscribers := make([]*Subscriber, 0, len(c.subscribers))
+	for _, sub := range c.subscribers {
+		subscribers = append(subscribers, sub)
+	}
+	c.subscribersMu.RUnlock()
 
-	subscriberCount := len(c.subscribers)
-	c.logger.Debug("Broadcasting to subscribers", "data_len", len(data), "subscriber_count", subscriberCount)
+	c.logger.Debug("Broadcasting to subscribers", "data_len", len(data), "subscriber_count", len(subscribers))
 
-	for _, subscriber := range c.subscribers {
-		if err := subscriber.Conn.WriteMessage(websocket.BinaryMessage, data); err != nil {
-			c.logger.Warn("Failed to send to subscriber", "subscriber_id", subscriber.ID, "error", err)
+	// Write to each subscriber with deadline (no lock held)
+	var failedIDs []string
+	for _, subscriber := range subscribers {
+		if err := subscriber.WriteMessage(data); err != nil {
+			c.logger.Warn("Failed to send to subscriber, removing",
+				"subscriber_id", subscriber.ID, "error", err)
+			failedIDs = append(failedIDs, subscriber.ID)
 		} else {
 			c.logger.Debug("Sent to subscriber", "subscriber_id", subscriber.ID, "data_len", len(data))
 		}
+	}
+
+	// Remove failed subscribers (acquires write lock separately)
+	for _, id := range failedIDs {
+		c.RemoveSubscriber(id)
 	}
 }
 
@@ -288,23 +351,28 @@ func (c *TerminalChannel) getBufferedOutput() [][]byte {
 	return result
 }
 
-// forwardPublisherToSubscribers forwards data from publisher to all subscribers
+// forwardPublisherToSubscribers forwards data from publisher to all subscribers.
+// Each goroutine captures its own conn reference at start. When SetPublisher replaces
+// the publisher, it closes the old conn, causing this goroutine's ReadMessage to fail
+// and exit cleanly via handlePublisherDisconnect's identity check.
 func (c *TerminalChannel) forwardPublisherToSubscribers() {
 	c.logger.Debug("Starting forwardPublisherToSubscribers loop")
+
+	// Capture conn once — this goroutine is bound to this specific connection
+	c.publisherMu.RLock()
+	conn := c.publisher
+	c.publisherMu.RUnlock()
+
+	if conn == nil {
+		c.logger.Debug("Publisher conn is nil, exiting forward loop")
+		return
+	}
+
 	for {
-		c.publisherMu.RLock()
-		conn := c.publisher
-		c.publisherMu.RUnlock()
-
-		if conn == nil {
-			c.logger.Debug("Publisher conn is nil, exiting forward loop")
-			break
-		}
-
 		_, data, err := conn.ReadMessage()
 		if err != nil {
 			c.logger.Info("Publisher disconnected", "error", err)
-			c.handlePublisherDisconnect()
+			c.handlePublisherDisconnect(conn)
 			break
 		}
 
@@ -359,37 +427,35 @@ func (c *TerminalChannel) forwardSubscriberToPublisher(subscriberID string) {
 
 		// Handle ping/pong locally
 		if msg.Type == protocol.MsgTypePing {
-			if err := subscriber.Conn.WriteMessage(websocket.BinaryMessage, protocol.EncodePong()); err != nil {
+			if err := subscriber.WriteMessage(protocol.EncodePong()); err != nil {
 				c.logger.Warn("Failed to send pong", "subscriber_id", subscriberID)
 			}
 			continue
 		}
 
-		// Forward to publisher
-		c.publisherMu.RLock()
-		if c.publisher != nil {
-			if err := c.publisher.WriteMessage(websocket.BinaryMessage, data); err != nil {
-				c.logger.Warn("Failed to forward to publisher", "error", err)
-			}
+		// Forward to publisher (serialized via publisherWriteMu)
+		if err := c.writeToPublisher(data); err != nil {
+			c.logger.Warn("Failed to forward to publisher", "error", err)
 		}
-		c.publisherMu.RUnlock()
 	}
 }
 
-// handlePublisherDisconnect handles publisher disconnect
-// Instead of immediately closing the channel, wait for publisher to reconnect
-func (c *TerminalChannel) handlePublisherDisconnect() {
+// handlePublisherDisconnect handles publisher disconnect with connection identity check.
+// Takes disconnectedConn to verify it's still the current publisher before acting.
+// If SetPublisher already replaced the publisher, this is a no-op (early return).
+func (c *TerminalChannel) handlePublisherDisconnect(disconnectedConn *websocket.Conn) {
 	c.publisherMu.Lock()
-	if c.publisher != nil {
-		c.publisher.Close()
-		c.publisher = nil
-	}
-	c.publisherDisconnected = true
 
-	// Notify all subscribers that publisher has disconnected
-	c.publisherMu.Unlock()
-	c.Broadcast(protocol.EncodeRunnerDisconnected())
-	c.publisherMu.Lock()
+	// Identity check: if publisher was already replaced by SetPublisher, just return.
+	// The old conn was already closed by SetPublisher, no need to close again.
+	if c.publisher != disconnectedConn {
+		c.publisherMu.Unlock()
+		return
+	}
+
+	c.publisher.Close()
+	c.publisher = nil
+	c.publisherDisconnected = true
 
 	c.logger.Info("Publisher disconnected, waiting for reconnection",
 		"timeout", c.config.PublisherReconnectTimeout)
@@ -406,6 +472,9 @@ func (c *TerminalChannel) handlePublisherDisconnect() {
 		}
 	})
 	c.publisherMu.Unlock()
+
+	// Broadcast AFTER releasing lock — eliminates the Unlock→Lock window
+	c.Broadcast(protocol.EncodeRunnerDisconnected())
 }
 
 // handleControlRequest handles input control requests
@@ -439,13 +508,16 @@ func (c *TerminalChannel) handleControlRequest(subscriberID string, payload []by
 
 	if response != nil {
 		data, _ := protocol.EncodeControlRequest(response)
+		// Get connection under lock, release before writing to avoid holding lock during I/O
 		c.subscribersMu.RLock()
-		if subscriber, ok := c.subscribers[subscriberID]; ok {
-			if err := subscriber.Conn.WriteMessage(websocket.BinaryMessage, data); err != nil {
+		subscriber, ok := c.subscribers[subscriberID]
+		c.subscribersMu.RUnlock()
+
+		if ok {
+			if err := subscriber.WriteMessage(data); err != nil {
 				c.logger.Warn("Failed to send control response", "subscriber_id", subscriberID, "error", err)
 			}
 		}
-		c.subscribersMu.RUnlock()
 	}
 }
 

--- a/relay/internal/server/server.go
+++ b/relay/internal/server/server.go
@@ -6,9 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"os"
-	"os/signal"
-	"syscall"
+	"sync/atomic"
 	"time"
 
 	"github.com/anthropics/agentsmesh/relay/internal/auth"
@@ -26,7 +24,7 @@ type Server struct {
 	handler        *Handler
 
 	// Graceful shutdown control
-	acceptingConnections bool
+	acceptingConnections atomic.Bool
 
 	logger *slog.Logger
 }
@@ -50,11 +48,11 @@ func New(cfg *config.Config) *Server {
 
 	// Create server instance first (for closure capture)
 	s := &Server{
-		cfg:                  cfg,
-		backendClient:        backendClient,
-		acceptingConnections: true,
-		logger:               slog.With("component", "server"),
+		cfg:           cfg,
+		backendClient: backendClient,
+		logger:        slog.With("component", "server"),
 	}
+	s.acceptingConnections.Store(true)
 
 	// Create callback for when all subscribers leave a channel
 	// Uses closure to capture server instance instead of global variable
@@ -98,11 +96,8 @@ func (s *Server) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to register with backend: %w", err)
 	}
 
-	// Start heartbeat loop
-	go s.backendClient.StartHeartbeat(ctx, s.cfg.Backend.HeartbeatInterval, func() int {
-		stats := s.channelManager.Stats()
-		return stats.ActiveChannels
-	})
+	// Start heartbeat loop with automatic restart on unexpected exit
+	go s.runHeartbeat(ctx)
 
 	// Set up HTTP routes
 	mux := http.NewServeMux()
@@ -170,18 +165,41 @@ func (s *Server) Start(ctx context.Context) error {
 		}()
 	}
 
-	// Set up signal handling for graceful shutdown
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-
-	// Wait for context cancellation, signal, or error
+	// Wait for context cancellation or server error
+	// Signal handling is done by the caller (main.go) which cancels the context.
 	select {
 	case <-ctx.Done():
 		return s.gracefulShutdown("context_cancelled")
-	case sig := <-sigCh:
-		return s.gracefulShutdown(fmt.Sprintf("signal_%s", sig))
 	case err := <-errCh:
 		return err
+	}
+}
+
+// runHeartbeat runs the heartbeat loop with automatic restart on unexpected exit.
+// This provides resilience against panics or unexpected goroutine termination.
+func (s *Server) runHeartbeat(ctx context.Context) {
+	const restartDelay = 5 * time.Second
+
+	for {
+		s.backendClient.StartHeartbeat(ctx, s.cfg.Backend.HeartbeatInterval, func() int {
+			stats := s.channelManager.Stats()
+			return stats.ActiveChannels
+		})
+
+		// If context is cancelled, don't restart
+		if ctx.Err() != nil {
+			return
+		}
+
+		// Unexpected exit (e.g., recovered panic), restart after delay
+		s.logger.Error("Heartbeat goroutine exited unexpectedly, restarting",
+			"restart_delay", restartDelay)
+		select {
+		case <-time.After(restartDelay):
+			s.logger.Info("Restarting heartbeat goroutine")
+		case <-ctx.Done():
+			return
+		}
 	}
 }
 
@@ -197,7 +215,7 @@ func (s *Server) gracefulShutdown(reason string) error {
 	cancel()
 
 	// 2. Stop accepting new connections
-	s.acceptingConnections = false
+	s.acceptingConnections.Store(false)
 	s.logger.Info("Stopped accepting new connections")
 
 	// 3. Wait for existing channels to close (with timeout)
@@ -232,7 +250,7 @@ func (s *Server) gracefulShutdown(reason string) error {
 
 // IsAcceptingConnections returns whether the server is accepting new connections
 func (s *Server) IsAcceptingConnections() bool {
-	return s.acceptingConnections
+	return s.acceptingConnections.Load()
 }
 
 // Stats returns server statistics

--- a/relay/internal/server/server_test.go
+++ b/relay/internal/server/server_test.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"testing"
 	"time"
 
@@ -811,8 +810,8 @@ func TestServer_New_OnAllSubscribersGone_NotifyFails(t *testing.T) {
 	// If we reach here without panic, the error path was handled gracefully
 }
 
-func TestServer_Start_SignalHandling(t *testing.T) {
-	// Test the signal handling path in Start() (line 181-182)
+func TestServer_Start_ContextCancellation(t *testing.T) {
+	// Test the context cancellation path in Start() — signal handling is now in main.go
 	mockBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -840,7 +839,7 @@ func TestServer_Start_SignalHandling(t *testing.T) {
 			MaxBrowsersPerPod: 10,
 		},
 		Relay: config.RelayConfig{
-			ID:       "relay-signal-test",
+			ID:       "relay-ctx-test",
 			URL:      fmt.Sprintf("ws://127.0.0.1:%d", port),
 			Region:   "test",
 			Capacity: 100,
@@ -849,9 +848,10 @@ func TestServer_Start_SignalHandling(t *testing.T) {
 
 	s := New(cfg)
 
+	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- s.Start(context.Background())
+		errCh <- s.Start(ctx)
 	}()
 
 	// Wait for server to be ready
@@ -867,12 +867,8 @@ func TestServer_Start_SignalHandling(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 	}
 
-	// Send SIGINT to trigger signal path
-	p, err := os.FindProcess(os.Getpid())
-	if err != nil {
-		t.Fatalf("FindProcess: %v", err)
-	}
-	_ = p.Signal(syscall.SIGINT)
+	// Cancel context to trigger shutdown (simulating main.go signal handler calling cancel())
+	cancel()
 
 	select {
 	case err := <-errCh:
@@ -880,7 +876,7 @@ func TestServer_Start_SignalHandling(t *testing.T) {
 			t.Errorf("Start returned error: %v", err)
 		}
 	case <-time.After(10 * time.Second):
-		t.Fatal("Start did not return after signal")
+		t.Fatal("Start did not return after context cancellation")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fix relay 503 errors caused by heartbeat goroutine permanently stalling due to RWMutex deadlock chain
- Root cause: `Broadcast()` held `subscribersMu.RLock` during WebSocket writes; a dead subscriber blocked indefinitely, preventing `Stats()`/`SubscriberCount()` from acquiring RLock (Go RWMutex fairness with pending writer), which stalled the heartbeat goroutine permanently

## Changes

- **Broadcast snapshot-then-write**: Copy subscriber list under lock, write without lock held
- **Per-conn write mutexes**: `Subscriber.writeMu` and `publisherWriteMu` to serialize gorilla/websocket writes
- **5s write deadlines**: Prevent indefinite blocking on dead/slow connections
- **Heartbeat robustness**: Panic recovery, `getConnections` 5s timeout, auto-restart on unexpected exit
- **SetPublisher old conn cleanup**: Close replaced publisher conn so stale forwarding goroutine exits cleanly
- **handlePublisherDisconnect identity check**: Verify conn identity before acting, prevent closing a replaced publisher
- **Eliminate Unlock→Lock window**: Move Broadcast after full lock release in handlePublisherDisconnect
- **atomic.Bool for acceptingConnections**: Fix data race between gracefulShutdown and IsAcceptingConnections
- **Signal handling consolidation**: Remove duplicate signal handling, use context cancellation only

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` passes (channel + server tests)
- [x] Multiple rounds of deep code review covering lock ordering, write path completeness, and concurrent scenario simulation