### PR TITLE
fix(runner): prevent relay deadlock and add regression tests

### DIFF
--- a/runner/internal/relay/mock_client.go
+++ b/runner/internal/relay/mock_client.go
@@ -2,6 +2,7 @@ package relay
 
 import (
 	"sync"
+	"time"
 
 	"github.com/anthropics/agentsmesh/runner/internal/terminal/vt"
 )
@@ -19,14 +20,17 @@ type MockClient struct {
 	connectedAt int64
 
 	// Tracking
-	ConnectCalled    bool
-	StartCalled      bool
-	StopCalled       bool
-	UpdateTokenCalls []string
+	ConnectCalled     bool
+	StartCalled       bool
+	StopCalled        bool
+	UpdateTokenCalls  []string
+	SendSnapshotCalls int // Tracks SendSnapshot call count
 
 	// Configurable behavior
 	ConnectError error
 	StartResult  bool
+	StopDelay    time.Duration // Artificial delay in Stop() to simulate real behavior
+	OnStopHook   func()        // Called during Stop() to simulate close handler side-effects
 
 	// Handlers (stored but not used in mock)
 	onInput        InputHandler
@@ -68,9 +72,18 @@ func (m *MockClient) Start() bool {
 // Stop implements RelayClient.
 func (m *MockClient) Stop() {
 	m.mu.Lock()
-	defer m.mu.Unlock()
+	delay := m.StopDelay
+	hook := m.OnStopHook
 	m.StopCalled = true
 	m.connected = false
+	m.mu.Unlock()
+
+	if delay > 0 {
+		time.Sleep(delay)
+	}
+	if hook != nil {
+		hook()
+	}
 }
 
 // IsConnected implements RelayClient.
@@ -151,6 +164,9 @@ func (m *MockClient) SendOutput(data []byte) error {
 
 // SendSnapshot implements RelayClient.
 func (m *MockClient) SendSnapshot(snapshot *vt.TerminalSnapshot) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.SendSnapshotCalls++
 	return nil
 }
 
@@ -185,6 +201,7 @@ func (m *MockClient) Reset() {
 	m.StartCalled = false
 	m.StopCalled = false
 	m.UpdateTokenCalls = nil
+	m.SendSnapshotCalls = 0
 }
 
 // Ensure MockClient implements RelayClient interface

--- a/runner/internal/runner/message_handler.go
+++ b/runner/internal/runner/message_handler.go
@@ -2,20 +2,23 @@ package runner
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"sync"
 
 	runnerv1 "github.com/anthropics/agentsmesh/proto/gen/go/runner/v1"
 	"github.com/anthropics/agentsmesh/runner/internal/client"
 	"github.com/anthropics/agentsmesh/runner/internal/logger"
+	"github.com/anthropics/agentsmesh/runner/internal/relay"
 	"github.com/anthropics/agentsmesh/runner/internal/terminal/detector"
 )
 
 // RunnerMessageHandler implements client.MessageHandler interface.
 type RunnerMessageHandler struct {
-	runner   *Runner
-	podStore PodStore
-	conn     client.Connection
+	runner             *Runner
+	podStore           PodStore
+	conn               client.Connection
+	relayClientFactory func(url, podKey, token string, logger *slog.Logger) relay.RelayClient
 }
 
 // NewRunnerMessageHandler creates a new message handler.
@@ -25,6 +28,9 @@ func NewRunnerMessageHandler(runner *Runner, store PodStore, conn client.Connect
 		runner:   runner,
 		podStore: store,
 		conn:     conn,
+		relayClientFactory: func(url, podKey, token string, logger *slog.Logger) relay.RelayClient {
+			return relay.NewClient(url, podKey, token, logger)
+		},
 	}
 }
 

--- a/runner/internal/runner/message_handler_relay.go
+++ b/runner/internal/runner/message_handler_relay.go
@@ -16,6 +16,9 @@ const maxImagePasteSize = 2 * 1024 * 1024 // 2MB, matches frontend limit
 // The channel is identified by PodKey (not session ID).
 // If already connected to the same Relay URL, just update the token without reconnecting.
 // This allows multiple clients (Web + Mobile) to share the same connection.
+//
+// Lock strategy: relayMu is held ONLY for the pointer check/swap to avoid
+// blocking on network I/O or cross-module locks (vt.mu via GetSnapshot).
 func (h *RunnerMessageHandler) OnSubscribeTerminal(req client.SubscribeTerminalRequest) error {
 	log := logger.Pod()
 
@@ -38,12 +41,10 @@ func (h *RunnerMessageHandler) OnSubscribeTerminal(req client.SubscribeTerminalR
 		return fmt.Errorf("pod not found: %s", req.PodKey)
 	}
 
-	// Serialize concurrent subscribe operations for the same pod to prevent
-	// relay client leaks when two subscribe_terminal commands arrive concurrently.
+	// Phase 1: Under lock — check existing client and extract/clear if needed.
+	// Keep lock scope minimal to avoid blocking on network I/O or cross-module locks.
+	var oldClient relay.RelayClient
 	pod.LockRelay()
-	defer pod.UnlockRelay()
-
-	// Check if already connected to the same Relay URL (under lock)
 	existingClient := pod.RelayClient
 	if existingClient != nil {
 		if existingClient.IsConnected() && existingClient.GetRelayURL() == relayURL {
@@ -52,6 +53,7 @@ func (h *RunnerMessageHandler) OnSubscribeTerminal(req client.SubscribeTerminalR
 				"pod_key", req.PodKey,
 				"relay_url", relayURL)
 			existingClient.UpdateToken(req.RunnerToken)
+			pod.UnlockRelay()
 			return nil
 		}
 		// Connected to different Relay or disconnected, need to reconnect
@@ -61,12 +63,17 @@ func (h *RunnerMessageHandler) OnSubscribeTerminal(req client.SubscribeTerminalR
 			"new_relay_url", relayURL,
 			"was_connected", existingClient.IsConnected())
 		pod.RelayClient = nil
-		// Stop outside the field — existing client has its own internal state
-		existingClient.Stop()
+		oldClient = existingClient
+	}
+	pod.UnlockRelay()
+
+	// Stop old client outside the lock — it has its own internal state
+	if oldClient != nil {
+		oldClient.Stop()
 	}
 
-	// Create new relay client (no sessionID needed)
-	relayClient := relay.NewClient(
+	// Phase 2: Outside lock — network I/O (Connect, Start) cannot deadlock.
+	relayClient := h.relayClientFactory(
 		relayURL,
 		req.PodKey,
 		req.RunnerToken,
@@ -80,12 +87,26 @@ func (h *RunnerMessageHandler) OnSubscribeTerminal(req client.SubscribeTerminalR
 	}
 
 	if !relayClient.Start() {
-		relayClient.Stop() // Clean up connection resources from Connect()
+		relayClient.Stop()
 		return fmt.Errorf("failed to start relay client: client already stopped")
 	}
-	// Direct field assignment — we already hold relayMu via LockRelay
-	pod.RelayClient = relayClient
 
+	// Phase 3: Under lock — swap the pointer atomically.
+	// Check for a race: another goroutine may have set a different client while we were connecting.
+	pod.LockRelay()
+	if pod.RelayClient != nil {
+		// Another subscribe_terminal won the race; discard our client.
+		pod.UnlockRelay()
+		log.Info("Another relay client was set while connecting, discarding ours",
+			"pod_key", req.PodKey)
+		relayClient.Stop()
+		return nil
+	}
+	pod.RelayClient = relayClient
+	pod.UnlockRelay()
+
+	// Phase 4: Outside lock — set up relay output and send snapshot.
+	// These operations may acquire other locks (vt.mu) but relayMu is NOT held.
 	if pod.Aggregator != nil {
 		pod.Aggregator.SetRelayOutput(func(data []byte) {
 			if err := relayClient.SendOutput(data); err != nil {
@@ -94,10 +115,16 @@ func (h *RunnerMessageHandler) OnSubscribeTerminal(req client.SubscribeTerminalR
 		})
 	}
 
-	// Send terminal snapshot so late subscribers see existing content
+	// Send terminal snapshot so late subscribers see existing content.
+	// Use TryGetSnapshot to avoid blocking if Feed() holds the VT write lock.
 	if pod.VirtualTerminal != nil {
-		snapshot := pod.VirtualTerminal.GetSnapshot()
-		relayClient.SendSnapshot(snapshot)
+		snapshot := pod.VirtualTerminal.TryGetSnapshot()
+		if snapshot != nil {
+			relayClient.SendSnapshot(snapshot)
+		} else {
+			log.Info("VT lock busy during subscribe, snapshot will be sent on next frame",
+				"pod_key", req.PodKey)
+		}
 	}
 
 	// Trigger TUI redraw if needed
@@ -191,9 +218,16 @@ func (h *RunnerMessageHandler) setupRelayClientHandlers(relayClient relay.RelayC
 				relayClient.SendOutput(data)
 			})
 		}
+		// Use TryGetSnapshot to avoid blocking if Feed() holds the VT write lock.
+		// If the lock is busy, the next aggregator frame will deliver the content.
 		if pod.VirtualTerminal != nil {
-			snapshot := pod.VirtualTerminal.GetSnapshot()
-			relayClient.SendSnapshot(snapshot)
+			snapshot := pod.VirtualTerminal.TryGetSnapshot()
+			if snapshot != nil {
+				relayClient.SendSnapshot(snapshot)
+			} else {
+				log.Info("VT lock busy during reconnect, snapshot will be sent on next frame",
+					"pod_key", podKey)
+			}
 		}
 		if pod.VirtualTerminal != nil && pod.VirtualTerminal.IsAltScreen() && pod.Terminal != nil {
 			go func() {

--- a/runner/internal/runner/message_handler_relay_deadlock_test.go
+++ b/runner/internal/runner/message_handler_relay_deadlock_test.go
@@ -1,0 +1,296 @@
+package runner
+
+import (
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/anthropics/agentsmesh/runner/internal/client"
+	"github.com/anthropics/agentsmesh/runner/internal/config"
+	"github.com/anthropics/agentsmesh/runner/internal/relay"
+	"github.com/anthropics/agentsmesh/runner/internal/terminal/vt"
+)
+
+// TestOnSubscribeTerminal_NoDeadlockWhenVTBusy verifies that OnSubscribeTerminal
+// does not deadlock when VT's write lock is held by a concurrent Feed() call.
+// The original bug: relayMu held → GetSnapshot() needs vt.mu → Feed() holds vt.mu → deadlock.
+// The fix uses TryGetSnapshot outside relayMu, so this test must complete within the timeout.
+func TestOnSubscribeTerminal_NoDeadlockWhenVTBusy(t *testing.T) {
+	store := NewInMemoryPodStore()
+	mockConn := client.NewMockConnection()
+
+	runner := &Runner{cfg: &config.Config{}}
+	handler := NewRunnerMessageHandler(runner, store, mockConn)
+
+	// Create a real VT to exercise the lock contention path.
+	terminal := vt.NewVirtualTerminal(80, 24, 1000)
+
+	// Inject a mock factory so Connect/Start succeed without network I/O.
+	var createdClient *relay.MockClient
+	handler.relayClientFactory = func(url, podKey, token string, logger *slog.Logger) relay.RelayClient {
+		mc := relay.NewMockClient(url)
+		createdClient = mc
+		return mc
+	}
+
+	pod := &Pod{
+		PodKey:          "pod-deadlock-1",
+		Status:          PodStatusRunning,
+		VirtualTerminal: terminal,
+	}
+	store.Put(pod.PodKey, pod)
+
+	// Continuously feed VT to hold vt.mu write lock under contention.
+	stopFeed := make(chan struct{})
+	go func() {
+		data := []byte("hello world\r\n")
+		for {
+			select {
+			case <-stopFeed:
+				return
+			default:
+				terminal.Feed(data)
+			}
+		}
+	}()
+	defer close(stopFeed)
+
+	// OnSubscribeTerminal must complete within the timeout — a deadlock means failure.
+	done := make(chan error, 1)
+	go func() {
+		done <- handler.OnSubscribeTerminal(client.SubscribeTerminalRequest{
+			PodKey:      pod.PodKey,
+			RelayURL:    "wss://relay.example.com",
+			RunnerToken: "token-1",
+		})
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("OnSubscribeTerminal returned error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("deadlock detected: OnSubscribeTerminal blocked for 3s")
+	}
+
+	// Verify the client was set up.
+	rc := pod.GetRelayClient()
+	if rc == nil {
+		t.Fatal("expected relay client to be set after subscribe")
+	}
+
+	// SendSnapshot may or may not have been called (TryGetSnapshot can return nil
+	// if the VT lock is busy), both outcomes are valid.
+	_ = createdClient
+}
+
+// TestOnSubscribeTerminal_ConcurrentSubscribes verifies that multiple concurrent
+// subscribe_terminal requests do not deadlock when VT is busy.
+func TestOnSubscribeTerminal_ConcurrentSubscribes(t *testing.T) {
+	store := NewInMemoryPodStore()
+	mockConn := client.NewMockConnection()
+
+	runner := &Runner{cfg: &config.Config{}}
+	handler := NewRunnerMessageHandler(runner, store, mockConn)
+
+	terminal := vt.NewVirtualTerminal(80, 24, 1000)
+
+	// Factory that creates a fresh MockClient for each call.
+	handler.relayClientFactory = func(url, podKey, token string, logger *slog.Logger) relay.RelayClient {
+		return relay.NewMockClient(url)
+	}
+
+	pod := &Pod{
+		PodKey:          "pod-concurrent",
+		Status:          PodStatusRunning,
+		VirtualTerminal: terminal,
+	}
+	store.Put(pod.PodKey, pod)
+
+	// Continuous VT feed to create lock contention.
+	stopFeed := make(chan struct{})
+	go func() {
+		data := []byte("output line\r\n")
+		for {
+			select {
+			case <-stopFeed:
+				return
+			default:
+				terminal.Feed(data)
+			}
+		}
+	}()
+	defer close(stopFeed)
+
+	const concurrency = 10
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		go func() {
+			defer wg.Done()
+			_ = handler.OnSubscribeTerminal(client.SubscribeTerminalRequest{
+				PodKey:      pod.PodKey,
+				RelayURL:    "wss://relay.example.com",
+				RunnerToken: "token-concurrent",
+			})
+		}()
+	}
+
+	// All goroutines must finish within the timeout.
+	allDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(allDone)
+	}()
+
+	select {
+	case <-allDone:
+		// Success
+	case <-time.After(5 * time.Second):
+		t.Fatal("deadlock detected: concurrent OnSubscribeTerminal blocked for 5s")
+	}
+
+	// At least one subscribe must have succeeded.
+	if pod.GetRelayClient() == nil {
+		t.Error("expected at least one relay client to be set")
+	}
+}
+
+// TestOnSubscribeTerminal_RaceConditionTwoSubscribers verifies that when two
+// goroutines concurrently complete Phase 2 (Connect + Start), only one wins
+// the Phase 3 pointer swap and the loser's client is properly stopped.
+func TestOnSubscribeTerminal_RaceConditionTwoSubscribers(t *testing.T) {
+	store := NewInMemoryPodStore()
+	mockConn := client.NewMockConnection()
+
+	runner := &Runner{cfg: &config.Config{}}
+	handler := NewRunnerMessageHandler(runner, store, mockConn)
+
+	// Track all created clients to verify cleanup.
+	var clientsMu sync.Mutex
+	var allClients []*relay.MockClient
+
+	handler.relayClientFactory = func(url, podKey, token string, logger *slog.Logger) relay.RelayClient {
+		mc := relay.NewMockClient(url)
+		clientsMu.Lock()
+		allClients = append(allClients, mc)
+		clientsMu.Unlock()
+		return mc
+	}
+
+	pod := &Pod{
+		PodKey: "pod-race",
+		Status: PodStatusRunning,
+	}
+	store.Put(pod.PodKey, pod)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Two subscribers with different relay URLs race to set the client.
+	for i := 0; i < 2; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			_ = handler.OnSubscribeTerminal(client.SubscribeTerminalRequest{
+				PodKey:      pod.PodKey,
+				RelayURL:    "wss://relay.example.com",
+				RunnerToken: "token-" + string(rune('A'+i)),
+			})
+		}()
+	}
+
+	allDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(allDone)
+	}()
+
+	select {
+	case <-allDone:
+		// Success
+	case <-time.After(5 * time.Second):
+		t.Fatal("deadlock detected: two concurrent subscribers blocked for 5s")
+	}
+
+	// Exactly one client should be active.
+	if pod.GetRelayClient() == nil {
+		t.Fatal("expected a relay client to be set")
+	}
+
+	// Verify no leaked clients: every client that lost the race should have Stop() called.
+	clientsMu.Lock()
+	defer clientsMu.Unlock()
+
+	var stoppedCount int32
+	for _, mc := range allClients {
+		if mc.StopCalled {
+			stoppedCount++
+		}
+	}
+
+	// With 2 clients created, at most 1 should remain (the winner).
+	// The loser(s) must have been stopped.
+	activeCount := int32(len(allClients)) - stoppedCount
+	if activeCount > 1 {
+		t.Errorf("relay client leak: %d clients active (expected at most 1), %d total created, %d stopped",
+			activeCount, len(allClients), stoppedCount)
+	}
+}
+
+// TestOnSubscribeTerminal_SnapshotSentOnSuccess verifies that SendSnapshot is
+// called when VT lock is available and the subscribe succeeds.
+func TestOnSubscribeTerminal_SnapshotSentOnSuccess(t *testing.T) {
+	store := NewInMemoryPodStore()
+	mockConn := client.NewMockConnection()
+
+	runner := &Runner{cfg: &config.Config{}}
+	handler := NewRunnerMessageHandler(runner, store, mockConn)
+
+	terminal := vt.NewVirtualTerminal(80, 24, 1000)
+	// Feed some content so snapshot is non-nil.
+	terminal.Feed([]byte("Hello, World!\r\n"))
+
+	var snapshotCalls atomic.Int32
+	handler.relayClientFactory = func(url, podKey, token string, logger *slog.Logger) relay.RelayClient {
+		mc := relay.NewMockClient(url)
+		// Wrap SendSnapshot to count calls atomically.
+		return &snapshotTrackingClient{MockClient: mc, calls: &snapshotCalls}
+	}
+
+	pod := &Pod{
+		PodKey:          "pod-snapshot",
+		Status:          PodStatusRunning,
+		VirtualTerminal: terminal,
+	}
+	store.Put(pod.PodKey, pod)
+
+	err := handler.OnSubscribeTerminal(client.SubscribeTerminalRequest{
+		PodKey:      pod.PodKey,
+		RelayURL:    "wss://relay.example.com",
+		RunnerToken: "token-snap",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Without VT contention, TryGetSnapshot should succeed and SendSnapshot should be called.
+	if snapshotCalls.Load() == 0 {
+		t.Error("expected SendSnapshot to be called when VT lock is available")
+	}
+}
+
+// snapshotTrackingClient wraps MockClient to track SendSnapshot calls atomically.
+type snapshotTrackingClient struct {
+	*relay.MockClient
+	calls *atomic.Int32
+}
+
+func (s *snapshotTrackingClient) SendSnapshot(snapshot *vt.TerminalSnapshot) error {
+	s.calls.Add(1)
+	return s.MockClient.SendSnapshot(snapshot)
+}

--- a/runner/internal/runner/pod.go
+++ b/runner/internal/runner/pod.go
@@ -115,14 +115,21 @@ func (p *Pod) HasRelayClient() bool {
 	return p.RelayClient != nil && p.RelayClient.IsConnected()
 }
 
-// DisconnectRelay disconnects and clears the relay client
+// DisconnectRelay disconnects and clears the relay client.
+// Lock strategy: relayMu is held ONLY for the pointer swap.
+// Stop() and SetRelayOutput() are called outside the lock to avoid
+// deadlocking with relay callbacks (e.g., fireOnClose → SetRelayClient → relayMu).
 func (p *Pod) DisconnectRelay() {
 	p.relayMu.Lock()
-	defer p.relayMu.Unlock()
-	if p.RelayClient != nil {
-		logger.Pod().Debug("Disconnecting relay client", "pod_key", p.PodKey)
-		p.RelayClient.Stop()
+	rc := p.RelayClient
+	if rc != nil {
 		p.RelayClient = nil
+	}
+	p.relayMu.Unlock()
+
+	if rc != nil {
+		logger.Pod().Debug("Disconnecting relay client", "pod_key", p.PodKey)
+		rc.Stop()
 	}
 	// Clear aggregator relay output - will fall back to gRPC
 	if p.Aggregator != nil {

--- a/runner/internal/runner/pod_relay_deadlock_test.go
+++ b/runner/internal/runner/pod_relay_deadlock_test.go
@@ -1,0 +1,138 @@
+package runner
+
+import (
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/anthropics/agentsmesh/runner/internal/client"
+	"github.com/anthropics/agentsmesh/runner/internal/config"
+	"github.com/anthropics/agentsmesh/runner/internal/relay"
+)
+
+// TestDisconnectRelay_NoDeadlockWithCloseHandler verifies that DisconnectRelay
+// does not deadlock when Stop() triggers a close handler that accesses relayMu.
+// The original bug: relayMu held → Stop() waits for readLoop → readLoop's close
+// handler calls SetRelayClient → tries to acquire relayMu → deadlock.
+// The fix: DisconnectRelay extracts the pointer under lock, then calls Stop() outside.
+func TestDisconnectRelay_NoDeadlockWithCloseHandler(t *testing.T) {
+	pod := &Pod{PodKey: "pod-disconnect-1", Status: PodStatusRunning}
+
+	mc := relay.NewMockClient("wss://relay.example.com")
+	mc.SetConnected(true)
+
+	// Simulate real behavior: Stop() takes time (readLoop exit) and triggers close handler.
+	mc.StopDelay = 50 * time.Millisecond
+	mc.OnStopHook = func() {
+		// This mimics the close handler calling SetRelayClient(nil).
+		// If relayMu is still held by DisconnectRelay, this will deadlock.
+		pod.SetRelayClient(nil)
+	}
+
+	pod.SetRelayClient(mc)
+
+	done := make(chan struct{})
+	go func() {
+		pod.DisconnectRelay()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success — no deadlock.
+	case <-time.After(3 * time.Second):
+		t.Fatal("deadlock detected: DisconnectRelay blocked for 3s")
+	}
+
+	// Verify cleanup.
+	if pod.GetRelayClient() != nil {
+		t.Error("expected relay client to be nil after DisconnectRelay")
+	}
+	if !mc.StopCalled {
+		t.Error("expected Stop() to be called")
+	}
+}
+
+// TestDisconnectRelay_ConcurrentWithSubscribe verifies that DisconnectRelay
+// and OnSubscribeTerminal can run concurrently without deadlock.
+func TestDisconnectRelay_ConcurrentWithSubscribe(t *testing.T) {
+	store := NewInMemoryPodStore()
+	mockConn := client.NewMockConnection()
+
+	runner := &Runner{cfg: &config.Config{}}
+	handler := NewRunnerMessageHandler(runner, store, mockConn)
+
+	handler.relayClientFactory = func(url, podKey, token string, logger *slog.Logger) relay.RelayClient {
+		mc := relay.NewMockClient(url)
+		return mc
+	}
+
+	pod := &Pod{PodKey: "pod-concurrent-ds", Status: PodStatusRunning}
+	store.Put(pod.PodKey, pod)
+
+	// Set an initial relay client.
+	initialClient := relay.NewMockClient("wss://relay.example.com")
+	initialClient.SetConnected(true)
+	pod.SetRelayClient(initialClient)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Goroutine 1: Disconnect.
+	go func() {
+		defer wg.Done()
+		pod.DisconnectRelay()
+	}()
+
+	// Goroutine 2: Subscribe (may win or lose against disconnect).
+	go func() {
+		defer wg.Done()
+		_ = handler.OnSubscribeTerminal(client.SubscribeTerminalRequest{
+			PodKey:      pod.PodKey,
+			RelayURL:    "wss://relay2.example.com",
+			RunnerToken: "token-new",
+		})
+	}()
+
+	allDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(allDone)
+	}()
+
+	select {
+	case <-allDone:
+		// Success — no deadlock.
+	case <-time.After(5 * time.Second):
+		t.Fatal("deadlock detected: concurrent DisconnectRelay + OnSubscribeTerminal blocked for 5s")
+	}
+
+	// Final state should be consistent: client is either nil or the new one.
+	rc := pod.GetRelayClient()
+	if rc != nil && rc == initialClient {
+		t.Error("initial client should have been replaced or cleared")
+	}
+}
+
+// TestDisconnectRelay_Idempotent verifies that calling DisconnectRelay multiple
+// times is safe and idempotent.
+func TestDisconnectRelay_Idempotent(t *testing.T) {
+	pod := &Pod{PodKey: "pod-idempotent", Status: PodStatusRunning}
+
+	mc := relay.NewMockClient("wss://relay.example.com")
+	mc.SetConnected(true)
+	pod.SetRelayClient(mc)
+
+	// First disconnect.
+	pod.DisconnectRelay()
+	if pod.GetRelayClient() != nil {
+		t.Error("expected nil after first DisconnectRelay")
+	}
+
+	// Second disconnect should be a no-op.
+	pod.DisconnectRelay()
+	if pod.GetRelayClient() != nil {
+		t.Error("expected nil after second DisconnectRelay")
+	}
+}

--- a/runner/internal/runner/pod_relay_race_test.go
+++ b/runner/internal/runner/pod_relay_race_test.go
@@ -1,0 +1,112 @@
+package runner
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/anthropics/agentsmesh/runner/internal/relay"
+)
+
+// TestPodRelayOperations_RaceDetection exercises concurrent relay operations
+// to detect data races via `go test -race`.
+// This test does not assert specific outcomes — its value is in triggering
+// the race detector on interleaved read/write access to Pod.RelayClient.
+func TestPodRelayOperations_RaceDetection(t *testing.T) {
+	pod := &Pod{PodKey: "pod-race-detect", Status: PodStatusRunning}
+
+	const goroutines = 20
+	const iterations = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	// Mix of operations that touch relayMu from different angles.
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				switch i % 4 {
+				case 0:
+					// SetRelayClient
+					mc := relay.NewMockClient("wss://relay.example.com")
+					pod.SetRelayClient(mc)
+				case 1:
+					// GetRelayClient
+					_ = pod.GetRelayClient()
+				case 2:
+					// DisconnectRelay
+					pod.DisconnectRelay()
+				case 3:
+					// HasRelayClient
+					_ = pod.HasRelayClient()
+				}
+			}
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// All operations completed without panic or deadlock.
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout: concurrent relay operations blocked for 10s")
+	}
+}
+
+// TestPodRelayOperations_LockRelayRaceDetection exercises the LockRelay/UnlockRelay
+// path used by OnSubscribeTerminal's check-and-swap pattern concurrently with
+// SetRelayClient and GetRelayClient.
+func TestPodRelayOperations_LockRelayRaceDetection(t *testing.T) {
+	pod := &Pod{PodKey: "pod-lock-race", Status: PodStatusRunning}
+
+	const goroutines = 10
+	const iterations = 200
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				switch i % 3 {
+				case 0:
+					// Simulate OnSubscribeTerminal's check-and-swap pattern.
+					pod.LockRelay()
+					existing := pod.RelayClient
+					if existing == nil {
+						pod.RelayClient = relay.NewMockClient("wss://relay.example.com")
+					}
+					pod.UnlockRelay()
+				case 1:
+					// Concurrent read.
+					_ = pod.GetRelayClient()
+				case 2:
+					// Concurrent disconnect.
+					pod.DisconnectRelay()
+				}
+			}
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout: LockRelay race detection blocked for 10s")
+	}
+}


### PR DESCRIPTION
## Summary

- Fix two deadlock scenarios in relay connection management (`OnSubscribeTerminal` and `DisconnectRelay`) by minimizing lock scope and moving network I/O outside critical sections
- Add `relayClientFactory` dependency injection to `RunnerMessageHandler` for testability
- Enhance `MockClient` with `StopDelay`/`OnStopHook` to simulate real close handler behavior
- Add 9 regression tests across 3 new test files covering deadlock detection, concurrent operations, and race condition verification

## Test plan

- [x] All 9 new tests pass: `go test ./internal/runner/... -run "Deadlock|Race" -v -timeout 30s`
- [x] Race detector clean: `go test ./internal/runner/... -race -timeout 60s`
- [x] No regression in existing tests: `go test ./internal/runner/... -count=1` and `go test ./internal/relay/... -count=1`