### PR TITLE
fix(web): prevent IME composition Enter from triggering send in channel

### DIFF
--- a/web/src/components/channel/CreateChannelDialog.tsx
+++ b/web/src/components/channel/CreateChannelDialog.tsx
@@ -90,6 +90,7 @@ export function CreateChannelDialog({
               onChange={(e) => setName(e.target.value)}
               placeholder={t("channels.createDialog.namePlaceholder")}
               onKeyDown={(e) => {
+                if (e.nativeEvent.isComposing) return;
                 if (e.key === "Enter" && !saving) handleSubmit();
               }}
               autoFocus
@@ -107,6 +108,7 @@ export function CreateChannelDialog({
               onChange={(e) => setDescription(e.target.value)}
               placeholder={t("channels.createDialog.descriptionPlaceholder")}
               onKeyDown={(e) => {
+                if (e.nativeEvent.isComposing) return;
                 if (e.key === "Enter" && !saving) handleSubmit();
               }}
             />

--- a/web/src/components/channel/MessageBubble.tsx
+++ b/web/src/components/channel/MessageBubble.tsx
@@ -84,6 +84,7 @@ export function MessageBubble({
 
   const handleEditKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
+      if (e.nativeEvent.isComposing) return;
       if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
         handleEditSubmit();

--- a/web/src/components/channel/MessageInput.tsx
+++ b/web/src/components/channel/MessageInput.tsx
@@ -161,6 +161,9 @@ export function MessageInput({
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    // Ignore key events during IME composition (e.g. Chinese Pinyin input)
+    if (e.nativeEvent.isComposing) return;
+
     if (mentionVisible && filteredCandidates.length > 0) {
       if (e.key === "ArrowDown") {
         e.preventDefault();


### PR DESCRIPTION
When typing Chinese/Japanese/Korean with an IME, pressing Enter to confirm character selection was incorrectly triggering message send. Added isComposing guard to all channel keydown handlers.

## Summary

- What changed?
- Why was this change needed?

## Changes

- 

## Validation

- [ ] Backend tests (`cd backend && go test ./...`)
- [ ] Web checks (`cd web && pnpm run lint && pnpm run type-check && pnpm run test:coverage`)
- [ ] Runner checks (`cd runner && go test ./...`)
- [ ] Manual validation performed (if applicable)

## Documentation

- [ ] Docs updated (README/docs/inline comments)
- [ ] No docs changes needed

## Risk and Rollback

- Risk level: Low / Medium / High
- Rollback plan:
