### PR TITLE
feat(web): add GitHub repo link to navbar/footer and rewrite changelog

### DIFF
--- a/web/src/app/changelog/page.tsx
+++ b/web/src/app/changelog/page.tsx
@@ -13,123 +13,260 @@ interface ChangelogEntry {
 
 const changelog: ChangelogEntry[] = [
   {
-    version: "0.5.0",
-    date: "2025-03-15",
+    version: "0.9.1",
+    date: "2026-03-07",
     changes: [
       {
-        type: "added",
+        type: "fixed",
         items: [
-          "Quick Create Pod from Workspace",
-          "DNS-based relay URL generation for Runners",
+          "gRPC TLS ServerName correctly set to prevent advancedtls SNI port bug",
         ],
       },
       {
         type: "changed",
         items: [
-          "Separated DNS record management from URL generation",
+          "Channel UI/UX refactoring with docs i18n sync",
+        ],
+      },
+    ],
+  },
+  {
+    version: "0.9.0",
+    date: "2026-03-07",
+    changes: [
+      {
+        type: "added",
+        items: [
+          "Runner cross-platform abstraction for Windows support (ConPTY, path handling)",
+          "Public relay URL for scalable multi-relay routing",
+          "Runner endpoint auto-discovery, PID file, and login shell PATH injection",
+          "HeartbeatAck and recv watchdog for half-dead connection detection",
         ],
       },
       {
         type: "fixed",
         items: [
-          "Terminal message deduplication in React StrictMode",
-          "Non-standard port handling in relay WebSocket URLs",
+          "Terminal content duplication on page refresh",
+          "4 bugs in Runner PATH injection and config update code",
+          "Relay flap detection to prevent 500ms reconnect storm",
+          "Deep architecture issues in Zustand stores and React rendering",
+          "Relay concurrency issues causing heartbeat deadlock and 503 errors",
+        ],
+      },
+    ],
+  },
+  {
+    version: "0.8.0",
+    date: "2026-03-04",
+    changes: [
+      {
+        type: "added",
+        items: [
+          "MCP post_comment tool for ticket collaboration",
+          "Runner relay URL fallback for local development",
+        ],
+      },
+      {
+        type: "fixed",
+        items: [
+          "Runner MCP server bound to localhost with macOS code signing",
+          "PATH fallback for agent detection in Runner service mode",
+          "Self-update download failure due to missing v-prefix",
+          "Runner CLI binary name in help and error messages",
+          "gRPC chain-only TLS verification with dynamic server cert SANs",
+          "Redundant pod capacity check removed from Runner side",
+        ],
+      },
+    ],
+  },
+  {
+    version: "0.7.0",
+    date: "2026-03-04",
+    changes: [
+      {
+        type: "added",
+        items: [
+          "Support ticket system with admin interface",
+          "Blog content migrated from JSON to Markdown files",
+        ],
+      },
+      {
+        type: "changed",
+        items: [
+          "Runner release migrated from standalone repo to main monorepo",
+          "Runner GoReleaser config modernized, deprecation warnings resolved",
+        ],
+      },
+    ],
+  },
+  {
+    version: "0.6.0",
+    date: "2026-03-03",
+    changes: [
+      {
+        type: "added",
+        items: [
+          "Enterprise page and inquiry flow",
+          "Help & feedback button in ActivityBar",
+          "Server-side filtering and pagination for pod list",
+          "Admin email verification action",
+        ],
+      },
+      {
+        type: "fixed",
+        items: [
+          "gRPC downstream silent failure for runner connections",
+          "LemonSqueezy seat billing and subscription edge cases",
+          "OAuth empty email linking to unrelated users",
+        ],
+      },
+      {
+        type: "changed",
+        items: [
+          "Runner install directory changed to ~/.local/bin",
+        ],
+      },
+    ],
+  },
+  {
+    version: "0.5.0",
+    date: "2026-02-27",
+    changes: [
+      {
+        type: "added",
+        items: [
+          "Skills & MCP Server capabilities system for extensibility",
+          "Agent version detection, heartbeat reporting, and server-side adaptation",
+          "Dual clone URL support (HTTP + SSH) for repository imports",
+          "Image paste support with clipboard shim and native backends",
+        ],
+      },
+      {
+        type: "fixed",
+        items: [
+          "Runner stops reconnecting on fatal auth errors with actionable hints",
+          "Cross-org runner registration causing connection failures",
+          "Channel message deduplication to prevent double display",
         ],
       },
     ],
   },
   {
     version: "0.4.0",
-    date: "2025-02-10",
+    date: "2026-02-22",
     changes: [
       {
         type: "added",
         items: [
-          "Mesh topology real-time visualization",
-          "Pod binding with permission scopes (terminal:read, terminal:write)",
-          "Multi-language support (8 languages)",
+          "Admin Console subscription management",
+          "Runner three-layer reliability defense system",
+          "Runner enhanced logging with daily rotation and directory size limit",
+          "Headless login mode with default server for Runner",
+          "Follow Runner model option for Claude Code pods",
+          "MCP tool results optimized from JSON to Markdown format",
         ],
       },
       {
         type: "changed",
         items: [
-          "Improved Runner registration flow with mTLS certificates",
+          "Unified ticket identifier to slug naming across the stack",
+          "Standardized API error responses with structured error codes",
         ],
       },
       {
         type: "fixed",
         items: [
-          "Git worktree cleanup on Pod termination",
+          "Terminal blank after reconnect due to stale relay connection",
+          "Relay reconnect race condition when multiple clients connect to same pod",
         ],
       },
     ],
   },
   {
     version: "0.3.0",
-    date: "2025-01-10",
+    date: "2026-02-07",
     changes: [
       {
         type: "added",
         items: [
-          "Agent configuration UI with credential profiles",
-          "Promo code redemption system",
-          "Push notification support for pod status changes",
-          "Git connection management with OAuth and PAT support",
-        ],
-      },
-      {
-        type: "changed",
-        items: [
-          "Restructured settings page with personal/organization separation",
-          "Improved runner registration token flow",
-          "Enhanced sidebar navigation",
+          "Runner relay connection status reporting and display",
+          "Auto-reconnect for Runner-Relay WebSocket connection with token refresh",
+          "Terminal state restoration after server restart",
+          "Bandwidth-aware full redraw throttling for PTY output",
+          "Priority-based dual-channel architecture for Runner",
+          "Auto-update system with graceful updater reliability",
+          "Structured logging migration to slog",
+          "PR/MR status awareness mechanism",
+          "iOS PWA notification support with OSC terminal notifications",
+          "Sandbox status query and resume support",
         ],
       },
       {
         type: "fixed",
         items: [
-          "Terminal reconnection stability",
-          "Git worktree cleanup on pod termination",
+          "Terminal flickering with Synchronized Output frame detection",
+          "Terminal output loss with backpressure mechanism",
+          "Terminal size synchronization issues",
+        ],
+      },
+      {
+        type: "changed",
+        items: [
+          "Relay routing switched from session_id to podKey",
+          "Runner binary renamed to agentsmesh-runner",
         ],
       },
     ],
   },
   {
     version: "0.2.0",
-    date: "2024-12-15",
+    date: "2026-01-16",
     changes: [
       {
         type: "added",
         items: [
-          "AgentsMesh multi-agent collaboration channels",
-          "Pod binding with permission controls",
-          "Real-time topology visualization",
-          "Ticket-Pod integration",
+          "Runner migrated from WebSocket to gRPC + mTLS communication",
+          "MCP tool: create_pod with agent_type_id parameter",
+          "macOS universal binary support in GoReleaser",
+          "Homebrew formula automatic updates on release",
+          "Windows ConPTY support for terminal",
         ],
       },
       {
         type: "changed",
         items: [
-          "Improved terminal performance",
-          "Enhanced pod lifecycle management",
+          "Unified brand name to AgentsMesh across codebase",
+          "Agent config system refactored: removed Lua plugins, added backend-driven config",
+          "WebSocket compression enabled for better performance",
+        ],
+      },
+      {
+        type: "fixed",
+        items: [
+          "Race conditions in terminal and token refresh tests",
+          "Post-quantum TLS and WebSocket connection issues",
+          "Pod OSC title parsing accuracy",
         ],
       },
     ],
   },
   {
     version: "0.1.0",
-    date: "2024-11-01",
+    date: "2026-01-11",
     changes: [
       {
         type: "added",
         items: [
           "Initial release of AgentsMesh platform",
-          "AgentPod remote AI workstation",
+          "AgentPod: remote AI coding workstation with PTY terminal",
           "Support for Claude Code, Codex CLI, Gemini CLI, Aider",
-          "Self-hosted runner deployment",
+          "Self-hosted Runner deployment with mTLS certificate management",
           "Git repository integration (GitHub, GitLab, Gitee)",
-          "Web terminal with real-time interaction",
-          "Organization and team management",
+          "Web terminal with real-time bidirectional interaction",
+          "Organization and team management with multi-tenancy",
+          "AgentsMesh multi-agent collaboration channels",
+          "Ticket management with kanban board",
+          "Multi-language support (8 languages)",
         ],
       },
     ],

--- a/web/src/components/landing/Footer.tsx
+++ b/web/src/components/landing/Footer.tsx
@@ -7,7 +7,7 @@ import { Logo } from "@/components/common";
 const socialLinks = [
   {
     label: "GitHub",
-    href: "https://github.com/agentsmesh",
+    href: "https://github.com/AgentsMesh/AgentsMesh",
     icon: (
       <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
         <path fillRule="evenodd" clipRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
@@ -52,6 +52,7 @@ export function Footer() {
       title: t("landing.footer.resources.title"),
       links: [
         { label: t("landing.footer.resources.documentation"), href: "/docs" },
+        { label: t("landing.footer.resources.github"), href: "https://github.com/AgentsMesh/AgentsMesh" },
         { label: t("landing.footer.resources.changelog"), href: "/changelog" },
       ],
     },
@@ -111,16 +112,30 @@ export function Footer() {
             <div key={section.title}>
               <h4 className="font-semibold mb-4">{section.title}</h4>
               <ul className="space-y-2">
-                {section.links.map((link) => (
-                  <li key={link.label}>
-                    <Link
-                      href={link.href}
-                      className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-                    >
-                      {link.label}
-                    </Link>
-                  </li>
-                ))}
+                {section.links.map((link) => {
+                  const isExternal = link.href.startsWith("http") || link.href.startsWith("mailto:");
+                  return (
+                    <li key={link.label}>
+                      {isExternal ? (
+                        <a
+                          href={link.href}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                        >
+                          {link.label}
+                        </a>
+                      ) : (
+                        <Link
+                          href={link.href}
+                          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                        >
+                          {link.label}
+                        </Link>
+                      )}
+                    </li>
+                  );
+                })}
               </ul>
             </div>
           ))}

--- a/web/src/components/landing/Navbar.tsx
+++ b/web/src/components/landing/Navbar.tsx
@@ -58,6 +58,17 @@ export function Navbar() {
 
           {/* Desktop CTA */}
           <div className="hidden md:flex items-center gap-4">
+            <a
+              href="https://github.com/AgentsMesh/AgentsMesh"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-muted-foreground hover:text-foreground transition-colors"
+              aria-label="GitHub"
+            >
+              <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                <path fillRule="evenodd" clipRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
+              </svg>
+            </a>
             <LanguageSwitcher variant="icon" />
             <AuthButtons size="sm" showRegister className="flex items-center gap-4" />
           </div>
@@ -107,6 +118,17 @@ export function Navbar() {
                 </Link>
               ))}
               <div className="flex flex-col gap-2 pt-4 border-t border-border">
+                <a
+                  href="https://github.com/AgentsMesh/AgentsMesh"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path fillRule="evenodd" clipRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
+                  </svg>
+                  GitHub
+                </a>
                 <div className="flex items-center justify-between px-1 py-2">
                   <span className="text-sm text-muted-foreground">{t("landing.nav.language")}</span>
                   <LanguageSwitcher variant="full" />

--- a/web/src/messages/de/landing.json
+++ b/web/src/messages/de/landing.json
@@ -381,6 +381,7 @@
         "documentation": "Dokumentation",
         "apiReference": "API-Referenz",
         "tutorials": "Tutorials",
+        "github": "GitHub",
         "changelog": "Änderungsprotokoll",
         "status": "Status"
       },

--- a/web/src/messages/en/landing.json
+++ b/web/src/messages/en/landing.json
@@ -362,6 +362,7 @@
         "documentation": "Documentation",
         "apiReference": "API Reference",
         "tutorials": "Tutorials",
+        "github": "GitHub",
         "changelog": "Changelog",
         "status": "Status"
       },

--- a/web/src/messages/es/landing.json
+++ b/web/src/messages/es/landing.json
@@ -381,6 +381,7 @@
         "documentation": "Documentación",
         "apiReference": "Referencia API",
         "tutorials": "Tutoriales",
+        "github": "GitHub",
         "changelog": "Registro de cambios",
         "status": "Estado"
       },

