### PR TITLE
fix(web): clear stale ticket content when switching tickets in detail…

### DIFF
--- a/web/src/components/tickets/TicketDetailPane.tsx
+++ b/web/src/components/tickets/TicketDetailPane.tsx
@@ -58,6 +58,9 @@ export function TicketDetailPane({ slug, onClose, className }: TicketDetailPaneP
     const cachedTicket = tickets.find(t => t.slug === slug);
     if (cachedTicket) {
       setTicket(cachedTicket);
+    } else {
+      // Reset stale ticket from previous slug
+      setTicket(null);
     }
 
     // If ticket was removed from store (e.g., deleted), skip the API call
@@ -257,7 +260,7 @@ export function TicketDetailPane({ slug, onClose, className }: TicketDetailPaneP
               </label>
               <div className="rounded-lg overflow-hidden bg-muted/20 ring-1 ring-border/30">
                 <Suspense fallback={<div className="h-[100px] animate-pulse bg-muted/30 rounded-lg" />}>
-                  <BlockViewer content={ticket.content} />
+                  <BlockViewer key={slug} content={ticket.content} />
                 </Suspense>
               </div>
             </div>


### PR DESCRIPTION
… pane

Reset ticket state to null when slug changes and no cached ticket exists, and add key={slug} to BlockViewer to force remount on ticket switch.

## Summary

- What changed?
- Why was this change needed?

## Changes

- 

## Validation

- [ ] Backend tests (`cd backend && go test ./...`)
- [ ] Web checks (`cd web && pnpm run lint && pnpm run type-check && pnpm run test:coverage`)
- [ ] Runner checks (`cd runner && go test ./...`)
- [ ] Manual validation performed (if applicable)

## Documentation

- [ ] Docs updated (README/docs/inline comments)
- [ ] No docs changes needed

## Risk and Rollback

- Risk level: Low / Medium / High
- Rollback plan:
