### PR TITLE
feat(runner): add remote upgrade via Web UI

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -186,6 +186,7 @@ func main() {
 	var grpcRunnerHandler *v1.GRPCRunnerHandler
 	var grpcServer *grpcserver.Server
 	var sandboxQuerySender runner.SandboxQuerySender
+	var upgradeCommandSender runner.UpgradeCommandSender
 	if cfg.PKI.CACertFile != "" && cfg.PKI.CAKeyFile != "" {
 		mcpDeps := &grpcserver.MCPDependencies{
 			PodService:        services.pod,
@@ -205,6 +206,7 @@ func main() {
 			podCoordinator.SetCommandSender(grpcCommandSender)
 			terminalRouter.SetCommandSender(grpcCommandSender)
 			sandboxQuerySender = grpcCommandSender
+			upgradeCommandSender = grpcCommandSender
 			slog.Info("PodCoordinator and TerminalRouter connected to gRPC Server")
 			setupRelayTokenRefreshCallback(db, runnerConnMgr, relayTokenGenerator, grpcCommandSender)
 		}
@@ -253,7 +255,8 @@ func main() {
 		APIKeyAdapter:      services.apikeyAdapter,
 		GRPCRunnerHandler:  grpcRunnerHandler,
 		SandboxQueryService: sandboxQuerySvc,
-		SandboxQuerySender:  sandboxQuerySender,
+		SandboxQuerySender:   sandboxQuerySender,
+		UpgradeCommandSender: upgradeCommandSender,
 		RelayManager:        relayManager,
 		RelayTokenGenerator: relayTokenGenerator,
 		RelayDNSService:     relayDNSService,

--- a/backend/internal/api/grpc/command_sender_adapter.go
+++ b/backend/internal/api/grpc/command_sender_adapter.go
@@ -79,8 +79,16 @@ func (s *GRPCCommandSender) IsConnected(runnerID int64) bool {
 	return s.adapter.IsConnected(runnerID)
 }
 
+// SendUpgradeRunner sends an upgrade command to a runner via gRPC.
+func (s *GRPCCommandSender) SendUpgradeRunner(runnerID int64, requestID, targetVersion string, force bool) error {
+	return s.adapter.SendUpgradeRunner(runnerID, requestID, targetVersion, force)
+}
+
 // Ensure GRPCCommandSender implements runner.RunnerCommandSender
 var _ runner.RunnerCommandSender = (*GRPCCommandSender)(nil)
 
 // Ensure GRPCCommandSender implements runner.SandboxQuerySender
 var _ runner.SandboxQuerySender = (*GRPCCommandSender)(nil)
+
+// Ensure GRPCCommandSender implements runner.UpgradeCommandSender
+var _ runner.UpgradeCommandSender = (*GRPCCommandSender)(nil)

--- a/backend/internal/api/grpc/runner_adapter_message.go
+++ b/backend/internal/api/grpc/runner_adapter_message.go
@@ -114,6 +114,9 @@ func (a *GRPCRunnerAdapter) handleProtoMessage(ctx context.Context, runnerID int
 	case *runnerv1.RunnerMessage_Pong:
 		a.handlePong(runnerID, conn, payload.Pong)
 
+	case *runnerv1.RunnerMessage_UpgradeStatus:
+		a.connManager.HandleUpgradeStatus(runnerID, payload.UpgradeStatus)
+
 	default:
 		a.logger.Warn("unknown message type", "runner_id", runnerID)
 	}

--- a/backend/internal/api/grpc/runner_adapter_send.go
+++ b/backend/internal/api/grpc/runner_adapter_send.go
@@ -192,6 +192,28 @@ func (a *GRPCRunnerAdapter) SendQuerySandboxes(runnerID int64, requestID string,
 	return conn.SendMessage(msg)
 }
 
+// ==================== Runner Upgrade Commands ====================
+
+// SendUpgradeRunner sends an upgrade command to a Runner.
+func (a *GRPCRunnerAdapter) SendUpgradeRunner(runnerID int64, requestID, targetVersion string, force bool) error {
+	conn := a.connManager.GetConnection(runnerID)
+	if conn == nil {
+		return status.Errorf(codes.NotFound, "runner %d not connected", runnerID)
+	}
+
+	msg := &runnerv1.ServerMessage{
+		Payload: &runnerv1.ServerMessage_UpgradeRunner{
+			UpgradeRunner: &runnerv1.UpgradeRunnerCommand{
+				RequestId:     requestID,
+				TargetVersion: targetVersion,
+				Force:         force,
+			},
+		},
+		Timestamp: time.Now().UnixMilli(),
+	}
+	return conn.SendMessage(msg)
+}
+
 // ==================== AutopilotController Commands ====================
 
 // SendCreateAutopilot sends a create AutopilotController command to a Runner.

--- a/backend/internal/api/rest/v1/routes.go
+++ b/backend/internal/api/rest/v1/routes.go
@@ -145,6 +145,9 @@ func registerRunnerRoutes(rg *gin.RouterGroup, svc *Services) {
 	if svc.VersionChecker != nil {
 		runnerOpts = append(runnerOpts, WithVersionChecker(svc.VersionChecker))
 	}
+	if svc.UpgradeCommandSender != nil {
+		runnerOpts = append(runnerOpts, WithUpgradeCommandSender(svc.UpgradeCommandSender))
+	}
 	runnerHandler := NewRunnerHandler(svc.Runner, runnerOpts...)
 	runners := rg.Group("/runners")
 	{
@@ -155,6 +158,7 @@ func registerRunnerRoutes(rg *gin.RouterGroup, svc *Services) {
 		runners.DELETE("/:id", runnerHandler.DeleteRunner)
 		runners.GET("/:id/pods", runnerHandler.ListRunnerPods)
 		runners.POST("/:id/sandboxes/query", runnerHandler.QuerySandboxes)
+		runners.POST("/:id/upgrade", runnerHandler.UpgradeRunner)
 
 		if svc.GRPCRunnerHandler != nil {
 			RegisterOrgGRPCRunnerRoutes(runners, svc.GRPCRunnerHandler)

--- a/backend/internal/api/rest/v1/routes_types.go
+++ b/backend/internal/api/rest/v1/routes_types.go
@@ -79,6 +79,9 @@ type Services struct {
 	SandboxQueryService *runner.SandboxQueryService // Sandbox status query service
 	SandboxQuerySender  runner.SandboxQuerySender   // Sandbox query sender (gRPC adapter)
 
+	// Upgrade command sender (gRPC adapter)
+	UpgradeCommandSender runner.UpgradeCommandSender
+
 	// Relay services for terminal data streaming
 	RelayManager        *relay.Manager        // Relay server management
 	RelayTokenGenerator *relay.TokenGenerator // Relay token generation

--- a/backend/internal/api/rest/v1/runners.go
+++ b/backend/internal/api/rest/v1/runners.go
@@ -7,12 +7,13 @@ import (
 
 // RunnerHandler handles runner-related requests
 type RunnerHandler struct {
-	runnerService       *runner.Service
-	podService          *agentpod.PodService
-	sandboxQueryService *runner.SandboxQueryService
-	sandboxQuerySender  runner.SandboxQuerySender
-	podCoordinator      *runner.PodCoordinator
-	versionChecker      *runner.VersionChecker
+	runnerService        *runner.Service
+	podService           *agentpod.PodService
+	sandboxQueryService  *runner.SandboxQueryService
+	sandboxQuerySender   runner.SandboxQuerySender
+	podCoordinator       *runner.PodCoordinator
+	versionChecker       *runner.VersionChecker
+	upgradeCommandSender runner.UpgradeCommandSender
 }
 
 // NewRunnerHandler creates a new runner handler
@@ -61,6 +62,13 @@ func WithPodCoordinatorForRunner(pc *runner.PodCoordinator) RunnerHandlerOption 
 func WithVersionChecker(vc *runner.VersionChecker) RunnerHandlerOption {
 	return func(h *RunnerHandler) {
 		h.versionChecker = vc
+	}
+}
+
+// WithUpgradeCommandSender sets the upgrade command sender for runner handler
+func WithUpgradeCommandSender(ucs runner.UpgradeCommandSender) RunnerHandlerOption {
+	return func(h *RunnerHandler) {
+		h.upgradeCommandSender = ucs
 	}
 }
 

--- a/backend/internal/api/rest/v1/runners_upgrade.go
+++ b/backend/internal/api/rest/v1/runners_upgrade.go
@@ -1,0 +1,96 @@
+package v1
+
+import (
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/anthropics/agentsmesh/backend/internal/middleware"
+	"github.com/anthropics/agentsmesh/backend/pkg/apierr"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// UpgradeRunnerRequest represents the request body for runner upgrade.
+type UpgradeRunnerRequest struct {
+	TargetVersion string `json:"target_version"`
+	Force         bool   `json:"force"`
+}
+
+// UpgradeRunner triggers a remote upgrade on a runner.
+// POST /api/v1/organizations/:slug/runners/:id/upgrade
+func (h *RunnerHandler) UpgradeRunner(c *gin.Context) {
+	if h.upgradeCommandSender == nil {
+		apierr.ServiceUnavailable(c, apierr.SERVICE_UNAVAILABLE, "Upgrade service not configured")
+		return
+	}
+
+	runnerID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		apierr.InvalidInput(c, "Invalid runner ID")
+		return
+	}
+
+	var req UpgradeRunnerRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		// Allow empty body (upgrade to latest)
+		req = UpgradeRunnerRequest{}
+	}
+
+	tenant := middleware.GetTenant(c)
+
+	// Verify runner exists and belongs to organization.
+	// Return 404 for both "not found" and "wrong org" to prevent cross-org enumeration.
+	r, err := h.runnerService.GetRunner(c.Request.Context(), runnerID)
+	if err != nil || r.OrganizationID != tenant.OrganizationID {
+		apierr.ResourceNotFound(c, "Runner not found")
+		return
+	}
+
+	// Check visibility: private runners are only visible to the registrant
+	if r.Visibility == "private" && (r.RegisteredByUserID == nil || *r.RegisteredByUserID != tenant.UserID) {
+		apierr.ForbiddenAccess(c)
+		return
+	}
+
+	// Check if runner is online
+	if !h.upgradeCommandSender.IsConnected(runnerID) {
+		apierr.ServiceUnavailable(c, apierr.SERVICE_UNAVAILABLE, "Runner is not connected")
+		return
+	}
+
+	// Check pod count (unless force)
+	if !req.Force && r.CurrentPods > 0 {
+		apierr.Conflict(c, apierr.HAS_REFERENCES, "Runner has active pods. Use force=true to override.")
+		return
+	}
+
+	// Generate request ID and send upgrade command
+	requestID := uuid.New().String()
+	if err := h.upgradeCommandSender.SendUpgradeRunner(runnerID, requestID, req.TargetVersion, req.Force); err != nil {
+		// Differentiate error types for better client diagnostics
+		if s, ok := status.FromError(err); ok && s.Code() == codes.NotFound {
+			apierr.ServiceUnavailable(c, apierr.SERVICE_UNAVAILABLE, "Runner disconnected before command could be sent")
+		} else {
+			apierr.InternalError(c, "Failed to send upgrade command")
+		}
+		return
+	}
+
+	// Audit log
+	slog.Info("Runner upgrade initiated",
+		"runner_id", runnerID,
+		"request_id", requestID,
+		"target_version", req.TargetVersion,
+		"force", req.Force,
+		"user_id", tenant.UserID,
+		"org_id", tenant.OrganizationID,
+	)
+
+	c.JSON(http.StatusAccepted, gin.H{
+		"request_id": requestID,
+		"message":    "Upgrade command sent to runner",
+	})
+}

--- a/backend/internal/middleware/audit_actions.go
+++ b/backend/internal/middleware/audit_actions.go
@@ -27,10 +27,11 @@ const (
 	AuditTeamMemberRemoved AuditAction = "teams.member_removed"
 
 	// Runner actions
-	AuditRunnerRegistered AuditAction = "runners.registered"
-	AuditRunnerDeleted    AuditAction = "runners.deleted"
-	AuditRunnerOnline     AuditAction = "runners.online"
-	AuditRunnerOffline    AuditAction = "runners.offline"
+	AuditRunnerRegistered      AuditAction = "runners.registered"
+	AuditRunnerDeleted         AuditAction = "runners.deleted"
+	AuditRunnerOnline          AuditAction = "runners.online"
+	AuditRunnerOffline         AuditAction = "runners.offline"
+	AuditRunnerUpgradeStarted  AuditAction = "runners.upgrade_started"
 
 	// Pod actions
 	AuditPodCreated    AuditAction = "pods.created"

--- a/backend/internal/service/runner/command_sender.go
+++ b/backend/internal/service/runner/command_sender.go
@@ -134,3 +134,13 @@ type SandboxQuerySender interface {
 	// IsConnected checks if a runner is connected.
 	IsConnected(runnerID int64) bool
 }
+
+// UpgradeCommandSender defines the interface for sending upgrade commands to runners.
+// This is a separate interface from RunnerCommandSender (Interface Segregation).
+type UpgradeCommandSender interface {
+	// SendUpgradeRunner sends an upgrade command to a runner.
+	SendUpgradeRunner(runnerID int64, requestID, targetVersion string, force bool) error
+
+	// IsConnected checks if a runner is connected.
+	IsConnected(runnerID int64) bool
+}

--- a/backend/internal/service/runner/connection_manager.go
+++ b/backend/internal/service/runner/connection_manager.go
@@ -55,6 +55,9 @@ type RunnerConnectionManager struct {
 	onPodError           func(runnerID int64, data *runnerv1.ErrorEvent)
 	onOSCTitle           func(runnerID int64, data *runnerv1.OSCTitleEvent)
 
+	// Upgrade event callback
+	onUpgradeStatus func(runnerID int64, data *runnerv1.UpgradeStatusEvent)
+
 	// AutopilotController event callbacks
 	onAutopilotStatus     func(runnerID int64, data *runnerv1.AutopilotStatusEvent)
 	onAutopilotIteration  func(runnerID int64, data *runnerv1.AutopilotIterationEvent)

--- a/backend/internal/service/runner/connection_manager_callbacks.go
+++ b/backend/internal/service/runner/connection_manager_callbacks.go
@@ -111,6 +111,13 @@ func (cm *RunnerConnectionManager) GetDisconnectCallback() func(runnerID int64) 
 	return cm.onDisconnect
 }
 
+// ==================== Upgrade Callback Setters ====================
+
+// SetUpgradeStatusCallback sets the upgrade status callback (Proto type)
+func (cm *RunnerConnectionManager) SetUpgradeStatusCallback(fn func(runnerID int64, data *runnerv1.UpgradeStatusEvent)) {
+	cm.onUpgradeStatus = fn
+}
+
 // ==================== AutopilotController Callback Setters ====================
 
 // SetAutopilotStatusCallback sets the AutopilotController status callback (Proto type)

--- a/backend/internal/service/runner/connection_manager_handlers.go
+++ b/backend/internal/service/runner/connection_manager_handlers.go
@@ -123,6 +123,24 @@ func (cm *RunnerConnectionManager) HandleOSCTitle(runnerID int64, data *runnerv1
 	}
 }
 
+// ==================== Upgrade Event Handlers ====================
+
+// HandleUpgradeStatus handles upgrade status event from runner (Proto type)
+func (cm *RunnerConnectionManager) HandleUpgradeStatus(runnerID int64, data *runnerv1.UpgradeStatusEvent) {
+	cm.UpdateHeartbeat(runnerID)
+	cm.logger.Info("received upgrade status",
+		"runner_id", runnerID,
+		"request_id", data.RequestId,
+		"phase", data.Phase,
+		"progress", data.Progress,
+		"message", data.Message,
+		"error", data.Error,
+	)
+	if cm.onUpgradeStatus != nil {
+		cm.onUpgradeStatus(runnerID, data)
+	}
+}
+
 // ==================== AutopilotController Event Handlers ====================
 
 // HandleAutopilotStatus handles AutopilotController status update event (Proto type)

--- a/proto/gen/go/runner/v1/runner.pb.go
+++ b/proto/gen/go/runner/v1/runner.pb.go
@@ -47,6 +47,7 @@ type RunnerMessage struct {
 	//	*RunnerMessage_AutopilotThinking
 	//	*RunnerMessage_McpRequest
 	//	*RunnerMessage_Pong
+	//	*RunnerMessage_UpgradeStatus
 	Payload       isRunnerMessage_Payload `protobuf_oneof:"payload"`
 	Timestamp     int64                   `protobuf:"varint,15,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -279,6 +280,15 @@ func (x *RunnerMessage) GetPong() *PongEvent {
 	return nil
 }
 
+func (x *RunnerMessage) GetUpgradeStatus() *UpgradeStatusEvent {
+	if x != nil {
+		if x, ok := x.Payload.(*RunnerMessage_UpgradeStatus); ok {
+			return x.UpgradeStatus
+		}
+	}
+	return nil
+}
+
 func (x *RunnerMessage) GetTimestamp() int64 {
 	if x != nil {
 		return x.Timestamp
@@ -377,6 +387,11 @@ type RunnerMessage_Pong struct {
 	Pong *PongEvent `protobuf:"bytes,22,opt,name=pong,proto3,oneof"`
 }
 
+type RunnerMessage_UpgradeStatus struct {
+	// 升级状态回报（Runner -> Backend）
+	UpgradeStatus *UpgradeStatusEvent `protobuf:"bytes,23,opt,name=upgrade_status,json=upgradeStatus,proto3,oneof"`
+}
+
 func (*RunnerMessage_Initialize) isRunnerMessage_Payload() {}
 
 func (*RunnerMessage_Initialized) isRunnerMessage_Payload() {}
@@ -418,6 +433,8 @@ func (*RunnerMessage_AutopilotThinking) isRunnerMessage_Payload() {}
 func (*RunnerMessage_McpRequest) isRunnerMessage_Payload() {}
 
 func (*RunnerMessage_Pong) isRunnerMessage_Payload() {}
+
+func (*RunnerMessage_UpgradeStatus) isRunnerMessage_Payload() {}
 
 // InitializeRequest Runner 初始化请求
 type InitializeRequest struct {
@@ -1333,6 +1350,7 @@ type ServerMessage struct {
 	//	*ServerMessage_McpResponse
 	//	*ServerMessage_Ping
 	//	*ServerMessage_HeartbeatAck
+	//	*ServerMessage_UpgradeRunner
 	Payload       isServerMessage_Payload `protobuf_oneof:"payload"`
 	Timestamp     int64                   `protobuf:"varint,15,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -1511,6 +1529,15 @@ func (x *ServerMessage) GetHeartbeatAck() *HeartbeatAck {
 	return nil
 }
 
+func (x *ServerMessage) GetUpgradeRunner() *UpgradeRunnerCommand {
+	if x != nil {
+		if x, ok := x.Payload.(*ServerMessage_UpgradeRunner); ok {
+			return x.UpgradeRunner
+		}
+	}
+	return nil
+}
+
 func (x *ServerMessage) GetTimestamp() int64 {
 	if x != nil {
 		return x.Timestamp
@@ -1586,6 +1613,11 @@ type ServerMessage_HeartbeatAck struct {
 	HeartbeatAck *HeartbeatAck `protobuf:"bytes,16,opt,name=heartbeat_ack,json=heartbeatAck,proto3,oneof"`
 }
 
+type ServerMessage_UpgradeRunner struct {
+	// 远程升级命令（Backend -> Runner）
+	UpgradeRunner *UpgradeRunnerCommand `protobuf:"bytes,17,opt,name=upgrade_runner,json=upgradeRunner,proto3,oneof"`
+}
+
 func (*ServerMessage_InitializeResult) isServerMessage_Payload() {}
 
 func (*ServerMessage_CreatePod) isServerMessage_Payload() {}
@@ -1615,6 +1647,8 @@ func (*ServerMessage_McpResponse) isServerMessage_Payload() {}
 func (*ServerMessage_Ping) isServerMessage_Payload() {}
 
 func (*ServerMessage_HeartbeatAck) isServerMessage_Payload() {}
+
+func (*ServerMessage_UpgradeRunner) isServerMessage_Payload() {}
 
 // InitializeResult 初始化响应
 type InitializeResult struct {
@@ -4681,11 +4715,167 @@ func (x *HeartbeatAck) GetHeartbeatTimestamp() int64 {
 	return 0
 }
 
+// UpgradeRunnerCommand 远程升级命令（Backend -> Runner）
+// 指示 Runner 下载并安装新版本，然后重启服务
+type UpgradeRunnerCommand struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RequestId     string                 `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`             // UUID，关联状态回报
+	TargetVersion string                 `protobuf:"bytes,2,opt,name=target_version,json=targetVersion,proto3" json:"target_version,omitempty"` // 目标版本号（空 = 最新版本）
+	Force         bool                   `protobuf:"varint,3,opt,name=force,proto3" json:"force,omitempty"`                                     // 忽略 Pod 计数检查
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpgradeRunnerCommand) Reset() {
+	*x = UpgradeRunnerCommand{}
+	mi := &file_runner_v1_runner_proto_msgTypes[62]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpgradeRunnerCommand) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpgradeRunnerCommand) ProtoMessage() {}
+
+func (x *UpgradeRunnerCommand) ProtoReflect() protoreflect.Message {
+	mi := &file_runner_v1_runner_proto_msgTypes[62]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpgradeRunnerCommand.ProtoReflect.Descriptor instead.
+func (*UpgradeRunnerCommand) Descriptor() ([]byte, []int) {
+	return file_runner_v1_runner_proto_rawDescGZIP(), []int{62}
+}
+
+func (x *UpgradeRunnerCommand) GetRequestId() string {
+	if x != nil {
+		return x.RequestId
+	}
+	return ""
+}
+
+func (x *UpgradeRunnerCommand) GetTargetVersion() string {
+	if x != nil {
+		return x.TargetVersion
+	}
+	return ""
+}
+
+func (x *UpgradeRunnerCommand) GetForce() bool {
+	if x != nil {
+		return x.Force
+	}
+	return false
+}
+
+// UpgradeStatusEvent 升级状态回报（Runner -> Backend）
+// Runner 在升级过程中持续回报各阶段状态
+type UpgradeStatusEvent struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	RequestId      string                 `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`                // 对应 UpgradeRunnerCommand.request_id
+	Phase          string                 `protobuf:"bytes,2,opt,name=phase,proto3" json:"phase,omitempty"`                                         // checking, downloading, applying, restarting, completed, failed
+	Progress       int32                  `protobuf:"varint,3,opt,name=progress,proto3" json:"progress,omitempty"`                                  // 0-100（下载进度）
+	Message        string                 `protobuf:"bytes,4,opt,name=message,proto3" json:"message,omitempty"`                                     // 人类可读状态信息
+	Error          string                 `protobuf:"bytes,5,opt,name=error,proto3" json:"error,omitempty"`                                         // phase=failed 时的错误信息
+	CurrentVersion string                 `protobuf:"bytes,6,opt,name=current_version,json=currentVersion,proto3" json:"current_version,omitempty"` // 当前运行版本
+	TargetVersion  string                 `protobuf:"bytes,7,opt,name=target_version,json=targetVersion,proto3" json:"target_version,omitempty"`    // 目标升级版本
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *UpgradeStatusEvent) Reset() {
+	*x = UpgradeStatusEvent{}
+	mi := &file_runner_v1_runner_proto_msgTypes[63]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpgradeStatusEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpgradeStatusEvent) ProtoMessage() {}
+
+func (x *UpgradeStatusEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_runner_v1_runner_proto_msgTypes[63]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpgradeStatusEvent.ProtoReflect.Descriptor instead.
+func (*UpgradeStatusEvent) Descriptor() ([]byte, []int) {
+	return file_runner_v1_runner_proto_rawDescGZIP(), []int{63}
+}
+
+func (x *UpgradeStatusEvent) GetRequestId() string {
+	if x != nil {
+		return x.RequestId
+	}
+	return ""
+}
+
+func (x *UpgradeStatusEvent) GetPhase() string {
+	if x != nil {
+		return x.Phase
+	}
+	return ""
+}
+
+func (x *UpgradeStatusEvent) GetProgress() int32 {
+	if x != nil {
+		return x.Progress
+	}
+	return 0
+}
+
+func (x *UpgradeStatusEvent) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *UpgradeStatusEvent) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
+func (x *UpgradeStatusEvent) GetCurrentVersion() string {
+	if x != nil {
+		return x.CurrentVersion
+	}
+	return ""
+}
+
+func (x *UpgradeStatusEvent) GetTargetVersion() string {
+	if x != nil {
+		return x.TargetVersion
+	}
+	return ""
+}
+
 var File_runner_v1_runner_proto protoreflect.FileDescriptor
 
 const file_runner_v1_runner_proto_rawDesc = "" +
 	"\n" +
-	"\x16runner/v1/runner.proto\x12\trunner.v1\"\xfa\v\n" +
+	"\x16runner/v1/runner.proto\x12\trunner.v1\"\xc2\f\n" +
 	"\rRunnerMessage\x12>\n" +
 	"\n" +
 	"initialize\x18\x01 \x01(\v2\x1c.runner.v1.InitializeRequestH\x00R\n" +
@@ -4713,7 +4903,8 @@ const file_runner_v1_runner_proto_rawDesc = "" +
 	"\x12autopilot_thinking\x18\x14 \x01(\v2!.runner.v1.AutopilotThinkingEventH\x00R\x11autopilotThinking\x128\n" +
 	"\vmcp_request\x18\x15 \x01(\v2\x15.runner.v1.McpRequestH\x00R\n" +
 	"mcpRequest\x12*\n" +
-	"\x04pong\x18\x16 \x01(\v2\x14.runner.v1.PongEventH\x00R\x04pong\x12\x1c\n" +
+	"\x04pong\x18\x16 \x01(\v2\x14.runner.v1.PongEventH\x00R\x04pong\x12F\n" +
+	"\x0eupgrade_status\x18\x17 \x01(\v2\x1d.runner.v1.UpgradeStatusEventH\x00R\rupgradeStatus\x12\x1c\n" +
 	"\ttimestamp\x18\x0f \x01(\x03R\ttimestampB\t\n" +
 	"\apayload\"v\n" +
 	"\x11InitializeRequest\x12)\n" +
@@ -4784,7 +4975,7 @@ const file_runner_v1_runner_proto_rawDesc = "" +
 	"\apod_key\x18\x01 \x01(\tR\x06podKey\x12\x14\n" +
 	"\x05phase\x18\x02 \x01(\tR\x05phase\x12\x1a\n" +
 	"\bprogress\x18\x03 \x01(\x05R\bprogress\x12\x18\n" +
-	"\amessage\x18\x04 \x01(\tR\amessage\"\xfb\b\n" +
+	"\amessage\x18\x04 \x01(\tR\amessage\"\xc5\t\n" +
 	"\rServerMessage\x12J\n" +
 	"\x11initialize_result\x18\x01 \x01(\v2\x1b.runner.v1.InitializeResultH\x00R\x10initializeResult\x12<\n" +
 	"\n" +
@@ -4803,7 +4994,8 @@ const file_runner_v1_runner_proto_rawDesc = "" +
 	"\x11autopilot_control\x18\f \x01(\v2\".runner.v1.AutopilotControlCommandH\x00R\x10autopilotControl\x12;\n" +
 	"\fmcp_response\x18\r \x01(\v2\x16.runner.v1.McpResponseH\x00R\vmcpResponse\x12,\n" +
 	"\x04ping\x18\x0e \x01(\v2\x16.runner.v1.PingCommandH\x00R\x04ping\x12>\n" +
-	"\rheartbeat_ack\x18\x10 \x01(\v2\x17.runner.v1.HeartbeatAckH\x00R\fheartbeatAck\x12\x1c\n" +
+	"\rheartbeat_ack\x18\x10 \x01(\v2\x17.runner.v1.HeartbeatAckH\x00R\fheartbeatAck\x12H\n" +
+	"\x0eupgrade_runner\x18\x11 \x01(\v2\x1f.runner.v1.UpgradeRunnerCommandH\x00R\rupgradeRunner\x12\x1c\n" +
 	"\ttimestamp\x18\x0f \x01(\x03R\ttimestampB\t\n" +
 	"\apayload\"\xcc\x01\n" +
 	"\x10InitializeResult\x12)\n" +
@@ -5038,7 +5230,21 @@ const file_runner_v1_runner_proto_rawDesc = "" +
 	"\tPongEvent\x12%\n" +
 	"\x0eping_timestamp\x18\x01 \x01(\x03R\rpingTimestamp\"?\n" +
 	"\fHeartbeatAck\x12/\n" +
-	"\x13heartbeat_timestamp\x18\x01 \x01(\x03R\x12heartbeatTimestamp2R\n" +
+	"\x13heartbeat_timestamp\x18\x01 \x01(\x03R\x12heartbeatTimestamp\"r\n" +
+	"\x14UpgradeRunnerCommand\x12\x1d\n" +
+	"\n" +
+	"request_id\x18\x01 \x01(\tR\trequestId\x12%\n" +
+	"\x0etarget_version\x18\x02 \x01(\tR\rtargetVersion\x12\x14\n" +
+	"\x05force\x18\x03 \x01(\bR\x05force\"\xe5\x01\n" +
+	"\x12UpgradeStatusEvent\x12\x1d\n" +
+	"\n" +
+	"request_id\x18\x01 \x01(\tR\trequestId\x12\x14\n" +
+	"\x05phase\x18\x02 \x01(\tR\x05phase\x12\x1a\n" +
+	"\bprogress\x18\x03 \x01(\x05R\bprogress\x12\x18\n" +
+	"\amessage\x18\x04 \x01(\tR\amessage\x12\x14\n" +
+	"\x05error\x18\x05 \x01(\tR\x05error\x12'\n" +
+	"\x0fcurrent_version\x18\x06 \x01(\tR\x0ecurrentVersion\x12%\n" +
+	"\x0etarget_version\x18\a \x01(\tR\rtargetVersion2R\n" +
 	"\rRunnerService\x12A\n" +
 	"\aConnect\x12\x18.runner.v1.RunnerMessage\x1a\x18.runner.v1.ServerMessage(\x010\x01B\x9a\x01\n" +
 	"\rcom.runner.v1B\vRunnerProtoP\x01Z7github.com/anthropic/agentmesh/proto/runner/v1;runnerv1\xa2\x02\x03RXX\xaa\x02\tRunner.V1\xca\x02\tRunner\\V1\xe2\x02\x15Runner\\V1\\GPBMetadata\xea\x02\n" +
@@ -5056,7 +5262,7 @@ func file_runner_v1_runner_proto_rawDescGZIP() []byte {
 	return file_runner_v1_runner_proto_rawDescData
 }
 
-var file_runner_v1_runner_proto_msgTypes = make([]protoimpl.MessageInfo, 64)
+var file_runner_v1_runner_proto_msgTypes = make([]protoimpl.MessageInfo, 66)
 var file_runner_v1_runner_proto_goTypes = []any{
 	(*RunnerMessage)(nil),              // 0: runner.v1.RunnerMessage
 	(*InitializeRequest)(nil),          // 1: runner.v1.InitializeRequest
@@ -5120,8 +5326,10 @@ var file_runner_v1_runner_proto_goTypes = []any{
 	(*PingCommand)(nil),                // 59: runner.v1.PingCommand
 	(*PongEvent)(nil),                  // 60: runner.v1.PongEvent
 	(*HeartbeatAck)(nil),               // 61: runner.v1.HeartbeatAck
-	nil,                                // 62: runner.v1.ErrorEvent.DetailsEntry
-	nil,                                // 63: runner.v1.CreatePodCommand.EnvVarsEntry
+	(*UpgradeRunnerCommand)(nil),       // 62: runner.v1.UpgradeRunnerCommand
+	(*UpgradeStatusEvent)(nil),         // 63: runner.v1.UpgradeStatusEvent
+	nil,                                // 64: runner.v1.ErrorEvent.DetailsEntry
+	nil,                                // 65: runner.v1.CreatePodCommand.EnvVarsEntry
 }
 var file_runner_v1_runner_proto_depIdxs = []int32{
 	1,  // 0: runner.v1.RunnerMessage.initialize:type_name -> runner.v1.InitializeRequest
@@ -5145,56 +5353,58 @@ var file_runner_v1_runner_proto_depIdxs = []int32{
 	51, // 18: runner.v1.RunnerMessage.autopilot_thinking:type_name -> runner.v1.AutopilotThinkingEvent
 	56, // 19: runner.v1.RunnerMessage.mcp_request:type_name -> runner.v1.McpRequest
 	60, // 20: runner.v1.RunnerMessage.pong:type_name -> runner.v1.PongEvent
-	2,  // 21: runner.v1.InitializeRequest.runner_info:type_name -> runner.v1.RunnerInfo
-	4,  // 22: runner.v1.InitializedConfirm.agent_versions:type_name -> runner.v1.AgentVersionInfo
-	6,  // 23: runner.v1.HeartbeatData.pods:type_name -> runner.v1.PodInfo
-	7,  // 24: runner.v1.HeartbeatData.relay_connections:type_name -> runner.v1.RelayConnectionInfo
-	4,  // 25: runner.v1.HeartbeatData.agent_versions:type_name -> runner.v1.AgentVersionInfo
-	62, // 26: runner.v1.ErrorEvent.details:type_name -> runner.v1.ErrorEvent.DetailsEntry
-	16, // 27: runner.v1.ServerMessage.initialize_result:type_name -> runner.v1.InitializeResult
-	19, // 28: runner.v1.ServerMessage.create_pod:type_name -> runner.v1.CreatePodCommand
-	23, // 29: runner.v1.ServerMessage.terminate_pod:type_name -> runner.v1.TerminatePodCommand
-	24, // 30: runner.v1.ServerMessage.terminal_input:type_name -> runner.v1.TerminalInputCommand
-	25, // 31: runner.v1.ServerMessage.terminal_resize:type_name -> runner.v1.TerminalResizeCommand
-	26, // 32: runner.v1.ServerMessage.send_prompt:type_name -> runner.v1.SendPromptCommand
-	27, // 33: runner.v1.ServerMessage.terminal_redraw:type_name -> runner.v1.TerminalRedrawCommand
-	28, // 34: runner.v1.ServerMessage.subscribe_terminal:type_name -> runner.v1.SubscribeTerminalCommand
-	29, // 35: runner.v1.ServerMessage.unsubscribe_terminal:type_name -> runner.v1.UnsubscribeTerminalCommand
-	31, // 36: runner.v1.ServerMessage.query_sandboxes:type_name -> runner.v1.QuerySandboxesCommand
-	47, // 37: runner.v1.ServerMessage.create_autopilot:type_name -> runner.v1.CreateAutopilotCommand
-	40, // 38: runner.v1.ServerMessage.autopilot_control:type_name -> runner.v1.AutopilotControlCommand
-	57, // 39: runner.v1.ServerMessage.mcp_response:type_name -> runner.v1.McpResponse
-	59, // 40: runner.v1.ServerMessage.ping:type_name -> runner.v1.PingCommand
-	61, // 41: runner.v1.ServerMessage.heartbeat_ack:type_name -> runner.v1.HeartbeatAck
-	17, // 42: runner.v1.InitializeResult.server_info:type_name -> runner.v1.ServerInfo
-	18, // 43: runner.v1.InitializeResult.agent_types:type_name -> runner.v1.AgentTypeInfo
-	63, // 44: runner.v1.CreatePodCommand.env_vars:type_name -> runner.v1.CreatePodCommand.EnvVarsEntry
-	21, // 45: runner.v1.CreatePodCommand.files_to_create:type_name -> runner.v1.FileToCreate
-	22, // 46: runner.v1.CreatePodCommand.sandbox_config:type_name -> runner.v1.SandboxConfig
-	20, // 47: runner.v1.CreatePodCommand.resources_to_download:type_name -> runner.v1.ResourceToDownload
-	32, // 48: runner.v1.QuerySandboxesCommand.queries:type_name -> runner.v1.SandboxQuery
-	34, // 49: runner.v1.SandboxesStatusEvent.sandboxes:type_name -> runner.v1.SandboxStatus
-	38, // 50: runner.v1.AutopilotStatusEvent.status:type_name -> runner.v1.AutopilotStatus
-	44, // 51: runner.v1.AutopilotControlCommand.pause:type_name -> runner.v1.AutopilotPauseAction
-	45, // 52: runner.v1.AutopilotControlCommand.resume:type_name -> runner.v1.AutopilotResumeAction
-	46, // 53: runner.v1.AutopilotControlCommand.stop:type_name -> runner.v1.AutopilotStopAction
-	41, // 54: runner.v1.AutopilotControlCommand.approve:type_name -> runner.v1.AutopilotApproveAction
-	42, // 55: runner.v1.AutopilotControlCommand.takeover:type_name -> runner.v1.AutopilotTakeoverAction
-	43, // 56: runner.v1.AutopilotControlCommand.handback:type_name -> runner.v1.AutopilotHandbackAction
-	19, // 57: runner.v1.CreateAutopilotCommand.pod_config:type_name -> runner.v1.CreatePodCommand
-	48, // 58: runner.v1.CreateAutopilotCommand.config:type_name -> runner.v1.AutopilotConfig
-	52, // 59: runner.v1.AutopilotThinkingEvent.action:type_name -> runner.v1.AutopilotAction
-	53, // 60: runner.v1.AutopilotThinkingEvent.progress:type_name -> runner.v1.AutopilotProgress
-	54, // 61: runner.v1.AutopilotThinkingEvent.help_request:type_name -> runner.v1.AutopilotHelpRequest
-	55, // 62: runner.v1.AutopilotHelpRequest.suggestions:type_name -> runner.v1.AutopilotHelpSuggestion
-	58, // 63: runner.v1.McpResponse.error:type_name -> runner.v1.McpError
-	0,  // 64: runner.v1.RunnerService.Connect:input_type -> runner.v1.RunnerMessage
-	15, // 65: runner.v1.RunnerService.Connect:output_type -> runner.v1.ServerMessage
-	65, // [65:66] is the sub-list for method output_type
-	64, // [64:65] is the sub-list for method input_type
-	64, // [64:64] is the sub-list for extension type_name
-	64, // [64:64] is the sub-list for extension extendee
-	0,  // [0:64] is the sub-list for field type_name
+	63, // 21: runner.v1.RunnerMessage.upgrade_status:type_name -> runner.v1.UpgradeStatusEvent
+	2,  // 22: runner.v1.InitializeRequest.runner_info:type_name -> runner.v1.RunnerInfo
+	4,  // 23: runner.v1.InitializedConfirm.agent_versions:type_name -> runner.v1.AgentVersionInfo
+	6,  // 24: runner.v1.HeartbeatData.pods:type_name -> runner.v1.PodInfo
+	7,  // 25: runner.v1.HeartbeatData.relay_connections:type_name -> runner.v1.RelayConnectionInfo
+	4,  // 26: runner.v1.HeartbeatData.agent_versions:type_name -> runner.v1.AgentVersionInfo
+	64, // 27: runner.v1.ErrorEvent.details:type_name -> runner.v1.ErrorEvent.DetailsEntry
+	16, // 28: runner.v1.ServerMessage.initialize_result:type_name -> runner.v1.InitializeResult
+	19, // 29: runner.v1.ServerMessage.create_pod:type_name -> runner.v1.CreatePodCommand
+	23, // 30: runner.v1.ServerMessage.terminate_pod:type_name -> runner.v1.TerminatePodCommand
+	24, // 31: runner.v1.ServerMessage.terminal_input:type_name -> runner.v1.TerminalInputCommand
+	25, // 32: runner.v1.ServerMessage.terminal_resize:type_name -> runner.v1.TerminalResizeCommand
+	26, // 33: runner.v1.ServerMessage.send_prompt:type_name -> runner.v1.SendPromptCommand
+	27, // 34: runner.v1.ServerMessage.terminal_redraw:type_name -> runner.v1.TerminalRedrawCommand
+	28, // 35: runner.v1.ServerMessage.subscribe_terminal:type_name -> runner.v1.SubscribeTerminalCommand
+	29, // 36: runner.v1.ServerMessage.unsubscribe_terminal:type_name -> runner.v1.UnsubscribeTerminalCommand
+	31, // 37: runner.v1.ServerMessage.query_sandboxes:type_name -> runner.v1.QuerySandboxesCommand
+	47, // 38: runner.v1.ServerMessage.create_autopilot:type_name -> runner.v1.CreateAutopilotCommand
+	40, // 39: runner.v1.ServerMessage.autopilot_control:type_name -> runner.v1.AutopilotControlCommand
+	57, // 40: runner.v1.ServerMessage.mcp_response:type_name -> runner.v1.McpResponse
+	59, // 41: runner.v1.ServerMessage.ping:type_name -> runner.v1.PingCommand
+	61, // 42: runner.v1.ServerMessage.heartbeat_ack:type_name -> runner.v1.HeartbeatAck
+	62, // 43: runner.v1.ServerMessage.upgrade_runner:type_name -> runner.v1.UpgradeRunnerCommand
+	17, // 44: runner.v1.InitializeResult.server_info:type_name -> runner.v1.ServerInfo
+	18, // 45: runner.v1.InitializeResult.agent_types:type_name -> runner.v1.AgentTypeInfo
+	65, // 46: runner.v1.CreatePodCommand.env_vars:type_name -> runner.v1.CreatePodCommand.EnvVarsEntry
+	21, // 47: runner.v1.CreatePodCommand.files_to_create:type_name -> runner.v1.FileToCreate
+	22, // 48: runner.v1.CreatePodCommand.sandbox_config:type_name -> runner.v1.SandboxConfig
+	20, // 49: runner.v1.CreatePodCommand.resources_to_download:type_name -> runner.v1.ResourceToDownload
+	32, // 50: runner.v1.QuerySandboxesCommand.queries:type_name -> runner.v1.SandboxQuery
+	34, // 51: runner.v1.SandboxesStatusEvent.sandboxes:type_name -> runner.v1.SandboxStatus
+	38, // 52: runner.v1.AutopilotStatusEvent.status:type_name -> runner.v1.AutopilotStatus
+	44, // 53: runner.v1.AutopilotControlCommand.pause:type_name -> runner.v1.AutopilotPauseAction
+	45, // 54: runner.v1.AutopilotControlCommand.resume:type_name -> runner.v1.AutopilotResumeAction
+	46, // 55: runner.v1.AutopilotControlCommand.stop:type_name -> runner.v1.AutopilotStopAction
+	41, // 56: runner.v1.AutopilotControlCommand.approve:type_name -> runner.v1.AutopilotApproveAction
+	42, // 57: runner.v1.AutopilotControlCommand.takeover:type_name -> runner.v1.AutopilotTakeoverAction
+	43, // 58: runner.v1.AutopilotControlCommand.handback:type_name -> runner.v1.AutopilotHandbackAction
+	19, // 59: runner.v1.CreateAutopilotCommand.pod_config:type_name -> runner.v1.CreatePodCommand
+	48, // 60: runner.v1.CreateAutopilotCommand.config:type_name -> runner.v1.AutopilotConfig
+	52, // 61: runner.v1.AutopilotThinkingEvent.action:type_name -> runner.v1.AutopilotAction
+	53, // 62: runner.v1.AutopilotThinkingEvent.progress:type_name -> runner.v1.AutopilotProgress
+	54, // 63: runner.v1.AutopilotThinkingEvent.help_request:type_name -> runner.v1.AutopilotHelpRequest
+	55, // 64: runner.v1.AutopilotHelpRequest.suggestions:type_name -> runner.v1.AutopilotHelpSuggestion
+	58, // 65: runner.v1.McpResponse.error:type_name -> runner.v1.McpError
+	0,  // 66: runner.v1.RunnerService.Connect:input_type -> runner.v1.RunnerMessage
+	15, // 67: runner.v1.RunnerService.Connect:output_type -> runner.v1.ServerMessage
+	67, // [67:68] is the sub-list for method output_type
+	66, // [66:67] is the sub-list for method input_type
+	66, // [66:66] is the sub-list for extension type_name
+	66, // [66:66] is the sub-list for extension extendee
+	0,  // [0:66] is the sub-list for field type_name
 }
 
 func init() { file_runner_v1_runner_proto_init() }
@@ -5224,6 +5434,7 @@ func file_runner_v1_runner_proto_init() {
 		(*RunnerMessage_AutopilotThinking)(nil),
 		(*RunnerMessage_McpRequest)(nil),
 		(*RunnerMessage_Pong)(nil),
+		(*RunnerMessage_UpgradeStatus)(nil),
 	}
 	file_runner_v1_runner_proto_msgTypes[15].OneofWrappers = []any{
 		(*ServerMessage_InitializeResult)(nil),
@@ -5241,6 +5452,7 @@ func file_runner_v1_runner_proto_init() {
 		(*ServerMessage_McpResponse)(nil),
 		(*ServerMessage_Ping)(nil),
 		(*ServerMessage_HeartbeatAck)(nil),
+		(*ServerMessage_UpgradeRunner)(nil),
 	}
 	file_runner_v1_runner_proto_msgTypes[40].OneofWrappers = []any{
 		(*AutopilotControlCommand_Pause)(nil),
@@ -5256,7 +5468,7 @@ func file_runner_v1_runner_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_runner_v1_runner_proto_rawDesc), len(file_runner_v1_runner_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   64,
+			NumMessages:   66,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/runner/v1/runner.proto
+++ b/proto/runner/v1/runner.proto
@@ -41,6 +41,8 @@ message RunnerMessage {
     McpRequest mcp_request = 21;
     // 下行心跳响应（Runner -> Backend）
     PongEvent pong = 22;
+    // 升级状态回报（Runner -> Backend）
+    UpgradeStatusEvent upgrade_status = 23;
   }
   int64 timestamp = 15;
 }
@@ -172,6 +174,8 @@ message ServerMessage {
     PingCommand ping = 14;
     // 上行心跳确认（Backend -> Runner）
     HeartbeatAck heartbeat_ack = 16;
+    // 远程升级命令（Backend -> Runner）
+    UpgradeRunnerCommand upgrade_runner = 17;
   }
   int64 timestamp = 15;
 }
@@ -590,4 +594,26 @@ message PongEvent {
 // Runner 收到后确认心跳已到达 Backend，用于上行通路存活检测
 message HeartbeatAck {
   int64 heartbeat_timestamp = 1;  // 原样回传 Runner 心跳的时间戳
+}
+
+// ==================== Runner 远程升级相关消息 ====================
+
+// UpgradeRunnerCommand 远程升级命令（Backend -> Runner）
+// 指示 Runner 下载并安装新版本，然后重启服务
+message UpgradeRunnerCommand {
+  string request_id = 1;       // UUID，关联状态回报
+  string target_version = 2;   // 目标版本号（空 = 最新版本）
+  bool force = 3;              // 忽略 Pod 计数检查
+}
+
+// UpgradeStatusEvent 升级状态回报（Runner -> Backend）
+// Runner 在升级过程中持续回报各阶段状态
+message UpgradeStatusEvent {
+  string request_id = 1;       // 对应 UpgradeRunnerCommand.request_id
+  string phase = 2;            // checking, downloading, applying, restarting, completed, failed
+  int32 progress = 3;          // 0-100（下载进度）
+  string message = 4;          // 人类可读状态信息
+  string error = 5;            // phase=failed 时的错误信息
+  string current_version = 6;  // 当前运行版本
+  string target_version = 7;   // 目标升级版本
 }

--- a/runner/cmd/runner/cmd_run.go
+++ b/runner/cmd/runner/cmd_run.go
@@ -18,6 +18,7 @@ import (
 	"github.com/anthropics/agentsmesh/runner/internal/logger"
 	"github.com/anthropics/agentsmesh/runner/internal/pidfile"
 	"github.com/anthropics/agentsmesh/runner/internal/runner"
+	"github.com/anthropics/agentsmesh/runner/internal/service"
 	"github.com/anthropics/agentsmesh/runner/internal/updater"
 )
 
@@ -167,6 +168,10 @@ func startRunner(cfg *config.Config) (ok bool) {
 		log.Error("Failed to create runner", "error", err)
 		return false
 	}
+
+	// Inject updater and restart function for remote upgrade support
+	r.SetUpdater(updater.New(version))
+	r.SetRestartFunc(service.RestartFunc())
 
 	// Create web console (lifecycle managed by Supervisor)
 	consoleServer := console.New(cfg, DefaultConsolePort, version)

--- a/runner/internal/client/grpc_handler.go
+++ b/runner/internal/client/grpc_handler.go
@@ -9,6 +9,7 @@ import (
 
 	runnerv1 "github.com/anthropics/agentsmesh/proto/gen/go/runner/v1"
 	"github.com/anthropics/agentsmesh/runner/internal/logger"
+	"github.com/anthropics/agentsmesh/runner/internal/safego"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -114,6 +115,13 @@ func (c *GRPCConnection) handleServerMessage(msg *runnerv1.ServerMessage) {
 	case *runnerv1.ServerMessage_HeartbeatAck:
 		c.handleHeartbeatAck(payload.HeartbeatAck)
 
+	case *runnerv1.ServerMessage_UpgradeRunner:
+		c.handlerWg.Add(1)
+		safego.Go("handle-upgrade-runner", func() {
+			defer c.handlerWg.Done()
+			c.handleUpgradeRunner(payload.UpgradeRunner)
+		})
+
 	default:
 		logger.GRPC().Warn("Unknown server message type")
 	}
@@ -164,3 +172,17 @@ func (c *GRPCConnection) handleTerminatePod(cmd *runnerv1.TerminatePodCommand) {
 
 // Note: Terminal, subscription, autopilot, MCP, and heartbeat handlers
 // are in grpc_handler_dispatch.go
+
+// handleUpgradeRunner handles upgrade_runner command from server.
+func (c *GRPCConnection) handleUpgradeRunner(cmd *runnerv1.UpgradeRunnerCommand) {
+	log := logger.GRPC()
+	log.Info("Received upgrade_runner", "request_id", cmd.RequestId, "target_version", cmd.TargetVersion, "force", cmd.Force)
+	if c.handler == nil {
+		log.Warn("No handler set, ignoring upgrade_runner")
+		return
+	}
+
+	if err := c.handler.OnUpgradeRunner(cmd); err != nil {
+		log.Error("Failed to handle upgrade runner", "request_id", cmd.RequestId, "error", err)
+	}
+}

--- a/runner/internal/client/grpc_sender_control.go
+++ b/runner/internal/client/grpc_sender_control.go
@@ -79,6 +79,17 @@ func (c *GRPCConnection) SendSandboxesStatus(requestID string, sandboxes []*Sand
 	return c.sendControl(msg)
 }
 
+// SendUpgradeStatus sends an upgrade status event to the server (control message).
+func (c *GRPCConnection) SendUpgradeStatus(event *runnerv1.UpgradeStatusEvent) error {
+	msg := &runnerv1.RunnerMessage{
+		Payload: &runnerv1.RunnerMessage_UpgradeStatus{
+			UpgradeStatus: event,
+		},
+		Timestamp: time.Now().UnixMilli(),
+	}
+	return c.sendControl(msg)
+}
+
 // sendError sends an error event back to the server (internal use, control message).
 func (c *GRPCConnection) sendError(podKey, code, message string) {
 	msg := &runnerv1.RunnerMessage{

--- a/runner/internal/client/grpc_writer_test.go
+++ b/runner/internal/client/grpc_writer_test.go
@@ -63,6 +63,10 @@ func (h *mockHandlerWithRelayConnections) OnAutopilotControl(cmd *runnerv1.Autop
 	return nil
 }
 
+func (h *mockHandlerWithRelayConnections) OnUpgradeRunner(cmd *runnerv1.UpgradeRunnerCommand) error {
+	return nil
+}
+
 // buildHeartbeatMessage builds a heartbeat message from handler data.
 // This is the core logic tested - extracted for testing without needing stream connection.
 func buildHeartbeatMessage(nodeID string, handler MessageHandler) *runnerv1.RunnerMessage {

--- a/runner/internal/client/interface.go
+++ b/runner/internal/client/interface.go
@@ -61,6 +61,9 @@ type ConnectionSender interface {
 	// SendAgentStatus sends an agent status change event to the server.
 	// Status values: "executing", "waiting", "idle".
 	SendAgentStatus(podKey string, status string) error
+
+	// SendUpgradeStatus sends an upgrade status event to the server.
+	SendUpgradeStatus(event *runnerv1.UpgradeStatusEvent) error
 }
 
 // ConnectionMonitor defines methods for monitoring connection health.

--- a/runner/internal/client/mock_connection.go
+++ b/runner/internal/client/mock_connection.go
@@ -220,6 +220,20 @@ func (m *MockConnection) SendAgentStatus(podKey string, status string) error {
 	return nil
 }
 
+// SendUpgradeStatus records an upgrade status event.
+func (m *MockConnection) SendUpgradeStatus(event *runnerv1.UpgradeStatusEvent) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.SendErr != nil {
+		return m.SendErr
+	}
+	m.Events = append(m.Events, EventCall{
+		Type: "upgrade_status",
+		Data: event,
+	})
+	return nil
+}
+
 // SendMessage records a raw RunnerMessage.
 func (m *MockConnection) SendMessage(msg *runnerv1.RunnerMessage) error {
 	m.mu.Lock()

--- a/runner/internal/client/mocks_test.go
+++ b/runner/internal/client/mocks_test.go
@@ -95,6 +95,10 @@ func (h *mockHandler) OnAutopilotControl(cmd *runnerv1.AutopilotControlCommand) 
 	return nil
 }
 
+func (h *mockHandler) OnUpgradeRunner(cmd *runnerv1.UpgradeRunnerCommand) error {
+	return nil
+}
+
 // mockHandlerWithError is a mock handler that can return errors.
 type mockHandlerWithError struct {
 	createError    error
@@ -149,6 +153,10 @@ func (h *mockHandlerWithError) OnCreateAutopilot(cmd *runnerv1.CreateAutopilotCo
 }
 
 func (h *mockHandlerWithError) OnAutopilotControl(cmd *runnerv1.AutopilotControlCommand) error {
+	return nil
+}
+
+func (h *mockHandlerWithError) OnUpgradeRunner(cmd *runnerv1.UpgradeRunnerCommand) error {
 	return nil
 }
 

--- a/runner/internal/client/protocol.go
+++ b/runner/internal/client/protocol.go
@@ -134,4 +134,7 @@ type MessageHandler interface {
 
 	// OnAutopilotControl handles Autopilot control commands (pause/resume/stop/approve/takeover/handback).
 	OnAutopilotControl(cmd *runnerv1.AutopilotControlCommand) error
+
+	// OnUpgradeRunner handles remote upgrade command from server.
+	OnUpgradeRunner(cmd *runnerv1.UpgradeRunnerCommand) error
 }

--- a/runner/internal/client/rpc_test.go
+++ b/runner/internal/client/rpc_test.go
@@ -46,7 +46,8 @@ func (m *mockSender) SendOSCNotification(string, string, string) error    { retu
 func (m *mockSender) SendOSCTitle(string, string) error                   { return nil }
 func (m *mockSender) SendRequestRelayToken(string, string) error          { return nil }
 func (m *mockSender) SendSandboxesStatus(string, []*SandboxStatusInfo) error { return nil }
-func (m *mockSender) QueueLength() int                                    { return 0 }
+func (m *mockSender) SendUpgradeStatus(*runnerv1.UpgradeStatusEvent) error   { return nil }
+func (m *mockSender) QueueLength() int                                       { return 0 }
 func (m *mockSender) QueueCapacity() int                                  { return 100 }
 func (m *mockSender) QueueUsage() float64                                 { return 0 }
 

--- a/runner/internal/runner/message_handler.go
+++ b/runner/internal/runner/message_handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/anthropics/agentsmesh/runner/internal/monitor"
 	"github.com/anthropics/agentsmesh/runner/internal/relay"
 	"github.com/anthropics/agentsmesh/runner/internal/terminal/detector"
+	"github.com/anthropics/agentsmesh/runner/internal/updater"
 )
 
 // MessageHandlerContext defines the subset of Runner capabilities needed by message handlers.
@@ -50,6 +51,26 @@ type MessageHandlerContext interface {
 
 	// NewPodController creates a new PodController for the given pod.
 	NewPodController(pod *Pod) *PodControllerImpl
+
+	// Upgrade lifecycle methods
+
+	// GetUpdater returns the updater instance (may be nil).
+	GetUpdater() *updater.Updater
+
+	// TryStartUpgrade atomically acquires the upgrade lock.
+	TryStartUpgrade() bool
+
+	// FinishUpgrade releases the upgrade lock.
+	FinishUpgrade()
+
+	// GetActivePodCount returns the number of active pods.
+	GetActivePodCount() int
+
+	// SetDraining sets the draining mode flag.
+	SetDraining(draining bool)
+
+	// GetRestartFunc returns the restart function (may be nil).
+	GetRestartFunc() func() (int, error)
 }
 
 // MCPServer defines the MCP server operations needed by message handlers.

--- a/runner/internal/runner/message_handler_upgrade.go
+++ b/runner/internal/runner/message_handler_upgrade.go
@@ -1,0 +1,161 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	runnerv1 "github.com/anthropics/agentsmesh/proto/gen/go/runner/v1"
+	"github.com/anthropics/agentsmesh/runner/internal/logger"
+)
+
+// OnUpgradeRunner handles remote upgrade command from server.
+func (h *RunnerMessageHandler) OnUpgradeRunner(cmd *runnerv1.UpgradeRunnerCommand) error {
+	log := logger.Runner()
+	log.Info("Received upgrade command",
+		"request_id", cmd.RequestId,
+		"target_version", cmd.TargetVersion,
+		"force", cmd.Force,
+	)
+
+	u := h.runner.GetUpdater()
+	if u == nil {
+		h.sendUpgradeStatus(cmd.RequestId, cmd.TargetVersion, "failed", 0, "", "updater not configured", nil)
+		return fmt.Errorf("updater not configured")
+	}
+
+	// Discard if another upgrade is already in progress
+	if !h.runner.TryStartUpgrade() {
+		log.Info("Upgrade already in progress, discarding command", "request_id", cmd.RequestId)
+		return nil
+	}
+
+	// Pod count check: refuse if pods are running and force is not set
+	podCount := h.runner.GetActivePodCount()
+	if !cmd.Force && podCount > 0 {
+		h.runner.FinishUpgrade()
+		msg := fmt.Sprintf("cannot upgrade: %d active pod(s), use force to override", podCount)
+		h.sendUpgradeStatus(cmd.RequestId, cmd.TargetVersion, "failed", 0, msg, msg, u)
+		return fmt.Errorf("%s", msg)
+	}
+
+	// Enter draining mode to prevent new pods
+	h.runner.SetDraining(true)
+
+	// Run upgrade asynchronously (already in goroutine from grpc_handler)
+	h.runUpgrade(cmd)
+	return nil
+}
+
+// runUpgrade executes the upgrade process and reports status at each phase.
+func (h *RunnerMessageHandler) runUpgrade(cmd *runnerv1.UpgradeRunnerCommand) {
+	log := logger.Runner()
+	u := h.runner.GetUpdater()
+	tv := cmd.TargetVersion
+
+	// Centralized cleanup: always restore draining and upgrade flags on exit.
+	// Set to false only when restart succeeds (process will exit).
+	restoreDraining := true
+	defer func() {
+		if restoreDraining {
+			h.runner.SetDraining(false)
+		}
+		h.runner.FinishUpgrade()
+	}()
+
+	// Check if runner is shutting down before starting
+	runCtx := h.runner.GetRunContext()
+	if runCtx.Err() != nil {
+		h.sendUpgradeFailure(cmd.RequestId, tv, "runner is shutting down", u)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(runCtx, 5*time.Minute)
+	defer cancel()
+
+	// Phase: checking
+	h.sendUpgradeStatus(cmd.RequestId, tv, "checking", 0, "Checking for updates...", "", u)
+
+	if tv == "" {
+		// Update to latest version
+		h.sendUpgradeStatus(cmd.RequestId, tv, "downloading", 0, "Downloading latest version...", "", u)
+
+		newVersion, err := u.UpdateNow(ctx, nil)
+		if err != nil {
+			h.sendUpgradeFailure(cmd.RequestId, tv, fmt.Sprintf("update failed: %v", err), u)
+			return
+		}
+		if newVersion == "" {
+			h.sendUpgradeStatus(cmd.RequestId, tv, "completed", 100, "Already up to date", "", u)
+			return
+		}
+
+		log.Info("Update downloaded and applied", "new_version", newVersion)
+	} else {
+		// Update to specific version
+		h.sendUpgradeStatus(cmd.RequestId, tv, "downloading", 0,
+			fmt.Sprintf("Downloading version %s...", tv), "", u)
+
+		if err := u.UpdateToVersion(ctx, tv, nil); err != nil {
+			h.sendUpgradeFailure(cmd.RequestId, tv, fmt.Sprintf("update to %s failed: %v", tv, err), u)
+			return
+		}
+
+		log.Info("Update downloaded and applied", "target_version", tv)
+	}
+
+	// Phase: applying
+	h.sendUpgradeStatus(cmd.RequestId, tv, "applying", 90, "Update applied, preparing restart...", "", u)
+
+	// Phase: restarting
+	h.sendUpgradeStatus(cmd.RequestId, tv, "restarting", 95, "Restarting service...", "", u)
+
+	restartFn := h.runner.GetRestartFunc()
+	if restartFn != nil {
+		if _, err := restartFn(); err != nil {
+			log.Error("Restart after upgrade failed", "error", err)
+			h.sendUpgradeStatus(cmd.RequestId, tv, "completed", 100,
+				"Update applied but restart failed, manual restart required", "", u)
+			return
+		}
+		// Restart succeeded — process will exit and service manager restarts it.
+		// Do NOT restore draining; the new process will reconnect.
+		restoreDraining = false
+	} else {
+		log.Warn("No restart function configured, update applied but restart required manually")
+		h.sendUpgradeStatus(cmd.RequestId, tv, "completed", 100,
+			"Update applied, manual restart required", "", u)
+	}
+}
+
+// sendUpgradeFailure reports an upgrade failure via status event.
+func (h *RunnerMessageHandler) sendUpgradeFailure(requestID, targetVersion, errMsg string, u interface{ CurrentVersion() string }) {
+	logger.Runner().Error("Upgrade failed", "request_id", requestID, "error", errMsg)
+	h.sendUpgradeStatus(requestID, targetVersion, "failed", 0, "", errMsg, u)
+}
+
+// sendUpgradeStatus sends an upgrade status event to the server.
+func (h *RunnerMessageHandler) sendUpgradeStatus(requestID, targetVersion, phase string, progress int32, message, errMsg string, u interface{ CurrentVersion() string }) {
+	currentVersion := ""
+	if u != nil {
+		currentVersion = u.CurrentVersion()
+	}
+
+	event := &runnerv1.UpgradeStatusEvent{
+		RequestId:      requestID,
+		Phase:          phase,
+		Progress:       progress,
+		Message:        message,
+		Error:          errMsg,
+		CurrentVersion: currentVersion,
+		TargetVersion:  targetVersion,
+	}
+
+	if err := h.conn.SendUpgradeStatus(event); err != nil {
+		logger.Runner().Error("Failed to send upgrade status",
+			"request_id", requestID,
+			"phase", phase,
+			"error", err,
+		)
+	}
+}

--- a/runner/internal/runner/message_handler_upgrade_test.go
+++ b/runner/internal/runner/message_handler_upgrade_test.go
@@ -1,0 +1,546 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	runnerv1 "github.com/anthropics/agentsmesh/proto/gen/go/runner/v1"
+	"github.com/anthropics/agentsmesh/runner/internal/client"
+	"github.com/anthropics/agentsmesh/runner/internal/config"
+	"github.com/anthropics/agentsmesh/runner/internal/updater"
+)
+
+// testReleaseDetector implements updater.ReleaseDetector for testing.
+type testReleaseDetector struct {
+	detectLatestFn  func(ctx context.Context) (*updater.ReleaseInfo, bool, error)
+	detectVersionFn func(ctx context.Context, version string) (*updater.ReleaseInfo, bool, error)
+	downloadToFn    func(ctx context.Context, release *updater.ReleaseInfo, path string) error
+}
+
+func (d *testReleaseDetector) DetectLatest(ctx context.Context) (*updater.ReleaseInfo, bool, error) {
+	if d.detectLatestFn != nil {
+		return d.detectLatestFn(ctx)
+	}
+	return nil, false, fmt.Errorf("not configured")
+}
+
+func (d *testReleaseDetector) DetectVersion(ctx context.Context, version string) (*updater.ReleaseInfo, bool, error) {
+	if d.detectVersionFn != nil {
+		return d.detectVersionFn(ctx, version)
+	}
+	return nil, false, fmt.Errorf("not configured")
+}
+
+func (d *testReleaseDetector) DownloadTo(ctx context.Context, release *updater.ReleaseInfo, path string) error {
+	if d.downloadToFn != nil {
+		return d.downloadToFn(ctx, release, path)
+	}
+	return fmt.Errorf("not configured")
+}
+
+func newTestRunnerForUpgrade(podCount int) *Runner {
+	store := NewInMemoryPodStore()
+	for i := 0; i < podCount; i++ {
+		store.Put(fmt.Sprintf("pod-%d", i), &Pod{
+			PodKey: fmt.Sprintf("pod-%d", i),
+			Status: PodStatusRunning,
+		})
+	}
+
+	r := &Runner{
+		cfg:      &config.Config{},
+		podStore: store,
+		runCtx:   context.Background(),
+	}
+	return r
+}
+
+func getUpgradeStatuses(mockConn *client.MockConnection) []*runnerv1.UpgradeStatusEvent {
+	events := mockConn.GetEvents()
+	var statuses []*runnerv1.UpgradeStatusEvent
+	for _, e := range events {
+		if e.Type == "upgrade_status" {
+			if evt, ok := e.Data.(*runnerv1.UpgradeStatusEvent); ok {
+				statuses = append(statuses, evt)
+			}
+		}
+	}
+	return statuses
+}
+
+// noUpdateDetector simulates "already up to date"
+func noUpdateDetector() *testReleaseDetector {
+	return &testReleaseDetector{
+		detectLatestFn: func(ctx context.Context) (*updater.ReleaseInfo, bool, error) {
+			return nil, false, nil // no update available
+		},
+	}
+}
+
+// failDetector simulates a network/API error during update check
+func failDetector() *testReleaseDetector {
+	return &testReleaseDetector{
+		detectLatestFn: func(ctx context.Context) (*updater.ReleaseInfo, bool, error) {
+			return nil, false, fmt.Errorf("network error")
+		},
+		detectVersionFn: func(ctx context.Context, version string) (*updater.ReleaseInfo, bool, error) {
+			return nil, false, fmt.Errorf("network error")
+		},
+	}
+}
+
+// successDetector simulates a successful update flow:
+// DetectLatest finds v2.0.0, DetectVersion confirms it, DownloadTo writes a fake binary.
+func successDetector(t *testing.T) *testReleaseDetector {
+	t.Helper()
+	release := &updater.ReleaseInfo{
+		Version:  "v2.0.0",
+		AssetURL: "https://example.com/runner.tar.gz",
+	}
+	return &testReleaseDetector{
+		detectLatestFn: func(ctx context.Context) (*updater.ReleaseInfo, bool, error) {
+			return release, true, nil
+		},
+		detectVersionFn: func(ctx context.Context, version string) (*updater.ReleaseInfo, bool, error) {
+			return release, true, nil
+		},
+		downloadToFn: func(ctx context.Context, rel *updater.ReleaseInfo, path string) error {
+			return os.WriteFile(path, []byte("fake-binary"), 0o755)
+		},
+	}
+}
+
+func TestOnUpgradeRunner_NoUpdater(t *testing.T) {
+	r := newTestRunnerForUpgrade(0)
+	mockConn := client.NewMockConnection()
+	handler := NewRunnerMessageHandler(r, r.podStore, mockConn)
+
+	err := handler.OnUpgradeRunner(&runnerv1.UpgradeRunnerCommand{
+		RequestId: "req-1",
+	})
+	if err == nil {
+		t.Fatal("expected error when updater is nil")
+	}
+
+	statuses := getUpgradeStatuses(mockConn)
+	if len(statuses) != 1 {
+		t.Fatalf("expected 1 status event, got %d", len(statuses))
+	}
+	if statuses[0].Phase != "failed" {
+		t.Errorf("expected phase=failed, got %q", statuses[0].Phase)
+	}
+	if statuses[0].Error == "" {
+		t.Error("expected non-empty error message")
+	}
+}
+
+func TestOnUpgradeRunner_ActivePods_Rejected(t *testing.T) {
+	r := newTestRunnerForUpgrade(2)
+	r.SetUpdater(updater.New("1.0.0"))
+	mockConn := client.NewMockConnection()
+	handler := NewRunnerMessageHandler(r, r.podStore, mockConn)
+
+	err := handler.OnUpgradeRunner(&runnerv1.UpgradeRunnerCommand{
+		RequestId: "req-2",
+		Force:     false,
+	})
+	if err == nil {
+		t.Fatal("expected error when pods are running")
+	}
+	if !contains(err.Error(), "active pod") {
+		t.Errorf("error should mention active pods, got: %v", err)
+	}
+
+	statuses := getUpgradeStatuses(mockConn)
+	if len(statuses) != 1 {
+		t.Fatalf("expected 1 status event, got %d", len(statuses))
+	}
+	if statuses[0].Phase != "failed" {
+		t.Errorf("expected phase=failed, got %q", statuses[0].Phase)
+	}
+
+	// Draining should NOT be set (rejected before entering draining)
+	if r.IsDraining() {
+		t.Error("should not enter draining when upgrade is rejected")
+	}
+}
+
+func TestOnUpgradeRunner_ActivePods_ForceAllowed(t *testing.T) {
+	r := newTestRunnerForUpgrade(1)
+	r.SetUpdater(updater.New("1.0.0", updater.WithReleaseDetector(failDetector())))
+	mockConn := client.NewMockConnection()
+	handler := NewRunnerMessageHandler(r, r.podStore, mockConn)
+
+	err := handler.OnUpgradeRunner(&runnerv1.UpgradeRunnerCommand{
+		RequestId: "req-3",
+		Force:     true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error with force=true: %v", err)
+	}
+
+	statuses := getUpgradeStatuses(mockConn)
+	if len(statuses) == 0 {
+		t.Fatal("expected status events")
+	}
+
+	// First status should be "checking"
+	if statuses[0].Phase != "checking" {
+		t.Errorf("expected first phase=checking, got %q", statuses[0].Phase)
+	}
+}
+
+func TestOnUpgradeRunner_UpdateCheckFails(t *testing.T) {
+	r := newTestRunnerForUpgrade(0)
+	r.SetUpdater(updater.New("1.0.0", updater.WithReleaseDetector(failDetector())))
+	mockConn := client.NewMockConnection()
+	handler := NewRunnerMessageHandler(r, r.podStore, mockConn)
+
+	err := handler.OnUpgradeRunner(&runnerv1.UpgradeRunnerCommand{
+		RequestId: "req-4",
+	})
+	if err != nil {
+		t.Fatalf("OnUpgradeRunner should not return error (runs upgrade async): %v", err)
+	}
+
+	statuses := getUpgradeStatuses(mockConn)
+	lastStatus := statuses[len(statuses)-1]
+	if lastStatus.Phase != "failed" {
+		t.Errorf("expected last phase=failed, got %q", lastStatus.Phase)
+	}
+
+	// Draining should be restored after failure
+	if r.IsDraining() {
+		t.Error("draining should be false after failed upgrade")
+	}
+}
+
+func TestOnUpgradeRunner_AlreadyUpToDate(t *testing.T) {
+	r := newTestRunnerForUpgrade(0)
+	r.SetUpdater(updater.New("1.0.0", updater.WithReleaseDetector(noUpdateDetector())))
+	mockConn := client.NewMockConnection()
+	handler := NewRunnerMessageHandler(r, r.podStore, mockConn)
+
+	err := handler.OnUpgradeRunner(&runnerv1.UpgradeRunnerCommand{
+		RequestId: "req-5",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	statuses := getUpgradeStatuses(mockConn)
+	lastStatus := statuses[len(statuses)-1]
+	if lastStatus.Phase != "completed" {
+		t.Errorf("expected last phase=completed, got %q", lastStatus.Phase)
+	}
+	if lastStatus.Progress != 100 {
+		t.Errorf("expected progress=100, got %d", lastStatus.Progress)
+	}
+
+	// Draining should be restored
+	if r.IsDraining() {
+		t.Error("draining should be false after already-up-to-date")
+	}
+}
+
+func TestOnUpgradeRunner_SuccessfulUpdate_NoRestartFunc(t *testing.T) {
+	r := newTestRunnerForUpgrade(0)
+	// Create a fake executable path for Apply
+	tmpDir := t.TempDir()
+	fakeExec := filepath.Join(tmpDir, "runner")
+	os.WriteFile(fakeExec, []byte("old-binary"), 0o755)
+
+	r.SetUpdater(updater.New("1.0.0",
+		updater.WithReleaseDetector(successDetector(t)),
+		updater.WithExecPathFunc(func() (string, error) { return fakeExec, nil }),
+	))
+	r.SetRestartFunc(nil) // no restart function
+	mockConn := client.NewMockConnection()
+	handler := NewRunnerMessageHandler(r, r.podStore, mockConn)
+
+	err := handler.OnUpgradeRunner(&runnerv1.UpgradeRunnerCommand{
+		RequestId: "req-6",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	statuses := getUpgradeStatuses(mockConn)
+	lastStatus := statuses[len(statuses)-1]
+	if lastStatus.Phase != "completed" {
+		t.Errorf("expected last phase=completed, got %q", lastStatus.Phase)
+	}
+	// Should report manual restart needed
+	if lastStatus.Message == "" {
+		t.Error("expected non-empty message about manual restart")
+	}
+
+	// Draining should be restored
+	if r.IsDraining() {
+		t.Error("draining should be false when no restart func and update completed")
+	}
+}
+
+func TestOnUpgradeRunner_SuccessfulUpdate_WithRestartFunc(t *testing.T) {
+	r := newTestRunnerForUpgrade(0)
+	tmpDir := t.TempDir()
+	fakeExec := filepath.Join(tmpDir, "runner")
+	os.WriteFile(fakeExec, []byte("old-binary"), 0o755)
+
+	r.SetUpdater(updater.New("1.0.0",
+		updater.WithReleaseDetector(successDetector(t)),
+		updater.WithExecPathFunc(func() (string, error) { return fakeExec, nil }),
+	))
+
+	restartCalled := false
+	r.SetRestartFunc(func() (int, error) {
+		restartCalled = true
+		return 0, nil // Simulate successful restart
+	})
+
+	mockConn := client.NewMockConnection()
+	handler := NewRunnerMessageHandler(r, r.podStore, mockConn)
+
+	err := handler.OnUpgradeRunner(&runnerv1.UpgradeRunnerCommand{
+		RequestId: "req-7",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !restartCalled {
+		t.Error("expected restart function to be called")
+	}
+
+	// Check phases: checking → downloading → applying → restarting
+	statuses := getUpgradeStatuses(mockConn)
+	phases := make([]string, len(statuses))
+	for i, s := range statuses {
+		phases[i] = s.Phase
+	}
+
+	expectedPhases := []string{"checking", "downloading", "applying", "restarting"}
+	for _, expected := range expectedPhases {
+		found := false
+		for _, p := range phases {
+			if p == expected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected phase %q in status events, got phases: %v", expected, phases)
+		}
+	}
+}
+
+func TestOnUpgradeRunner_RestartFuncFails(t *testing.T) {
+	r := newTestRunnerForUpgrade(0)
+	tmpDir := t.TempDir()
+	fakeExec := filepath.Join(tmpDir, "runner")
+	os.WriteFile(fakeExec, []byte("old-binary"), 0o755)
+
+	r.SetUpdater(updater.New("1.0.0",
+		updater.WithReleaseDetector(successDetector(t)),
+		updater.WithExecPathFunc(func() (string, error) { return fakeExec, nil }),
+	))
+	r.SetRestartFunc(func() (int, error) {
+		return 0, fmt.Errorf("restart permission denied")
+	})
+
+	mockConn := client.NewMockConnection()
+	handler := NewRunnerMessageHandler(r, r.podStore, mockConn)
+
+	_ = handler.OnUpgradeRunner(&runnerv1.UpgradeRunnerCommand{
+		RequestId: "req-8",
+	})
+
+	statuses := getUpgradeStatuses(mockConn)
+	lastStatus := statuses[len(statuses)-1]
+	if lastStatus.Phase != "completed" {
+		t.Errorf("expected phase=completed even when restart fails, got %q", lastStatus.Phase)
+	}
+	if !contains(lastStatus.Message, "restart failed") {
+		t.Errorf("expected message about restart failure, got %q", lastStatus.Message)
+	}
+
+	// Draining should be restored
+	if r.IsDraining() {
+		t.Error("draining should be false after restart failure")
+	}
+}
+
+func TestOnUpgradeRunner_RequestIdPropagated(t *testing.T) {
+	r := newTestRunnerForUpgrade(0)
+	r.SetUpdater(updater.New("1.0.0", updater.WithReleaseDetector(failDetector())))
+	mockConn := client.NewMockConnection()
+	handler := NewRunnerMessageHandler(r, r.podStore, mockConn)
+
+	requestID := "unique-request-id-12345"
+	_ = handler.OnUpgradeRunner(&runnerv1.UpgradeRunnerCommand{
+		RequestId: requestID,
+	})
+
+	statuses := getUpgradeStatuses(mockConn)
+	for _, s := range statuses {
+		if s.RequestId != requestID {
+			t.Errorf("expected request_id=%q in all statuses, got %q", requestID, s.RequestId)
+		}
+	}
+}
+
+func TestOnUpgradeRunner_CurrentVersionReported(t *testing.T) {
+	r := newTestRunnerForUpgrade(0)
+	r.SetUpdater(updater.New("2.5.0", updater.WithReleaseDetector(failDetector())))
+	mockConn := client.NewMockConnection()
+	handler := NewRunnerMessageHandler(r, r.podStore, mockConn)
+
+	_ = handler.OnUpgradeRunner(&runnerv1.UpgradeRunnerCommand{
+		RequestId: "req-ver",
+	})
+
+	statuses := getUpgradeStatuses(mockConn)
+	if len(statuses) == 0 {
+		t.Fatal("expected status events")
+	}
+	for _, s := range statuses {
+		// updater normalizes version to "v2.5.0"
+		if s.CurrentVersion != "v2.5.0" {
+			t.Errorf("expected current_version=v2.5.0, got %q", s.CurrentVersion)
+		}
+	}
+}
+
+func TestOnUpgradeRunner_TargetVersion(t *testing.T) {
+	r := newTestRunnerForUpgrade(0)
+	detector := &testReleaseDetector{
+		detectVersionFn: func(ctx context.Context, version string) (*updater.ReleaseInfo, bool, error) {
+			return nil, false, fmt.Errorf("version %s not found", version)
+		},
+	}
+	r.SetUpdater(updater.New("1.0.0", updater.WithReleaseDetector(detector)))
+	mockConn := client.NewMockConnection()
+	handler := NewRunnerMessageHandler(r, r.podStore, mockConn)
+
+	_ = handler.OnUpgradeRunner(&runnerv1.UpgradeRunnerCommand{
+		RequestId:     "req-target",
+		TargetVersion: "3.0.0",
+	})
+
+	statuses := getUpgradeStatuses(mockConn)
+	lastStatus := statuses[len(statuses)-1]
+	if lastStatus.Phase != "failed" {
+		t.Errorf("expected phase=failed for missing version, got %q", lastStatus.Phase)
+	}
+
+	// Verify target_version is propagated in all status events
+	for _, s := range statuses {
+		if s.TargetVersion != "3.0.0" {
+			t.Errorf("expected target_version=3.0.0 in all statuses, got %q", s.TargetVersion)
+		}
+	}
+}
+
+func TestOnUpgradeRunner_TargetVersionEmpty_WhenLatest(t *testing.T) {
+	r := newTestRunnerForUpgrade(0)
+	r.SetUpdater(updater.New("1.0.0", updater.WithReleaseDetector(noUpdateDetector())))
+	mockConn := client.NewMockConnection()
+	handler := NewRunnerMessageHandler(r, r.podStore, mockConn)
+
+	_ = handler.OnUpgradeRunner(&runnerv1.UpgradeRunnerCommand{
+		RequestId: "req-latest",
+		// TargetVersion intentionally empty — upgrade to latest
+	})
+
+	statuses := getUpgradeStatuses(mockConn)
+	for _, s := range statuses {
+		if s.TargetVersion != "" {
+			t.Errorf("expected empty target_version for latest upgrade, got %q", s.TargetVersion)
+		}
+	}
+}
+
+func TestOnUpgradeRunner_SendError(t *testing.T) {
+	r := newTestRunnerForUpgrade(0)
+	// updater is nil to trigger immediate error path
+	mockConn := client.NewMockConnection()
+	mockConn.SendErr = fmt.Errorf("connection lost")
+	handler := NewRunnerMessageHandler(r, r.podStore, mockConn)
+
+	err := handler.OnUpgradeRunner(&runnerv1.UpgradeRunnerCommand{
+		RequestId: "req-err",
+	})
+	// Should still return the primary error even if send fails
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestOnUpgradeRunner_ConcurrentUpgrade_Discarded(t *testing.T) {
+	r := newTestRunnerForUpgrade(0)
+
+	// Simulate an upgrade already in progress by acquiring the flag
+	if !r.TryStartUpgrade() {
+		t.Fatal("should be able to start upgrade")
+	}
+
+	r.SetUpdater(updater.New("1.0.0", updater.WithReleaseDetector(failDetector())))
+	mockConn := client.NewMockConnection()
+	handler := NewRunnerMessageHandler(r, r.podStore, mockConn)
+
+	// Second upgrade while first is in progress should be silently discarded
+	err := handler.OnUpgradeRunner(&runnerv1.UpgradeRunnerCommand{
+		RequestId: "req-second",
+	})
+	if err != nil {
+		t.Fatalf("concurrent upgrade should be silently discarded, got error: %v", err)
+	}
+
+	// No status events should be produced for the discarded command
+	statuses := getUpgradeStatuses(mockConn)
+	if len(statuses) != 0 {
+		t.Errorf("expected no status events for discarded upgrade, got %d", len(statuses))
+	}
+
+	// Clean up
+	r.FinishUpgrade()
+}
+
+func TestOnUpgradeRunner_ContextCancelled(t *testing.T) {
+	r := newTestRunnerForUpgrade(0)
+
+	// Set a cancelled context to simulate runner shutting down
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+	r.runCtx = ctx
+
+	r.SetUpdater(updater.New("1.0.0", updater.WithReleaseDetector(failDetector())))
+	mockConn := client.NewMockConnection()
+	handler := NewRunnerMessageHandler(r, r.podStore, mockConn)
+
+	err := handler.OnUpgradeRunner(&runnerv1.UpgradeRunnerCommand{
+		RequestId: "req-ctx",
+	})
+	if err != nil {
+		t.Fatalf("should not return error (upgrade runs async): %v", err)
+	}
+
+	statuses := getUpgradeStatuses(mockConn)
+	lastStatus := statuses[len(statuses)-1]
+	if lastStatus.Phase != "failed" {
+		t.Errorf("expected phase=failed when context cancelled, got %q", lastStatus.Phase)
+	}
+
+	// Draining should be restored
+	if r.IsDraining() {
+		t.Error("draining should be false after context cancellation")
+	}
+
+	// Upgrade flag should be cleared
+	if !r.TryStartUpgrade() {
+		t.Error("upgrade flag should be cleared after context cancellation")
+	}
+}

--- a/runner/internal/runner/runner.go
+++ b/runner/internal/runner/runner.go
@@ -15,6 +15,7 @@ import (
 	"github.com/anthropics/agentsmesh/runner/internal/logger"
 	"github.com/anthropics/agentsmesh/runner/internal/mcp"
 	"github.com/anthropics/agentsmesh/runner/internal/monitor"
+	"github.com/anthropics/agentsmesh/runner/internal/updater"
 	"github.com/anthropics/agentsmesh/runner/internal/workspace"
 )
 
@@ -44,6 +45,10 @@ type Runner struct {
 	// Update management
 	draining   bool
 	drainingMu sync.RWMutex
+	upgrading  bool
+	upgradeMu  sync.Mutex
+	updater    *updater.Updater
+	restartFn  func() (int, error)
 
 	// Run lifecycle context (set by Run, used by message handlers)
 	runCtx context.Context
@@ -238,4 +243,47 @@ func (r *Runner) NewPodController(pod *Pod) *PodControllerImpl {
 // GetConnection returns the gRPC connection.
 func (r *Runner) GetConnection() client.Connection {
 	return r.conn
+}
+
+// Upgrade state management
+
+// TryStartUpgrade atomically checks and sets the upgrading flag.
+// Returns true if upgrade can proceed, false if another upgrade is in progress.
+func (r *Runner) TryStartUpgrade() bool {
+	r.upgradeMu.Lock()
+	defer r.upgradeMu.Unlock()
+	if r.upgrading {
+		return false
+	}
+	r.upgrading = true
+	return true
+}
+
+// FinishUpgrade clears the upgrading flag.
+func (r *Runner) FinishUpgrade() {
+	r.upgradeMu.Lock()
+	defer r.upgradeMu.Unlock()
+	r.upgrading = false
+}
+
+// Updater management methods
+
+// SetUpdater sets the updater instance for remote upgrade support.
+func (r *Runner) SetUpdater(u *updater.Updater) {
+	r.updater = u
+}
+
+// GetUpdater returns the updater instance.
+func (r *Runner) GetUpdater() *updater.Updater {
+	return r.updater
+}
+
+// SetRestartFunc sets the restart function for post-upgrade restart.
+func (r *Runner) SetRestartFunc(fn func() (int, error)) {
+	r.restartFn = fn
+}
+
+// GetRestartFunc returns the restart function.
+func (r *Runner) GetRestartFunc() func() (int, error) {
+	return r.restartFn
 }

--- a/web/src/app/(dashboard)/[org]/runners/[id]/components/RunnerOverviewTab.tsx
+++ b/web/src/app/(dashboard)/[org]/runners/[id]/components/RunnerOverviewTab.tsx
@@ -1,10 +1,13 @@
 "use client";
 
+import { useState } from "react";
 import { format, formatDistanceToNow } from "date-fns";
-import { Cpu, HardDrive, Terminal, Radio } from "lucide-react";
+import { Cpu, HardDrive, Terminal, Radio, ArrowUpCircle } from "lucide-react";
 import type { RunnerData, RelayConnectionInfo } from "@/lib/api";
+import { runnerApi } from "@/lib/api";
 import { isVersionOutdated } from "@/lib/utils/version";
 import { useTranslations } from "next-intl";
+import { toast } from "sonner";
 
 interface RunnerOverviewTabProps {
   runner: RunnerData;
@@ -17,6 +20,25 @@ interface RunnerOverviewTabProps {
  */
 export function RunnerOverviewTab({ runner, relayConnections, latestRunnerVersion }: RunnerOverviewTabProps) {
   const t = useTranslations();
+  const [upgrading, setUpgrading] = useState(false);
+
+  const hasUpdate = !!latestRunnerVersion && isVersionOutdated(runner.runner_version, latestRunnerVersion);
+  const canUpgrade = hasUpdate
+    && runner.status === "online"
+    && runner.current_pods === 0;
+
+  const handleUpgrade = async () => {
+    if (!confirm(t("runners.detail.upgradeConfirm"))) return;
+    setUpgrading(true);
+    try {
+      await runnerApi.upgrade(runner.id);
+      toast.success(t("runners.detail.upgradeSent"));
+    } catch {
+      toast.error(t("runners.detail.upgradeFailed"));
+    } finally {
+      setUpgrading(false);
+    }
+  };
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -51,10 +73,27 @@ export function RunnerOverviewTab({ runner, relayConnections, latestRunnerVersio
             <dd className="text-sm text-foreground">
               <span className="flex items-center gap-2">
                 {runner.runner_version || "-"}
-                {isVersionOutdated(runner.runner_version, latestRunnerVersion) && (
-                  <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
-                    {t("runners.detail.upgradeAvailable", { version: latestRunnerVersion! })}
-                  </span>
+                {hasUpdate && (
+                  <>
+                    <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+                      {t("runners.detail.upgradeAvailable", { version: latestRunnerVersion })}
+                    </span>
+                    <button
+                      onClick={handleUpgrade}
+                      disabled={!canUpgrade || upgrading}
+                      title={
+                        runner.status !== "online"
+                          ? t("runners.detail.upgradeOffline")
+                          : runner.current_pods > 0
+                            ? t("runners.detail.upgradeHasPods")
+                            : t("runners.detail.upgradeTooltip")
+                      }
+                      className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                    >
+                      <ArrowUpCircle className="w-3.5 h-3.5" />
+                      {upgrading ? t("runners.detail.upgrading") : t("runners.detail.upgrade")}
+                    </button>
+                  </>
                 )}
               </span>
             </dd>

--- a/web/src/lib/api/runner.ts
+++ b/web/src/lib/api/runner.ts
@@ -123,6 +123,13 @@ export const runnerApi = {
       method: "POST",
       body: { pod_keys: podKeys },
     }),
+
+  // Trigger remote upgrade on a runner
+  upgrade: (id: number, data?: { target_version?: string; force?: boolean }) =>
+    request<{ request_id: string; message: string }>(`${orgPath("/runners")}/${id}/upgrade`, {
+      method: "POST",
+      body: data || {},
+    }),
 };
 
 // Pod data returned from Runner pods endpoint

--- a/web/src/messages/de/runners.json
+++ b/web/src/messages/de/runners.json
@@ -186,7 +186,15 @@
       "resumeDialogTitle": "Resume Pod",
       "resumeDialogDescription": "You are about to resume from the sandbox of \"{podKey}\".",
       "resumeDialogInfo": "This will create a new Pod using the existing workspace, allowing the AI agent to continue from where it left off.",
-      "confirmResumeBtn": "Resume"
+      "confirmResumeBtn": "Resume",
+      "upgrade": "Aktualisieren",
+      "upgrading": "Aktualisierung...",
+      "upgradeConfirm": "Möchten Sie diesen Runner wirklich auf die neueste Version aktualisieren? Der Runner wird nach dem Upgrade neu gestartet.",
+      "upgradeSent": "Upgrade-Befehl gesendet. Der Runner wird automatisch herunterladen und neu starten.",
+      "upgradeFailed": "Upgrade-Befehl konnte nicht gesendet werden. Bitte versuchen Sie es erneut.",
+      "upgradeOffline": "Runner ist offline, Upgrade nicht möglich",
+      "upgradeHasPods": "Runner hat aktive Pods, Upgrade nicht möglich",
+      "upgradeTooltip": "Runner auf die neueste Version aktualisieren"
     },
     "authorize": {
       "title": "Authorize Runner",

--- a/web/src/messages/en/runners.json
+++ b/web/src/messages/en/runners.json
@@ -154,7 +154,15 @@
       "resumeDialogTitle": "Resume Pod",
       "resumeDialogDescription": "You are about to resume from the sandbox of \"{podKey}\".",
       "resumeDialogInfo": "This will create a new Pod using the existing workspace, allowing the AI agent to continue from where it left off.",
-      "confirmResumeBtn": "Resume"
+      "confirmResumeBtn": "Resume",
+      "upgrade": "Upgrade",
+      "upgrading": "Upgrading...",
+      "upgradeConfirm": "Are you sure you want to upgrade this runner to the latest version? The runner will restart after upgrading.",
+      "upgradeSent": "Upgrade command sent. The runner will download and restart automatically.",
+      "upgradeFailed": "Failed to send upgrade command. Please try again.",
+      "upgradeOffline": "Runner is offline, cannot upgrade",
+      "upgradeHasPods": "Runner has active pods, cannot upgrade",
+      "upgradeTooltip": "Upgrade runner to the latest version"
     },
     "authorize": {
       "title": "Authorize Runner",

--- a/web/src/messages/es/runners.json
+++ b/web/src/messages/es/runners.json
@@ -186,7 +186,15 @@
       "resumeDialogTitle": "Resume Pod",
       "resumeDialogDescription": "You are about to resume from the sandbox of \"{podKey}\".",
       "resumeDialogInfo": "This will create a new Pod using the existing workspace, allowing the AI agent to continue from where it left off.",
-      "confirmResumeBtn": "Resume"
+      "confirmResumeBtn": "Resume",
+      "upgrade": "Actualizar",
+      "upgrading": "Actualizando...",
+      "upgradeConfirm": "¿Está seguro de que desea actualizar este runner a la última versión? El runner se reiniciará después de la actualización.",
+      "upgradeSent": "Comando de actualización enviado. El runner descargará y se reiniciará automáticamente.",
+      "upgradeFailed": "Error al enviar el comando de actualización. Inténtelo de nuevo.",
+      "upgradeOffline": "Runner está fuera de línea, no se puede actualizar",
+      "upgradeHasPods": "Runner tiene pods activos, no se puede actualizar",
+      "upgradeTooltip": "Actualizar runner a la última versión"
     },
     "authorize": {
       "title": "Authorize Runner",

--- a/web/src/messages/fr/runners.json
+++ b/web/src/messages/fr/runners.json
@@ -186,7 +186,15 @@
       "resumeDialogTitle": "Resume Pod",
       "resumeDialogDescription": "You are about to resume from the sandbox of \"{podKey}\".",
       "resumeDialogInfo": "This will create a new Pod using the existing workspace, allowing the AI agent to continue from where it left off.",
-      "confirmResumeBtn": "Resume"
+      "confirmResumeBtn": "Resume",
+      "upgrade": "Mettre à jour",
+      "upgrading": "Mise à jour...",
+      "upgradeConfirm": "Êtes-vous sûr de vouloir mettre à jour ce runner vers la dernière version ? Le runner redémarrera après la mise à jour.",
+      "upgradeSent": "Commande de mise à jour envoyée. Le runner téléchargera et redémarrera automatiquement.",
+      "upgradeFailed": "Échec de l'envoi de la commande de mise à jour. Veuillez réessayer.",
+      "upgradeOffline": "Runner hors ligne, mise à jour impossible",
+      "upgradeHasPods": "Runner a des pods actifs, mise à jour impossible",
+      "upgradeTooltip": "Mettre à jour le runner vers la dernière version"
     },
     "authorize": {
       "title": "Authorize Runner",

--- a/web/src/messages/ja/runners.json
+++ b/web/src/messages/ja/runners.json
@@ -186,7 +186,15 @@
       "resumeDialogTitle": "Resume Pod",
       "resumeDialogDescription": "You are about to resume from the sandbox of \"{podKey}\".",
       "resumeDialogInfo": "This will create a new Pod using the existing workspace, allowing the AI agent to continue from where it left off.",
-      "confirmResumeBtn": "Resume"
+      "confirmResumeBtn": "Resume",
+      "upgrade": "アップグレード",
+      "upgrading": "アップグレード中...",
+      "upgradeConfirm": "このランナーを最新バージョンにアップグレードしますか？アップグレード後にランナーは再起動します。",
+      "upgradeSent": "アップグレードコマンドを送信しました。ランナーは自動的にダウンロードして再起動します。",
+      "upgradeFailed": "アップグレードコマンドの送信に失敗しました。再試行してください。",
+      "upgradeOffline": "ランナーがオフラインのため、アップグレードできません",
+      "upgradeHasPods": "ランナーにアクティブなPodがあるため、アップグレードできません",
+      "upgradeTooltip": "ランナーを最新バージョンにアップグレード"
     },
     "authorize": {
       "title": "Authorize Runner",

--- a/web/src/messages/ko/runners.json
+++ b/web/src/messages/ko/runners.json
@@ -186,7 +186,15 @@
       "resumeDialogTitle": "Resume Pod",
       "resumeDialogDescription": "You are about to resume from the sandbox of \"{podKey}\".",
       "resumeDialogInfo": "This will create a new Pod using the existing workspace, allowing the AI agent to continue from where it left off.",
-      "confirmResumeBtn": "Resume"
+      "confirmResumeBtn": "Resume",
+      "upgrade": "업그레이드",
+      "upgrading": "업그레이드 중...",
+      "upgradeConfirm": "이 러너를 최신 버전으로 업그레이드하시겠습니까? 업그레이드 후 러너가 재시작됩니다.",
+      "upgradeSent": "업그레이드 명령이 전송되었습니다. 러너가 자동으로 다운로드하고 재시작합니다.",
+      "upgradeFailed": "업그레이드 명령 전송에 실패했습니다. 다시 시도해 주세요.",
+      "upgradeOffline": "러너가 오프라인이므로 업그레이드할 수 없습니다",
+      "upgradeHasPods": "러너에 활성 Pod가 있어 업그레이드할 수 없습니다",
+      "upgradeTooltip": "러너를 최신 버전으로 업그레이드"
     },
     "authorize": {
       "title": "Authorize Runner",

--- a/web/src/messages/pt/runners.json
+++ b/web/src/messages/pt/runners.json
@@ -186,7 +186,15 @@
       "resumeDialogTitle": "Resume Pod",
       "resumeDialogDescription": "You are about to resume from the sandbox of \"{podKey}\".",
       "resumeDialogInfo": "This will create a new Pod using the existing workspace, allowing the AI agent to continue from where it left off.",
-      "confirmResumeBtn": "Resume"
+      "confirmResumeBtn": "Resume",
+      "upgrade": "Atualizar",
+      "upgrading": "Atualizando...",
+      "upgradeConfirm": "Tem certeza de que deseja atualizar este runner para a versão mais recente? O runner será reiniciado após a atualização.",
+      "upgradeSent": "Comando de atualização enviado. O runner baixará e reiniciará automaticamente.",
+      "upgradeFailed": "Falha ao enviar o comando de atualização. Tente novamente.",
+      "upgradeOffline": "Runner está offline, não é possível atualizar",
+      "upgradeHasPods": "Runner tem pods ativos, não é possível atualizar",
+      "upgradeTooltip": "Atualizar runner para a versão mais recente"
     },
     "authorize": {
       "title": "Authorize Runner",

--- a/web/src/messages/zh/runners.json
+++ b/web/src/messages/zh/runners.json
@@ -154,7 +154,15 @@
       "resumeDialogTitle": "恢复 Pod",
       "resumeDialogDescription": "即将从「{podKey}」的 Sandbox 恢复。",
       "resumeDialogInfo": "这将使用现有工作区创建新 Pod，让 AI 智能体可以从上次中断的地方继续工作。",
-      "confirmResumeBtn": "确认恢复"
+      "confirmResumeBtn": "确认恢复",
+      "upgrade": "升级",
+      "upgrading": "升级中...",
+      "upgradeConfirm": "确定要将此 Runner 升级到最新版本吗？升级完成后 Runner 将自动重启。",
+      "upgradeSent": "升级命令已发送，Runner 将自动下载并重启。",
+      "upgradeFailed": "升级命令发送失败，请重试。",
+      "upgradeOffline": "Runner 离线，无法升级",
+      "upgradeHasPods": "Runner 存在活跃 Pod，无法升级",
+      "upgradeTooltip": "将 Runner 升级到最新版本"
     },
     "authorize": {
       "title": "授权 Runner",


### PR DESCRIPTION
## Summary

- Add remote runner upgrade capability from the Web UI dashboard
- Full flow: REST endpoint → gRPC command → runner downloads binary → atomic replace → service restart
- Proto messages: `UpgradeRunnerCommand` / `UpgradeStatusEvent` with phase tracking
- Safety: concurrent upgrade mutex, context cancellation check, panic recovery (safego), centralized defer cleanup, cross-org 404 hardening
- Frontend: upgrade button on runner detail page with i18n (8 languages)

## Changes

**Proto** (2 new messages)
- `UpgradeRunnerCommand`: request_id, target_version, force
- `UpgradeStatusEvent`: phase (checking/downloading/applying/restarting/completed/failed), progress, current/target version

**Runner** (upgrade handler + tests)
- `message_handler_upgrade.go`: OnUpgradeRunner + runUpgrade with draining mode
- `message_handler_upgrade_test.go`: 16 test cases covering all paths
- `MessageHandlerContext` interface: upgrade lifecycle methods (DIP compliance)
- gRPC dispatch via `safego.Go` for panic recovery

**Backend** (REST + gRPC adapter)
- `POST /api/v1/organizations/:slug/runners/:id/upgrade` → 202 Accepted
- `UpgradeCommandSender` ISP interface
- Cross-org enumeration prevention (unified 404 response)
- Audit logging with structured slog

**Web** (upgrade button)
- Version outdated badge + upgrade button on RunnerOverviewTab
- Disabled when offline or pods active
- i18n translations for 8 languages

## Test plan

- [x] Runner: `go test ./...` — all 24 packages pass
- [x] Backend: `go build ./...` — compiles clean
- [ ] E2E: trigger upgrade from Web UI → verify runner downloads, replaces, restarts