--- a/web/src/messages/fr/landing.json
+++ b/web/src/messages/fr/landing.json
@@ -381,6 +381,7 @@
         "documentation": "Documentation",
         "apiReference": "Référence API",
         "tutorials": "Tutoriels",
+        "github": "GitHub",
         "changelog": "Journal des modifications",
         "status": "Statut"
       },

--- a/web/src/messages/ja/landing.json
+++ b/web/src/messages/ja/landing.json
@@ -381,6 +381,7 @@
         "documentation": "ドキュメント",
         "apiReference": "APIリファレンス",
         "tutorials": "チュートリアル",
+        "github": "GitHub",
         "changelog": "変更履歴",
         "status": "ステータス"
       },

--- a/web/src/messages/ko/landing.json
+++ b/web/src/messages/ko/landing.json
@@ -381,6 +381,7 @@
         "documentation": "문서",
         "apiReference": "API 레퍼런스",
         "tutorials": "튜토리얼",
+        "github": "GitHub",
         "changelog": "변경 로그",
         "status": "상태"
       },

--- a/web/src/messages/pt/landing.json
+++ b/web/src/messages/pt/landing.json
@@ -381,6 +381,7 @@
         "documentation": "Documentação",
         "apiReference": "Referência da API",
         "tutorials": "Tutoriais",
+        "github": "GitHub",
         "changelog": "Registro de alterações",
         "status": "Status"
       },

--- a/web/src/messages/zh/landing.json
+++ b/web/src/messages/zh/landing.json
@@ -362,6 +362,7 @@
         "documentation": "文档",
         "apiReference": "API 参考",
         "tutorials": "教程",
+        "github": "GitHub",
         "changelog": "更新日志",
         "status": "服务状态"
       },


### PR DESCRIPTION
## Summary

- Add GitHub open-source repo icon link (`github.com/AgentsMesh/AgentsMesh`) to both desktop and mobile top navbar
- Update footer: fix GitHub social link URL to point to the repo (not org), add GitHub text link in Resources section
- Improve footer link rendering: external URLs now use `<a target="_blank">` instead of Next.js `<Link>`
- Rewrite changelog page with actual version history (v0.1.0~v0.9.1) derived from real git tags and commits
- Add `github` i18n key to all 8 language files (en/zh/de/es/fr/ja/ko/pt)

## Test plan
- [ ] Verify GitHub icon appears in desktop navbar (between nav links and language switcher)
- [ ] Verify GitHub link appears in mobile hamburger menu
- [ ] Verify footer GitHub social icon links to `https://github.com/AgentsMesh/AgentsMesh`
- [ ] Verify footer Resources section shows "GitHub" link opening in new tab
- [ ] Verify changelog page displays all 10 versions with correct dates
- [ ] Verify all language variants render without missing translation warnings