### PR TITLE
fix(sso): fix CI — remove dead cross-protocol validation, apply De Morgan's law

### DIFF
--- a/backend/internal/service/sso/config_update.go
+++ b/backend/internal/service/sso/config_update.go
@@ -20,12 +20,10 @@ func (s *Service) UpdateConfig(ctx context.Context, id int64, req *UpdateConfigR
 		return nil, err
 	}
 
-	// Strip cross-protocol empty-string fields before validation,
-	// then reject any non-empty cross-protocol field updates.
+	// Strip all non-matching protocol fields unconditionally.
+	// Frontends send every field (including defaults like ldap_port=389),
+	// so we nil them before any validation to avoid false cross-protocol errors.
 	stripCrossProtocolEmptyFields(existing.Protocol, req)
-	if err := validateUpdateFieldsMatchProtocol(existing.Protocol, req); err != nil {
-		return nil, err
-	}
 
 	// Reject explicitly clearing required fields (pointer non-nil but value empty).
 	if err := validateRequiredFieldsNotCleared(existing, req); err != nil {
@@ -204,39 +202,6 @@ func stripCrossProtocolEmptyFields(protocol sso.Protocol, req *UpdateConfigReque
 	}
 }
 
-// strPtrSet returns true if the *string pointer is non-nil and points to a non-empty string.
-// This correctly handles frontends that send empty strings for irrelevant cross-protocol fields.
-func strPtrSet(p *string) bool { return p != nil && *p != "" }
-
-// validateUpdateFieldsMatchProtocol rejects updates that set fields belonging
-// to a different protocol than the config's actual protocol.
-// Empty-string values are treated as "not set" so frontends can safely send
-// all fields without triggering cross-protocol validation errors.
-func validateUpdateFieldsMatchProtocol(protocol sso.Protocol, req *UpdateConfigRequest) error {
-	hasOIDC := strPtrSet(req.OIDCIssuerURL) || strPtrSet(req.OIDCClientID) || strPtrSet(req.OIDCClientSecret) || strPtrSet(req.OIDCScopes)
-	hasSAML := strPtrSet(req.SAMLIDPMetadataURL) || strPtrSet(req.SAMLIDPMetadataXML) || strPtrSet(req.SAMLIDPSSOURL) ||
-		strPtrSet(req.SAMLIDPCert) || strPtrSet(req.SAMLSPEntityID) || strPtrSet(req.SAMLNameIDFormat)
-	hasLDAP := strPtrSet(req.LDAPHost) || req.LDAPPort != nil || req.LDAPUseTLS != nil || strPtrSet(req.LDAPBindDN) ||
-		strPtrSet(req.LDAPBindPassword) || strPtrSet(req.LDAPBaseDN) || strPtrSet(req.LDAPUserFilter) ||
-		strPtrSet(req.LDAPEmailAttr) || strPtrSet(req.LDAPNameAttr) || strPtrSet(req.LDAPUsernameAttr)
-
-	switch protocol {
-	case sso.ProtocolOIDC:
-		if hasSAML || hasLDAP {
-			return NewValidationError("cannot set SAML/LDAP fields on an OIDC config")
-		}
-	case sso.ProtocolSAML:
-		if hasOIDC || hasLDAP {
-			return NewValidationError("cannot set OIDC/LDAP fields on a SAML config")
-		}
-	case sso.ProtocolLDAP:
-		if hasOIDC || hasSAML {
-			return NewValidationError("cannot set OIDC/SAML fields on an LDAP config")
-		}
-	}
-	return nil
-}
-
 // validateRequiredFieldsNotCleared rejects updates that clear protocol-specific
 // required fields (pointer non-nil but value empty).
 func validateRequiredFieldsNotCleared(existing *sso.Config, req *UpdateConfigRequest) error {
@@ -269,7 +234,7 @@ func validateRequiredFieldsNotCleared(existing *sso.Config, req *UpdateConfigReq
 		} else if req.SAMLIDPCert != nil && *req.SAMLIDPCert != "" {
 			hasCert = true
 		}
-		if metadataURL == "" && metadataXML == "" && !(ssoURL != "" && hasCert) {
+		if metadataURL == "" && metadataXML == "" && (ssoURL == "" || !hasCert) {
 			return NewValidationError("SAML requires at least one IdP source (metadata URL, metadata XML, or SSO URL with certificate)")
 		}
 	case sso.ProtocolLDAP:

--- a/backend/internal/service/sso/config_update_extra_test.go
+++ b/backend/internal/service/sso/config_update_extra_test.go
@@ -202,10 +202,10 @@ func TestValidateRequiredFieldsNotCleared_SAML_MetadataXMLKeepsValid(t *testing.
 	assert.NoError(t, err)
 }
 
-// --- validateUpdateFieldsMatchProtocol: LDAP with LDAP fields ---
+// --- stripCrossProtocolEmptyFields: LDAP preserves own fields ---
 
-func TestValidateUpdateFieldsMatchProtocol_LDAPWithLDAP(t *testing.T) {
-	err := validateUpdateFieldsMatchProtocol(sso.ProtocolLDAP, &UpdateConfigRequest{
+func TestStripCrossProtocol_LDAPPreservesAllLDAPFields(t *testing.T) {
+	req := &UpdateConfigRequest{
 		LDAPHost:         ptr("ldap.test.com"),
 		LDAPPort:         ptr(636),
 		LDAPUseTLS:       ptr(true),
@@ -216,22 +216,38 @@ func TestValidateUpdateFieldsMatchProtocol_LDAPWithLDAP(t *testing.T) {
 		LDAPEmailAttr:    ptr("mail"),
 		LDAPNameAttr:     ptr("cn"),
 		LDAPUsernameAttr: ptr("uid"),
-	})
-	assert.NoError(t, err)
+	}
+	stripCrossProtocolEmptyFields(sso.ProtocolLDAP, req)
+	assert.NotNil(t, req.LDAPHost)
+	assert.NotNil(t, req.LDAPPort)
+	assert.NotNil(t, req.LDAPUseTLS)
+	assert.NotNil(t, req.LDAPBindDN)
+	assert.NotNil(t, req.LDAPBindPassword)
+	assert.NotNil(t, req.LDAPBaseDN)
+	assert.NotNil(t, req.LDAPUserFilter)
+	assert.NotNil(t, req.LDAPEmailAttr)
+	assert.NotNil(t, req.LDAPNameAttr)
+	assert.NotNil(t, req.LDAPUsernameAttr)
 }
 
-// --- validateUpdateFieldsMatchProtocol: SAML with SAML fields ---
+// --- stripCrossProtocolEmptyFields: SAML preserves own fields ---
 
-func TestValidateUpdateFieldsMatchProtocol_SAMLWithSAML(t *testing.T) {
-	err := validateUpdateFieldsMatchProtocol(sso.ProtocolSAML, &UpdateConfigRequest{
+func TestStripCrossProtocol_SAMLPreservesAllSAMLFields(t *testing.T) {
+	req := &UpdateConfigRequest{
 		SAMLIDPMetadataURL: ptr("https://metadata"),
 		SAMLIDPMetadataXML: ptr("<xml/>"),
 		SAMLIDPSSOURL:      ptr("https://sso"),
 		SAMLIDPCert:        ptr("cert"),
 		SAMLSPEntityID:     ptr("entity"),
 		SAMLNameIDFormat:   ptr("format"),
-	})
-	assert.NoError(t, err)
+	}
+	stripCrossProtocolEmptyFields(sso.ProtocolSAML, req)
+	assert.NotNil(t, req.SAMLIDPMetadataURL)
+	assert.NotNil(t, req.SAMLIDPMetadataXML)
+	assert.NotNil(t, req.SAMLIDPSSOURL)
+	assert.NotNil(t, req.SAMLIDPCert)
+	assert.NotNil(t, req.SAMLSPEntityID)
+	assert.NotNil(t, req.SAMLNameIDFormat)
 }
 
 // --- ptrStringOr ---

--- a/backend/internal/service/sso/config_update_test.go
+++ b/backend/internal/service/sso/config_update_test.go
@@ -99,42 +99,38 @@ func TestUpdateConfig_NotFound(t *testing.T) {
 	assert.ErrorIs(t, err, ErrConfigNotFound)
 }
 
-func TestUpdateConfig_CrossProtocolRejection(t *testing.T) {
+func TestUpdateConfig_CrossProtocolFieldsSilentlyStripped(t *testing.T) {
+	// Cross-protocol fields are unconditionally stripped by stripCrossProtocolEmptyFields,
+	// so sending them should succeed (fields ignored, not rejected).
 	tests := []struct {
-		name    string
-		seed    func(*mockRepository) *sso.Config
-		req     *UpdateConfigRequest
-		wantErr string
+		name string
+		seed func(*mockRepository) *sso.Config
+		req  *UpdateConfigRequest
 	}{
 		{
 			name: "SAML fields on OIDC config",
 			seed: seedOIDCConfig,
 			req:  &UpdateConfigRequest{SAMLIDPMetadataURL: ptr("https://idp.com/metadata")},
-			wantErr: "cannot set SAML/LDAP fields on an OIDC config",
 		},
 		{
 			name: "LDAP fields on OIDC config",
 			seed: seedOIDCConfig,
 			req:  &UpdateConfigRequest{LDAPHost: ptr("ldap.company.com")},
-			wantErr: "cannot set SAML/LDAP fields on an OIDC config",
 		},
 		{
 			name: "OIDC fields on SAML config",
 			seed: seedSAMLConfig,
 			req:  &UpdateConfigRequest{OIDCIssuerURL: ptr("https://issuer.com")},
-			wantErr: "cannot set OIDC/LDAP fields on a SAML config",
 		},
 		{
 			name: "OIDC fields on LDAP config",
 			seed: seedLDAPConfig,
 			req:  &UpdateConfigRequest{OIDCClientID: ptr("client-id")},
-			wantErr: "cannot set OIDC/SAML fields on an LDAP config",
 		},
 		{
 			name: "SAML fields on LDAP config",
 			seed: seedLDAPConfig,
 			req:  &UpdateConfigRequest{SAMLIDPSSOURL: ptr("https://sso.com")},
-			wantErr: "cannot set OIDC/SAML fields on an LDAP config",
 		},
 	}
 
@@ -144,9 +140,9 @@ func TestUpdateConfig_CrossProtocolRejection(t *testing.T) {
 			svc := newTestService(repo)
 			existing := tt.seed(repo)
 
-			_, err := svc.UpdateConfig(context.Background(), existing.ID, tt.req)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tt.wantErr)
+			cfg, err := svc.UpdateConfig(context.Background(), existing.ID, tt.req)
+			require.NoError(t, err, "cross-protocol fields should be silently stripped, not rejected")
+			assert.Equal(t, existing.ID, cfg.ID)
 		})
 	}
 }
@@ -315,20 +311,26 @@ func TestBuildUpdateMap_AllCommonFields(t *testing.T) {
 	assert.Len(t, updates, 3)
 }
 
-func TestValidateUpdateFieldsMatchProtocol_AllowSameProtocol(t *testing.T) {
-	// OIDC fields on OIDC config should pass
-	err := validateUpdateFieldsMatchProtocol(sso.ProtocolOIDC, &UpdateConfigRequest{
+func TestStripCrossProtocolEmptyFields_PreservesSameProtocol(t *testing.T) {
+	// OIDC fields on OIDC config should be preserved
+	req := &UpdateConfigRequest{
 		OIDCIssuerURL: ptr("https://new-issuer.com"),
 		OIDCClientID:  ptr("new-client"),
 		OIDCScopes:    ptr("openid email"),
-	})
-	assert.NoError(t, err)
+	}
+	stripCrossProtocolEmptyFields(sso.ProtocolOIDC, req)
+	assert.NotNil(t, req.OIDCIssuerURL)
+	assert.NotNil(t, req.OIDCClientID)
+	assert.NotNil(t, req.OIDCScopes)
 
-	// LDAP fields on LDAP config should pass
-	err = validateUpdateFieldsMatchProtocol(sso.ProtocolLDAP, &UpdateConfigRequest{
+	// LDAP fields on LDAP config should be preserved
+	req2 := &UpdateConfigRequest{
 		LDAPHost:   ptr("new-host"),
 		LDAPPort:   ptr(636),
 		LDAPUseTLS: ptr(true),
-	})
-	assert.NoError(t, err)
+	}
+	stripCrossProtocolEmptyFields(sso.ProtocolLDAP, req2)
+	assert.NotNil(t, req2.LDAPHost)
+	assert.NotNil(t, req2.LDAPPort)
+	assert.NotNil(t, req2.LDAPUseTLS)
 }


### PR DESCRIPTION
## Summary

Fix CI failures introduced by #85 (SSO integration).

- **Backend Lint (staticcheck QF1001)**: Apply De Morgan's law to `!(ssoURL != "" && hasCert)` → `(ssoURL == "" || !hasCert)`
- **Backend Tests**: `TestUpdateConfig_CrossProtocolRejection` expected errors for cross-protocol fields, but `stripCrossProtocolEmptyFields` now unconditionally nils them before validation reaches `validateUpdateFieldsMatchProtocol` — making that function dead code
- Remove `validateUpdateFieldsMatchProtocol` and `strPtrSet` (dead code)
- Update tests to verify cross-protocol fields are silently stripped, not rejected

## Test plan
- [x] `go test ./internal/service/sso/...` — all pass locally