### PR TITLE
fix(runner): redesign connection lifecycle and pod state management

### DIFF
--- a/backend/cmd/server/eventbus_pod.go
+++ b/backend/cmd/server/eventbus_pod.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 
 	notifDomain "github.com/anthropics/agentsmesh/backend/internal/domain/notification"
+	"github.com/anthropics/agentsmesh/backend/internal/domain/agentpod"
 	"github.com/anthropics/agentsmesh/backend/internal/infra/eventbus"
 	notifService "github.com/anthropics/agentsmesh/backend/internal/service/notification"
 	"github.com/anthropics/agentsmesh/backend/internal/service/runner"
@@ -35,9 +36,9 @@ func setupPodEventCallbacks(db *gorm.DB, podCoordinator *runner.PodCoordinator, 
 		var eventType eventbus.EventType
 		if agentStatus != "" {
 			eventType = eventbus.EventPodAgentChanged
-		} else if status == "completed" || status == "terminated" {
+		} else if status == agentpod.StatusCompleted || status == agentpod.StatusTerminated {
 			eventType = eventbus.EventPodTerminated
-		} else if pod.Status == "initializing" && status == "running" {
+		} else if pod.Status == agentpod.StatusInitializing && status == agentpod.StatusRunning {
 			// Pod transitioned from initializing to running - this is a newly created pod starting
 			eventType = eventbus.EventPodCreated
 		} else {
@@ -68,7 +69,7 @@ func setupPodEventCallbacks(db *gorm.DB, podCoordinator *runner.PodCoordinator, 
 		}
 
 		// Route task:completed through NotificationDispatcher (preference-aware)
-		if status == "completed" || status == "terminated" || status == "failed" {
+		if status == agentpod.StatusCompleted || status == agentpod.StatusTerminated || status == agentpod.StatusError {
 			if err := notifDispatcher.Dispatch(context.Background(), &notifDomain.NotificationRequest{
 				OrganizationID:    pod.OrganizationID,
 				Source:            notifDomain.SourceTaskCompleted,

--- a/backend/cmd/server/eventbus_runner.go
+++ b/backend/cmd/server/eventbus_runner.go
@@ -21,8 +21,15 @@ func setupRunnerEventCallbacks(db *gorm.DB, runnerConnMgr *runner.RunnerConnecti
 			originalHeartbeatCallback(runnerID, data)
 		}
 
-		// Publish runner online event (heartbeat indicates runner is online)
-		// Only publish if this is likely a new connection or status change
+		// Short-circuit: if this connection already sent the online event, skip DB query.
+		// Each new connection resets the flag, so the first heartbeat after (re)connect
+		// will still publish the event.
+		conn := runnerConnMgr.GetConnection(runnerID)
+		if conn == nil || conn.IsOnlineEventSent() {
+			return
+		}
+
+		// First heartbeat on this connection: query DB for org_id/node_id
 		var r struct {
 			OrganizationID int64  `gorm:"column:organization_id"`
 			NodeID         string `gorm:"column:node_id"`
@@ -47,6 +54,9 @@ func setupRunnerEventCallbacks(db *gorm.DB, runnerConnMgr *runner.RunnerConnecti
 				slog.Error("failed to publish runner online event", "error", err)
 			}
 		}
+
+		// Mark event as sent for this connection — subsequent heartbeats skip DB
+		conn.MarkOnlineEventSent()
 	})
 
 	// Wrap disconnect callback to publish runner offline events

--- a/backend/internal/api/grpc/runner_adapter.go
+++ b/backend/internal/api/grpc/runner_adapter.go
@@ -192,7 +192,7 @@ func (a *GRPCRunnerAdapter) Connect(stream runnerv1.RunnerService_ConnectServer)
 
 	// Add connection to RunnerConnectionManager (uses 256-shard locks)
 	conn := a.connManager.AddConnection(runnerInfo.ID, identity.NodeID, identity.OrgSlug, grpcStream)
-	defer a.connManager.RemoveConnection(runnerInfo.ID)
+	defer a.connManager.RemoveConnection(runnerInfo.ID, conn.Generation)
 
 	a.logger.Info("Runner connected",
 		"runner_id", runnerInfo.ID,

--- a/backend/internal/infra/agentpod_repo.go
+++ b/backend/internal/infra/agentpod_repo.go
@@ -195,9 +195,8 @@ func (r *podRepo) DecrementRunnerPods(ctx context.Context, runnerID int64) error
 func (r *podRepo) ListActiveByRunner(ctx context.Context, runnerID int64) ([]*agentpod.Pod, error) {
 	var pods []*agentpod.Pod
 	err := r.db.WithContext(ctx).
-		Where("runner_id = ? AND status IN ?", runnerID, []string{
-			agentpod.StatusRunning, agentpod.StatusInitializing,
-		}).Find(&pods).Error
+		Where("runner_id = ? AND status IN ?", runnerID, agentpod.ActiveStatuses()).
+		Find(&pods).Error
 	return pods, err
 }
 

--- a/backend/internal/infra/billing_repo.go
+++ b/backend/internal/infra/billing_repo.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/anthropics/agentsmesh/backend/internal/domain/agentpod"
+
 	"github.com/anthropics/agentsmesh/backend/internal/domain/billing"
 	"gorm.io/gorm"
 )
@@ -177,7 +179,7 @@ func (r *billingRepository) CountRunners(ctx context.Context, orgID int64) (int6
 func (r *billingRepository) CountActivePods(ctx context.Context, orgID int64) (int64, error) {
 	var count int64
 	err := r.db.WithContext(ctx).Table("pods").
-		Where("organization_id = ? AND status IN ?", orgID, []string{"running", "initializing"}).
+		Where("organization_id = ? AND status IN ?", orgID, agentpod.ActiveStatuses()).
 		Count(&count).Error
 	return count, err
 }

--- a/backend/internal/service/admin/service_dashboard.go
+++ b/backend/internal/service/admin/service_dashboard.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/anthropics/agentsmesh/backend/internal/domain/agentpod"
 	"github.com/anthropics/agentsmesh/backend/internal/domain/organization"
 	"github.com/anthropics/agentsmesh/backend/internal/domain/user"
 )
@@ -61,7 +62,7 @@ func (s *Service) GetDashboardStats(ctx context.Context) (*DashboardStats, error
 	if err := s.db.Table("pods").Count(&stats.TotalPods); err != nil {
 		return nil, fmt.Errorf("failed to count pods: %w", err)
 	}
-	if err := s.db.Table("pods").Where("status IN ?", []string{"pending", "starting", "running"}).Count(&stats.ActivePods); err != nil {
+	if err := s.db.Table("pods").Where("status IN ?", agentpod.ActiveStatuses()).Count(&stats.ActivePods); err != nil {
 		return nil, fmt.Errorf("failed to count active pods: %w", err)
 	}
 

--- a/backend/internal/service/admin/service_runners.go
+++ b/backend/internal/service/admin/service_runners.go
@@ -171,7 +171,7 @@ func (s *Service) DeleteRunner(ctx context.Context, runnerID int64) (*runner.Run
 	// Check for active pods before deletion
 	var podCount int64
 	if err := s.db.Model(&agentpod.Pod{}).
-		Where("runner_id = ? AND status IN ?", runnerID, []string{"pending", "starting", "running"}).
+		Where("runner_id = ? AND status IN ?", runnerID, agentpod.ActiveStatuses()).
 		Count(&podCount); err != nil {
 		return nil, fmt.Errorf("failed to check pods: %w", err)
 	}

--- a/backend/internal/service/runner/connection.go
+++ b/backend/internal/service/runner/connection.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	runnerv1 "github.com/anthropics/agentsmesh/proto/gen/go/runner/v1"
@@ -24,10 +25,11 @@ type RunnerStream interface {
 
 // GRPCConnection represents an active gRPC connection to a runner.
 type GRPCConnection struct {
-	RunnerID int64
-	NodeID   string
-	OrgSlug  string
-	Stream   RunnerStream
+	RunnerID   int64
+	Generation int64 // Unique monotonic ID for this connection instance
+	NodeID     string
+	OrgSlug    string
+	Stream     RunnerStream
 
 	// Connection timestamps
 	ConnectedAt time.Time
@@ -37,6 +39,10 @@ type GRPCConnection struct {
 	// Initialization state
 	initialized     bool
 	availableAgents []string
+
+	// Online event deduplication: true after the first "runner online" event
+	// has been published for this connection, preventing repeated DB queries.
+	onlineEventSent atomic.Bool
 
 	// Send channel for outgoing messages (type-safe)
 	Send chan *runnerv1.ServerMessage
@@ -50,9 +56,10 @@ type GRPCConnection struct {
 }
 
 // NewGRPCConnection creates a new gRPC connection wrapper.
-func NewGRPCConnection(runnerID int64, nodeID, orgSlug string, stream RunnerStream) *GRPCConnection {
+func NewGRPCConnection(runnerID int64, generation int64, nodeID, orgSlug string, stream RunnerStream) *GRPCConnection {
 	return &GRPCConnection{
 		RunnerID:    runnerID,
+		Generation:  generation,
 		NodeID:      nodeID,
 		OrgSlug:     orgSlug,
 		Stream:      stream,
@@ -164,3 +171,13 @@ func (c *GRPCConnection) SendMessage(msg *runnerv1.ServerMessage) error {
 
 // Note: All connection errors are now defined in errors.go for consistency.
 // Use ErrConnectionClosed, ErrSendBufferFull, ErrRunnerNotConnected, ErrCommandSenderNotSet from there.
+
+// IsOnlineEventSent returns whether the "runner online" event has been sent for this connection.
+func (c *GRPCConnection) IsOnlineEventSent() bool {
+	return c.onlineEventSent.Load()
+}
+
+// MarkOnlineEventSent marks the "runner online" event as sent for this connection.
+func (c *GRPCConnection) MarkOnlineEventSent() {
+	c.onlineEventSent.Store(true)
+}

--- a/backend/internal/service/runner/connection_generation_test.go
+++ b/backend/internal/service/runner/connection_generation_test.go
@@ -1,0 +1,121 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRemoveConnection_GenerationMismatch verifies that a stale defer call
+// (from an old connection) does not remove a newer connection.
+func TestRemoveConnection_GenerationMismatch(t *testing.T) {
+	cm := NewRunnerConnectionManager(newTestLogger())
+	defer cm.Close()
+
+	stream1 := newMockRunnerStream()
+	stream2 := newMockRunnerStream()
+	defer stream1.Close()
+	defer stream2.Close()
+
+	disconnected := false
+	cm.SetDisconnectCallback(func(runnerID int64) {
+		disconnected = true
+	})
+
+	// Simulate: old connection established
+	oldConn := cm.AddConnection(1, "node", "org", stream1)
+	oldGen := oldConn.Generation
+
+	// Simulate: new connection replaces old one (e.g., runner reconnected)
+	newConn := cm.AddConnection(1, "node", "org", stream2)
+	assert.NotEqual(t, oldGen, newConn.Generation, "new connection should have different generation")
+	assert.True(t, oldConn.IsClosed(), "old connection should be closed by AddConnection")
+	assert.Equal(t, int64(1), cm.ConnectionCount())
+
+	// Simulate: old connection's defer fires with stale generation
+	cm.RemoveConnection(1, oldGen)
+
+	// New connection must survive
+	assert.Equal(t, int64(1), cm.ConnectionCount(), "new connection should not be removed")
+	stored := cm.GetConnection(1)
+	assert.Same(t, newConn, stored, "should still be the new connection")
+	assert.False(t, disconnected, "disconnect callback should NOT fire for generation mismatch")
+}
+
+// TestRemoveConnection_MatchingGeneration verifies that removal works
+// when the generation matches (normal disconnect scenario).
+func TestRemoveConnection_MatchingGeneration(t *testing.T) {
+	cm := NewRunnerConnectionManager(newTestLogger())
+	defer cm.Close()
+
+	stream := newMockRunnerStream()
+	defer stream.Close()
+
+	disconnected := false
+	cm.SetDisconnectCallback(func(runnerID int64) {
+		disconnected = true
+	})
+
+	conn := cm.AddConnection(1, "node", "org", stream)
+	cm.RemoveConnection(1, conn.Generation)
+
+	assert.Equal(t, int64(0), cm.ConnectionCount())
+	assert.Nil(t, cm.GetConnection(1))
+	assert.True(t, disconnected, "disconnect callback should fire for matching generation")
+}
+
+// TestRemoveConnection_NonExistentRunner verifies no-op for unknown runner.
+func TestRemoveConnection_NonExistentRunner(t *testing.T) {
+	cm := NewRunnerConnectionManager(newTestLogger())
+	defer cm.Close()
+
+	disconnected := false
+	cm.SetDisconnectCallback(func(runnerID int64) {
+		disconnected = true
+	})
+
+	// Should not panic or call disconnect callback
+	cm.RemoveConnection(999, 1)
+	assert.False(t, disconnected)
+}
+
+// TestConnectionGeneration_MonotonicallyIncreasing verifies that generation IDs
+// are unique and monotonically increasing across connections.
+func TestConnectionGeneration_MonotonicallyIncreasing(t *testing.T) {
+	cm := NewRunnerConnectionManager(newTestLogger())
+	defer cm.Close()
+
+	streams := make([]*MockRunnerStream, 5)
+	for i := range streams {
+		streams[i] = newMockRunnerStream()
+		defer streams[i].Close()
+	}
+
+	var generations []int64
+	for i, s := range streams {
+		conn := cm.AddConnection(int64(i+1), "node", "org", s)
+		generations = append(generations, conn.Generation)
+	}
+
+	for i := 1; i < len(generations); i++ {
+		assert.Greater(t, generations[i], generations[i-1],
+			"generation IDs should be monotonically increasing")
+	}
+}
+
+// TestOnlineEventSent verifies the per-connection deduplication flag.
+func TestOnlineEventSent(t *testing.T) {
+	stream := newMockRunnerStream()
+	defer stream.Close()
+
+	conn := NewGRPCConnection(1, 1, "node", "org", stream)
+
+	assert.False(t, conn.IsOnlineEventSent(), "should be false initially")
+
+	conn.MarkOnlineEventSent()
+	assert.True(t, conn.IsOnlineEventSent(), "should be true after marking")
+
+	// Verify a new connection starts fresh
+	conn2 := NewGRPCConnection(1, 2, "node", "org", stream)
+	assert.False(t, conn2.IsOnlineEventSent(), "new connection should start with false")
+}

--- a/backend/internal/service/runner/connection_manager.go
+++ b/backend/internal/service/runner/connection_manager.go
@@ -25,10 +25,11 @@ const DefaultInitTimeout = 30 * time.Second
 // - Messages are sent through the connection's Send channel
 // - Callbacks use Proto types directly (no JSON serialization overhead)
 type RunnerConnectionManager struct {
-	shards       [numShards]*grpcConnectionShard
-	logger       *slog.Logger
-	connCount    atomic.Int64
-	pingInterval time.Duration
+	shards            [numShards]*grpcConnectionShard
+	logger            *slog.Logger
+	connCount         atomic.Int64
+	generationCounter atomic.Int64 // Monotonic counter for connection generation IDs
+	pingInterval      time.Duration
 
 	// Initialization timeout
 	initTimeout     time.Duration
@@ -100,8 +101,10 @@ func (cm *RunnerConnectionManager) getShard(runnerID int64) *grpcConnectionShard
 // ==================== Connection Management ====================
 
 // AddConnection adds a gRPC connection.
+// Returns the new connection with a unique generation ID.
 func (cm *RunnerConnectionManager) AddConnection(runnerID int64, nodeID, orgSlug string, stream RunnerStream) *GRPCConnection {
 	shard := cm.getShard(runnerID)
+	gen := cm.generationCounter.Add(1)
 
 	shard.mu.Lock()
 	defer shard.mu.Unlock()
@@ -112,7 +115,7 @@ func (cm *RunnerConnectionManager) AddConnection(runnerID int64, nodeID, orgSlug
 		cm.connCount.Add(-1)
 	}
 
-	conn := NewGRPCConnection(runnerID, nodeID, orgSlug, stream)
+	conn := NewGRPCConnection(runnerID, gen, nodeID, orgSlug, stream)
 	shard.connections[runnerID] = conn
 	cm.connCount.Add(1)
 
@@ -120,18 +123,32 @@ func (cm *RunnerConnectionManager) AddConnection(runnerID int64, nodeID, orgSlug
 		"runner_id", runnerID,
 		"node_id", nodeID,
 		"org_slug", orgSlug,
+		"generation", gen,
 		"total_connections", cm.connCount.Load(),
 	)
 
 	return conn
 }
 
-// RemoveConnection removes a gRPC connection.
-func (cm *RunnerConnectionManager) RemoveConnection(runnerID int64) {
+// RemoveConnection removes a gRPC connection only if the generation matches.
+// If the current connection has a different generation (newer connection replaced it),
+// the removal is skipped to prevent stale defer calls from closing active connections.
+func (cm *RunnerConnectionManager) RemoveConnection(runnerID, generation int64) {
 	shard := cm.getShard(runnerID)
 
 	shard.mu.Lock()
 	conn, ok := shard.connections[runnerID]
+	if ok && conn.Generation != generation {
+		// Generation mismatch: a newer connection has replaced this one.
+		// Skip removal to avoid closing the active connection.
+		shard.mu.Unlock()
+		cm.logger.Debug("generation mismatch, skipping remove",
+			"runner_id", runnerID,
+			"remove_generation", generation,
+			"current_generation", conn.Generation,
+		)
+		return
+	}
 	if ok {
 		delete(shard.connections, runnerID)
 		cm.connCount.Add(-1)
@@ -142,6 +159,7 @@ func (cm *RunnerConnectionManager) RemoveConnection(runnerID int64) {
 		conn.Close()
 		cm.logger.Info("runner disconnected (gRPC)",
 			"runner_id", runnerID,
+			"generation", generation,
 			"total_connections", cm.connCount.Load(),
 		)
 
@@ -233,30 +251,34 @@ func (cm *RunnerConnectionManager) initTimeoutLoop() {
 
 func (cm *RunnerConnectionManager) checkInitTimeouts() {
 	now := time.Now()
-	var timedOutRunners []int64
+	type timedOutEntry struct {
+		runnerID   int64
+		generation int64
+	}
+	var timedOut []timedOutEntry
 
 	for i := 0; i < numShards; i++ {
 		shard := cm.shards[i]
 		shard.mu.RLock()
 		for runnerID, conn := range shard.connections {
 			if !conn.IsInitialized() && now.Sub(conn.ConnectedAt) > cm.initTimeout {
-				timedOutRunners = append(timedOutRunners, runnerID)
+				timedOut = append(timedOut, timedOutEntry{runnerID: runnerID, generation: conn.Generation})
 			}
 		}
 		shard.mu.RUnlock()
 	}
 
-	for _, runnerID := range timedOutRunners {
+	for _, entry := range timedOut {
 		reason := "initialization timeout"
 		cm.logger.Warn("removing gRPC connection due to initialization timeout",
-			"runner_id", runnerID,
+			"runner_id", entry.runnerID,
 			"timeout", cm.initTimeout,
 		)
 
 		if cm.onInitFailed != nil {
-			cm.onInitFailed(runnerID, reason)
+			cm.onInitFailed(entry.runnerID, reason)
 		}
 
-		cm.RemoveConnection(runnerID)
+		cm.RemoveConnection(entry.runnerID, entry.generation)
 	}
 }

--- a/backend/internal/service/runner/connection_manager_test.go
+++ b/backend/internal/service/runner/connection_manager_test.go
@@ -140,10 +140,10 @@ func TestConnectionManager_RemoveConnection(t *testing.T) {
 	})
 
 	// Add and remove connection
-	cm.AddConnection(1, "test-node", "test-org", stream)
+	conn := cm.AddConnection(1, "test-node", "test-org", stream)
 	assert.Equal(t, int64(1), cm.ConnectionCount())
 
-	cm.RemoveConnection(1)
+	cm.RemoveConnection(1, conn.Generation)
 	assert.Equal(t, int64(0), cm.ConnectionCount())
 	assert.Nil(t, cm.GetConnection(1))
 	assert.True(t, disconnected)
@@ -158,10 +158,10 @@ func TestConnectionManager_IsConnected(t *testing.T) {
 
 	assert.False(t, cm.IsConnected(1))
 
-	cm.AddConnection(1, "test-node", "test-org", stream)
+	conn := cm.AddConnection(1, "test-node", "test-org", stream)
 	assert.True(t, cm.IsConnected(1))
 
-	cm.RemoveConnection(1)
+	cm.RemoveConnection(1, conn.Generation)
 	assert.False(t, cm.IsConnected(1))
 }
 
@@ -278,11 +278,11 @@ func TestConnectionManager_ConcurrentOperations(t *testing.T) {
 
 			for j := 0; j < numOperations; j++ {
 				stream := newMockRunnerStream()
-				cm.AddConnection(runnerID, "node", "org", stream)
+				conn := cm.AddConnection(runnerID, "node", "org", stream)
 				cm.IsConnected(runnerID)
 				cm.GetConnection(runnerID)
 				cm.UpdateHeartbeat(runnerID)
-				cm.RemoveConnection(runnerID)
+				cm.RemoveConnection(runnerID, conn.Generation)
 				stream.Close()
 			}
 		}(i)

--- a/backend/internal/service/runner/connection_test.go
+++ b/backend/internal/service/runner/connection_test.go
@@ -13,7 +13,7 @@ func TestNewGRPCConnection(t *testing.T) {
 	stream := newMockRunnerStream()
 	defer stream.Close()
 
-	conn := NewGRPCConnection(1, "test-node", "test-org", stream)
+	conn := NewGRPCConnection(1, 1, "test-node", "test-org", stream)
 
 	assert.Equal(t, int64(1), conn.RunnerID)
 	assert.Equal(t, "test-node", conn.NodeID)
@@ -31,7 +31,7 @@ func TestGRPCConnection_IsInitialized(t *testing.T) {
 	stream := newMockRunnerStream()
 	defer stream.Close()
 
-	conn := NewGRPCConnection(1, "test-node", "test-org", stream)
+	conn := NewGRPCConnection(1, 1, "test-node", "test-org", stream)
 
 	// Initially not initialized
 	assert.False(t, conn.IsInitialized())
@@ -49,7 +49,7 @@ func TestGRPCConnection_SetInitialized(t *testing.T) {
 	stream := newMockRunnerStream()
 	defer stream.Close()
 
-	conn := NewGRPCConnection(1, "test-node", "test-org", stream)
+	conn := NewGRPCConnection(1, 1, "test-node", "test-org", stream)
 
 	agents := []string{"claude-code", "aider"}
 	conn.SetInitialized(true, agents)
@@ -62,7 +62,7 @@ func TestGRPCConnection_GetAvailableAgents(t *testing.T) {
 	stream := newMockRunnerStream()
 	defer stream.Close()
 
-	conn := NewGRPCConnection(1, "test-node", "test-org", stream)
+	conn := NewGRPCConnection(1, 1, "test-node", "test-org", stream)
 
 	// Initially nil
 	assert.Nil(t, conn.GetAvailableAgents())
@@ -83,7 +83,7 @@ func TestGRPCConnection_UpdateLastPing(t *testing.T) {
 	stream := newMockRunnerStream()
 	defer stream.Close()
 
-	conn := NewGRPCConnection(1, "test-node", "test-org", stream)
+	conn := NewGRPCConnection(1, 1, "test-node", "test-org", stream)
 	initialPing := conn.GetLastPing()
 
 	time.Sleep(10 * time.Millisecond)
@@ -96,7 +96,7 @@ func TestGRPCConnection_GetLastPing(t *testing.T) {
 	stream := newMockRunnerStream()
 	defer stream.Close()
 
-	conn := NewGRPCConnection(1, "test-node", "test-org", stream)
+	conn := NewGRPCConnection(1, 1, "test-node", "test-org", stream)
 
 	ping := conn.GetLastPing()
 	assert.WithinDuration(t, time.Now(), ping, time.Second)
@@ -106,7 +106,7 @@ func TestGRPCConnection_LastPong_InitiallyZero(t *testing.T) {
 	stream := newMockRunnerStream()
 	defer stream.Close()
 
-	conn := NewGRPCConnection(1, "test-node", "test-org", stream)
+	conn := NewGRPCConnection(1, 1, "test-node", "test-org", stream)
 
 	// Initially zero (no pong received yet)
 	assert.True(t, conn.GetLastPong().IsZero())
@@ -116,7 +116,7 @@ func TestGRPCConnection_UpdateLastPong(t *testing.T) {
 	stream := newMockRunnerStream()
 	defer stream.Close()
 
-	conn := NewGRPCConnection(1, "test-node", "test-org", stream)
+	conn := NewGRPCConnection(1, 1, "test-node", "test-org", stream)
 	assert.True(t, conn.GetLastPong().IsZero())
 
 	// Update lastPong
@@ -131,7 +131,7 @@ func TestGRPCConnection_UpdateLastPong_Advances(t *testing.T) {
 	stream := newMockRunnerStream()
 	defer stream.Close()
 
-	conn := NewGRPCConnection(1, "test-node", "test-org", stream)
+	conn := NewGRPCConnection(1, 1, "test-node", "test-org", stream)
 
 	conn.UpdateLastPong()
 	first := conn.GetLastPong()
@@ -147,7 +147,7 @@ func TestGRPCConnection_IsClosed(t *testing.T) {
 	stream := newMockRunnerStream()
 	defer stream.Close()
 
-	conn := NewGRPCConnection(1, "test-node", "test-org", stream)
+	conn := NewGRPCConnection(1, 1, "test-node", "test-org", stream)
 
 	assert.False(t, conn.IsClosed())
 
@@ -159,7 +159,7 @@ func TestGRPCConnection_IsClosed(t *testing.T) {
 func TestGRPCConnection_Close(t *testing.T) {
 	stream := newMockRunnerStream()
 
-	conn := NewGRPCConnection(1, "test-node", "test-org", stream)
+	conn := NewGRPCConnection(1, 1, "test-node", "test-org", stream)
 
 	// Close should work
 	conn.Close()
@@ -173,7 +173,7 @@ func TestGRPCConnection_Close(t *testing.T) {
 func TestGRPCConnection_CloseChan(t *testing.T) {
 	stream := newMockRunnerStream()
 
-	conn := NewGRPCConnection(1, "test-node", "test-org", stream)
+	conn := NewGRPCConnection(1, 1, "test-node", "test-org", stream)
 
 	closeChan := conn.CloseChan()
 	assert.NotNil(t, closeChan)
@@ -202,7 +202,7 @@ func TestGRPCConnection_SendMessage(t *testing.T) {
 	stream := newMockRunnerStream()
 	defer stream.Close()
 
-	conn := NewGRPCConnection(1, "test-node", "test-org", stream)
+	conn := NewGRPCConnection(1, 1, "test-node", "test-org", stream)
 
 	msg := &runnerv1.ServerMessage{
 		Payload: &runnerv1.ServerMessage_InitializeResult{
@@ -228,7 +228,7 @@ func TestGRPCConnection_SendMessage(t *testing.T) {
 func TestGRPCConnection_SendMessage_Closed(t *testing.T) {
 	stream := newMockRunnerStream()
 
-	conn := NewGRPCConnection(1, "test-node", "test-org", stream)
+	conn := NewGRPCConnection(1, 1, "test-node", "test-org", stream)
 	conn.Close()
 
 	msg := &runnerv1.ServerMessage{
@@ -248,7 +248,7 @@ func TestGRPCConnection_SendMessage_BufferFull(t *testing.T) {
 	stream := newMockRunnerStream()
 	defer stream.Close()
 
-	conn := NewGRPCConnection(1, "test-node", "test-org", stream)
+	conn := NewGRPCConnection(1, 1, "test-node", "test-org", stream)
 
 	// Fill up the send buffer (buffer size is 256)
 	msg := &runnerv1.ServerMessage{

--- a/backend/internal/service/runner/pod_coordinator.go
+++ b/backend/internal/service/runner/pod_coordinator.go
@@ -16,6 +16,10 @@ import (
 const (
 	terminateCooldown      = 5 * time.Minute  // 冷却期：两次 terminate 之间的最短间隔
 	terminateCacheCleanup  = 30 * time.Minute // 缓存条目过期清理阈值
+
+	// orphanMissThreshold is the number of consecutive heartbeat misses required
+	// before marking a pod as orphaned. At ~30s per heartbeat cycle, 3 misses ≈ 90s.
+	orphanMissThreshold = 3
 )
 
 // PodCoordinator coordinates pod lifecycle events between backend and runners
@@ -39,6 +43,13 @@ type PodCoordinator struct {
 	// during heartbeat reconciliation. Maps podKey → last sent time.
 	terminateSentCache map[string]time.Time
 	terminateCacheMu   sync.Mutex
+
+	// Pod miss counter: tracks consecutive heartbeat misses per pod.
+	// A pod is only orphaned after orphanMissThreshold consecutive misses,
+	// providing tolerance for transient network issues and reconnections.
+	podMissCount map[string]int            // podKey → consecutive miss count
+	podMissOwner map[string]int64          // podKey → runnerID (reverse index for clearByRunner)
+	podMissMu    sync.Mutex
 
 	// Callbacks
 	onStatusChange   func(podKey string, status string, agentStatus string)
@@ -72,6 +83,8 @@ func NewPodCoordinator(
 		commandSender:        NewNoOpCommandSender(logger), // Default to no-op
 		relayConnectionCache: NewRelayConnectionCache(),
 		terminateSentCache:   make(map[string]time.Time),
+		podMissCount:         make(map[string]int),
+		podMissOwner:         make(map[string]int64),
 	}
 
 	// Set up callbacks from connection manager
@@ -178,8 +191,9 @@ func (pc *PodCoordinator) TerminatePod(ctx context.Context, podKey string) error
 		return err
 	}
 
-	// Unregister from terminal router
+	// Unregister from terminal router and clean up miss counter
 	pc.terminalRouter.UnregisterPod(podKey)
+	pc.clearMissCount(podKey)
 
 	// Decrement pod count
 	return pc.DecrementPods(ctx, pod.RunnerID)
@@ -244,6 +258,40 @@ func (pc *PodCoordinator) recordTerminateSent(podKey string) {
 	for key, t := range pc.terminateSentCache {
 		if now.Sub(t) > terminateCacheCleanup {
 			delete(pc.terminateSentCache, key)
+		}
+	}
+}
+
+// ==================== Pod Miss Counter ====================
+
+// incrementMissCount increments the consecutive heartbeat miss count for a pod.
+// Returns the new miss count.
+func (pc *PodCoordinator) incrementMissCount(podKey string, runnerID int64) int {
+	pc.podMissMu.Lock()
+	defer pc.podMissMu.Unlock()
+	pc.podMissCount[podKey]++
+	pc.podMissOwner[podKey] = runnerID
+	return pc.podMissCount[podKey]
+}
+
+// clearMissCount removes the miss counter for a specific pod (e.g., pod reported in heartbeat).
+func (pc *PodCoordinator) clearMissCount(podKey string) {
+	pc.podMissMu.Lock()
+	defer pc.podMissMu.Unlock()
+	delete(pc.podMissCount, podKey)
+	delete(pc.podMissOwner, podKey)
+}
+
+// clearMissCountsForRunner removes all miss counters for pods belonging to the given runner.
+// Called on runner disconnect to prevent stale counters from affecting reconnection.
+// Uses an in-memory reverse index instead of DB queries to avoid TOCTOU races.
+func (pc *PodCoordinator) clearMissCountsForRunner(runnerID int64) {
+	pc.podMissMu.Lock()
+	defer pc.podMissMu.Unlock()
+	for podKey, ownerID := range pc.podMissOwner {
+		if ownerID == runnerID {
+			delete(pc.podMissCount, podKey)
+			delete(pc.podMissOwner, podKey)
 		}
 	}
 }

--- a/backend/internal/service/runner/pod_event_handler_heartbeat_test.go
+++ b/backend/internal/service/runner/pod_event_handler_heartbeat_test.go
@@ -140,7 +140,10 @@ func TestHandleHeartbeatReconcilePods(t *testing.T) {
 		},
 	}
 
-	pc.handleHeartbeat(r.ID, data)
+	// Need orphanMissThreshold heartbeats for pod-2 to become orphaned
+	for i := 0; i < orphanMissThreshold; i++ {
+		pc.handleHeartbeat(r.ID, data)
+	}
 
 	// Verify pod-1 is still running and registered
 	var status1 string
@@ -221,7 +224,10 @@ func TestReconcilePods(t *testing.T) {
 		// pod-2 and pod-3 are NOT reported
 	}
 
-	pc.reconcilePods(ctx, r.ID, reportedPods)
+	// Need orphanMissThreshold reconcile calls for unreported pods to become orphaned
+	for i := 0; i < orphanMissThreshold; i++ {
+		pc.reconcilePods(ctx, r.ID, reportedPods)
+	}
 
 	// Verify pod-1 is registered
 	if !tr.IsPodRegistered("recon-pod-1") {
@@ -305,10 +311,13 @@ func TestReconcilePodsOrphanedCallsStatusChangeCallback(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	// Report empty pods - both should become orphaned
+	// Report empty pods - both should become orphaned after threshold
 	reportedPods := map[string]bool{}
 
-	pc.reconcilePods(ctx, r.ID, reportedPods)
+	// Need orphanMissThreshold reconcile calls for unreported pods to become orphaned
+	for i := 0; i < orphanMissThreshold; i++ {
+		pc.reconcilePods(ctx, r.ID, reportedPods)
+	}
 
 	// Verify both pods are orphaned in DB
 	var status1, status2 string

--- a/backend/internal/service/runner/pod_heartbeat_handler.go
+++ b/backend/internal/service/runner/pod_heartbeat_handler.go
@@ -140,25 +140,44 @@ func (pc *PodCoordinator) reconcilePods(ctx context.Context, runnerID int64, rep
 		return
 	}
 
-	// Mark pods that are in DB but not reported by runner as orphaned
-	// This means the pod process has terminated on the runner side
+	// Mark pods that are in DB but not reported by runner.
+	// Uses evidence-based orphaning: a pod must be missing for orphanMissThreshold
+	// consecutive heartbeats before being orphaned, providing tolerance for
+	// transient network issues and runner reconnections.
 	for _, p := range activePods {
-		if !reportedPods[p.PodKey] {
-			if err := pc.podRepo.MarkOrphaned(ctx, p, now); err != nil {
-				pc.logger.Error("failed to mark pod as orphaned",
-					"pod_key", p.PodKey,
-					"error", err)
-			} else {
-				pc.logger.Warn("pod marked as orphaned (not reported by runner)",
-					"pod_key", p.PodKey,
-					"runner_id", runnerID)
-				// Unregister from terminal router
-				pc.terminalRouter.UnregisterPod(p.PodKey)
+		if reportedPods[p.PodKey] {
+			// Pod is present in heartbeat — clear any accumulated miss count
+			pc.clearMissCount(p.PodKey)
+			continue
+		}
 
-				// Notify status change for WebSocket event
-				if pc.onStatusChange != nil {
-					pc.onStatusChange(p.PodKey, agentpod.StatusOrphaned, "")
-				}
+		missCount := pc.incrementMissCount(p.PodKey, runnerID)
+		if missCount < orphanMissThreshold {
+			pc.logger.Debug("pod not reported, waiting for more evidence",
+				"pod_key", p.PodKey,
+				"runner_id", runnerID,
+				"miss_count", missCount,
+				"threshold", orphanMissThreshold)
+			continue
+		}
+
+		// Evidence threshold reached — orphan the pod
+		pc.clearMissCount(p.PodKey)
+		if err := pc.podRepo.MarkOrphaned(ctx, p, now); err != nil {
+			pc.logger.Error("failed to mark pod as orphaned",
+				"pod_key", p.PodKey,
+				"error", err)
+		} else {
+			pc.logger.Warn("pod marked as orphaned (not reported by runner)",
+				"pod_key", p.PodKey,
+				"runner_id", runnerID,
+				"miss_count", missCount)
+			// Unregister from terminal router
+			pc.terminalRouter.UnregisterPod(p.PodKey)
+
+			// Notify status change for WebSocket event
+			if pc.onStatusChange != nil {
+				pc.onStatusChange(p.PodKey, agentpod.StatusOrphaned, "")
 			}
 		}
 	}

--- a/backend/internal/service/runner/pod_lifecycle_handler.go
+++ b/backend/internal/service/runner/pod_lifecycle_handler.go
@@ -94,8 +94,9 @@ func (pc *PodCoordinator) handlePodTerminated(runnerID int64, data *runnerv1.Pod
 	// Decrement runner pod count
 	_ = pc.runnerRepo.DecrementPods(ctx, runnerID)
 
-	// Unregister from terminal router
+	// Unregister from terminal router and clean up miss counter
 	pc.terminalRouter.UnregisterPod(data.PodKey)
+	pc.clearMissCount(data.PodKey)
 
 	pc.logger.Info("pod terminated",
 		"pod_key", data.PodKey,
@@ -198,6 +199,10 @@ func (pc *PodCoordinator) handleRunnerDisconnect(runnerID int64) {
 
 	// Clear relay connection cache for this runner
 	pc.relayConnectionCache.Delete(runnerID)
+
+	// Clear miss counters for this runner's pods to prevent stale counts
+	// from affecting reconciliation after reconnection.
+	pc.clearMissCountsForRunner(runnerID)
 
 	pc.logger.Info("runner disconnected, pods will be reconciled on reconnect",
 		"runner_id", runnerID)

--- a/backend/internal/service/runner/pod_miss_counter_test.go
+++ b/backend/internal/service/runner/pod_miss_counter_test.go
@@ -1,0 +1,133 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/anthropics/agentsmesh/backend/internal/domain/agentpod"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPodMissCount_IncrementAndClear(t *testing.T) {
+	_, _, tr, hb, podRepo, runnerRepo := setupPodCoordinatorDeps(t)
+	logger := newTestLogger()
+	cm := NewRunnerConnectionManager(logger)
+	defer cm.Close()
+
+	pc := NewPodCoordinator(podRepo, runnerRepo, cm, tr, hb, logger)
+
+	// Increment miss count
+	assert.Equal(t, 1, pc.incrementMissCount("pod-1", 1))
+	assert.Equal(t, 2, pc.incrementMissCount("pod-1", 1))
+	assert.Equal(t, 3, pc.incrementMissCount("pod-1", 1))
+
+	// Different pod has independent counter
+	assert.Equal(t, 1, pc.incrementMissCount("pod-2", 1))
+
+	// Clear single pod
+	pc.clearMissCount("pod-1")
+	assert.Equal(t, 1, pc.incrementMissCount("pod-1", 1), "counter should restart after clear")
+
+	// pod-2 should be unaffected
+	assert.Equal(t, 2, pc.incrementMissCount("pod-2", 1))
+}
+
+func TestPodMissCount_ClearForRunner(t *testing.T) {
+	_, _, tr, hb, podRepo, runnerRepo := setupPodCoordinatorDeps(t)
+	logger := newTestLogger()
+	cm := NewRunnerConnectionManager(logger)
+	defer cm.Close()
+
+	pc := NewPodCoordinator(podRepo, runnerRepo, cm, tr, hb, logger)
+
+	// Accumulate miss counts with runner ownership
+	pc.incrementMissCount("pod-a", 1) // runner 1
+	pc.incrementMissCount("pod-a", 1)
+	pc.incrementMissCount("pod-b", 1) // runner 1
+	pc.incrementMissCount("pod-c", 2) // runner 2
+
+	// Clear for runner 1 only (no DB query needed — uses reverse index)
+	pc.clearMissCountsForRunner(1)
+
+	// Runner 1's pods should be reset
+	assert.Equal(t, 1, pc.incrementMissCount("pod-a", 1), "pod-a should restart after runner clear")
+	assert.Equal(t, 1, pc.incrementMissCount("pod-b", 1), "pod-b should restart after runner clear")
+
+	// Runner 2's pod should be unaffected
+	assert.Equal(t, 2, pc.incrementMissCount("pod-c", 2), "pod-c should continue counting")
+}
+
+func TestOrphanMissThreshold_NotReachedYet(t *testing.T) {
+	db, _, tr, hb, podRepo, runnerRepo := setupPodCoordinatorDeps(t)
+	logger := newTestLogger()
+	cm := NewRunnerConnectionManager(logger)
+	defer cm.Close()
+
+	pc := NewPodCoordinator(podRepo, runnerRepo, cm, tr, hb, logger)
+
+	// Create a running pod
+	require.NoError(t, db.Exec(`INSERT INTO pods (pod_key, runner_id, status) VALUES (?, ?, ?)`,
+		"pod-x", 1, agentpod.StatusRunning).Error)
+
+	// Simulate heartbeats that don't report this pod, but fewer than threshold
+	for i := 0; i < orphanMissThreshold-1; i++ {
+		pc.reconcilePods(t.Context(), 1, map[string]bool{}) // empty heartbeat
+	}
+
+	// Pod should still be running (not yet orphaned)
+	pod, err := podRepo.GetByKey(t.Context(), "pod-x")
+	require.NoError(t, err)
+	assert.Equal(t, agentpod.StatusRunning, pod.Status, "pod should NOT be orphaned before threshold")
+}
+
+func TestOrphanMissThreshold_ReachedOrphans(t *testing.T) {
+	db, _, tr, hb, podRepo, runnerRepo := setupPodCoordinatorDeps(t)
+	logger := newTestLogger()
+	cm := NewRunnerConnectionManager(logger)
+	defer cm.Close()
+
+	pc := NewPodCoordinator(podRepo, runnerRepo, cm, tr, hb, logger)
+
+	// Create a running pod
+	require.NoError(t, db.Exec(`INSERT INTO pods (pod_key, runner_id, status) VALUES (?, ?, ?)`,
+		"pod-y", 1, agentpod.StatusRunning).Error)
+
+	// Simulate heartbeats that don't report this pod, reaching threshold
+	for i := 0; i < orphanMissThreshold; i++ {
+		pc.reconcilePods(t.Context(), 1, map[string]bool{})
+	}
+
+	// Pod should now be orphaned
+	pod, err := podRepo.GetByKey(t.Context(), "pod-y")
+	require.NoError(t, err)
+	assert.Equal(t, agentpod.StatusOrphaned, pod.Status, "pod should be orphaned after threshold")
+}
+
+func TestOrphanMissThreshold_ResetByPresence(t *testing.T) {
+	db, _, tr, hb, podRepo, runnerRepo := setupPodCoordinatorDeps(t)
+	logger := newTestLogger()
+	cm := NewRunnerConnectionManager(logger)
+	defer cm.Close()
+
+	pc := NewPodCoordinator(podRepo, runnerRepo, cm, tr, hb, logger)
+
+	// Create a running pod
+	require.NoError(t, db.Exec(`INSERT INTO pods (pod_key, runner_id, status) VALUES (?, ?, ?)`,
+		"pod-z", 1, agentpod.StatusRunning).Error)
+
+	// Miss twice (below threshold)
+	pc.reconcilePods(t.Context(), 1, map[string]bool{})
+	pc.reconcilePods(t.Context(), 1, map[string]bool{})
+
+	// Pod reports in heartbeat — counter should reset
+	pc.reconcilePods(t.Context(), 1, map[string]bool{"pod-z": true})
+
+	// Miss twice again — still below threshold from fresh start
+	pc.reconcilePods(t.Context(), 1, map[string]bool{})
+	pc.reconcilePods(t.Context(), 1, map[string]bool{})
+
+	// Pod should still be running
+	pod, err := podRepo.GetByKey(t.Context(), "pod-z")
+	require.NoError(t, err)
+	assert.Equal(t, agentpod.StatusRunning, pod.Status, "miss counter should have reset on pod presence")
+}

--- a/runner/internal/client/grpc_connection.go
+++ b/runner/internal/client/grpc_connection.go
@@ -74,9 +74,7 @@ type GRPCConnection struct {
 	lastSendTime atomic.Int64
 
 	// Recv liveness tracking — updated by readLoop on every successful Recv().
-	// recvWatchdog triggers reconnect when no message arrives for 3× heartbeatInterval,
-	// handling the half-dead connection case where the server closed the downstream
-	// but stream.Recv() keeps blocking on the runner side.
+	// Used for diagnostics and connection state reporting.
 	lastRecvTime atomic.Int64
 
 	// Rate limiting for terminal output (bytes per second)

--- a/runner/internal/client/grpc_connection_loop.go
+++ b/runner/internal/client/grpc_connection_loop.go
@@ -127,4 +127,4 @@ func (c *GRPCConnection) tryEndpointDiscovery() {
 	c.reconnectStrategy.Reset()
 }
 
-// Note: runConnection, recvWatchdog, buildMTLSConfig are in grpc_connection_run.go
+// Note: runConnection, buildMTLSConfig are in grpc_connection_run.go

--- a/runner/internal/client/grpc_connection_run.go
+++ b/runner/internal/client/grpc_connection_run.go
@@ -103,15 +103,11 @@ func (c *GRPCConnection) runConnection() {
 		c.certRenewalChecker(ctx, done)
 	})
 
-	// Start recv watchdog — detects half-dead connections where readLoop
-	// is stuck on Recv() after the server closed the downstream.
-	// Backend sends downstream pings every 30s; if nothing arrives for
-	// 3x heartbeatInterval the connection is dead.
-	wg.Add(1)
-	safego.Go("grpc-recv-watchdog", func() {
-		defer wg.Done()
-		c.recvWatchdog(done, cancel)
-	})
+	// Note: recvWatchdog was removed as redundant. Downstream failure is now
+	// detected by two complementary mechanisms:
+	// 1. Backend PingPong: Backend sends Ping → 90s timeout → closes connection → Runner readLoop EOF
+	// 2. HeartbeatMonitor: Runner sends heartbeat → no ack for 3 cycles → triggers reconnect
+	// Having a third mechanism (recvWatchdog) caused cancel signal races during reconnection.
 
 	// Monitor for reconnection signal (certificate renewal)
 	wg.Add(1)
@@ -151,44 +147,6 @@ func (c *GRPCConnection) runConnection() {
 	// This prevents goroutine accumulation across reconnections.
 	wg.Wait()
 	logger.GRPC().Debug("All child goroutines exited, runConnection returning")
-}
-
-// recvWatchdog monitors for recv liveness. If no message is received from the
-// server for 3x heartbeatInterval (90s by default, matching the backend's
-// downstream pong timeout), the connection is considered half-dead and
-// reconnection is triggered by cancelling the stream context.
-//
-// This handles the case where the backend has closed the downstream send loop
-// (e.g. pong timeout) but the runner's stream.Recv() keeps blocking because
-// the gRPC transport hasn't detected the closure.
-func (c *GRPCConnection) recvWatchdog(done <-chan struct{}, cancel context.CancelFunc) {
-	recvTimeout := 3 * c.heartbeatInterval
-	ticker := time.NewTicker(c.heartbeatInterval)
-	defer ticker.Stop()
-
-	log := logger.GRPC()
-
-	for {
-		select {
-		case <-c.stopCh:
-			return
-		case <-done:
-			return
-		case <-ticker.C:
-			lastRecvNs := c.lastRecvTime.Load()
-			if lastRecvNs == 0 {
-				continue // Not yet initialized
-			}
-			lastRecv := time.Unix(0, lastRecvNs)
-			since := time.Since(lastRecv)
-			if since > recvTimeout {
-				log.Error("Recv watchdog: no message from server, triggering reconnect",
-					"timeout", recvTimeout, "last_recv_ago", since)
-				cancel() // Cancel stream context -> unblocks Recv() -> readLoop exits
-				return
-			}
-		}
-	}
 }
 
 // buildMTLSConfig builds a TLS config for mTLS HTTP requests using the runner's

--- a/runner/internal/client/grpc_handler.go
+++ b/runner/internal/client/grpc_handler.go
@@ -23,7 +23,7 @@ func (c *GRPCConnection) readLoop(ctx context.Context, done chan<- struct{}) {
 	for {
 		msg, err := c.stream.Recv()
 		if err != nil {
-			// Don't update lastRecvTime on error — watchdog should detect staleness
+			// Don't update lastRecvTime on error — only track successful receives
 			if err == io.EOF {
 				log.Info("Stream ended (EOF)")
 				return
@@ -39,7 +39,7 @@ func (c *GRPCConnection) readLoop(ctx context.Context, done chan<- struct{}) {
 			}
 			return
 		}
-		// Record successful recv for liveness tracking (recvWatchdog uses this)
+		// Record successful recv for liveness tracking and diagnostics
 		c.lastRecvTime.Store(time.Now().UnixNano())
 		c.handleServerMessage(msg)
 	}


### PR DESCRIPTION
## Summary

Production pods were disappearing and reappearing due to three subsystems (connection lifecycle, state sync, liveness detection) lacking a unified state model. This redesign addresses the root cause with five coordinated changes:

- **Connection Generation (A)**: Unique monotonic ID per gRPC connection prevents stale `defer` from killing new connections during rapid reconnection
- **Evidence-Based Orphaning (B)**: Pods require 3 consecutive heartbeat misses (~90s) before orphaning, replacing instant single-miss judgement. Includes reverse index for efficient per-runner cleanup without DB queries
- **Liveness Detection Unification (C)**: Remove redundant `recvWatchdog` from Runner — `HeartbeatMonitor` + `PingPong` already cover both directions, eliminating cascade cancel signals
- **Active Pod Query Scope (D)**: `ListActiveByRunner` now uses `ActiveStatuses()` domain function, covering `paused`/`disconnected` pods previously invisible to reconciliation
- **Runner Online Event Dedup (E)**: Per-connection `atomic.Bool` flag skips DB query on subsequent heartbeats (was querying every 30s)

Also fixes hardcoded status lists in `billing_repo`, admin dashboard/runners, and `eventbus_pod` (including a bug where `"failed"` status — which doesn't exist in the domain model — prevented error pods from triggering notifications).

### Architecture

```
Change A (connection identity) ─── foundation: eliminate race conditions
   ├── Change B (orphan tolerance) ── state layer: reconnection no longer triggers false orphan
   │      └── Change D (query scope) ── data layer: reconcile covers all active statuses
   ├── Change E (event dedup) ──── event layer: per-connection flag on A's connection object
   └── Change C (liveness) ──── runner layer: independent, reduce cascade triggers
```

### Files changed (21 files, +470/-127)

**Backend — connection lifecycle**: `connection.go`, `connection_manager.go`, `runner_adapter.go`
**Backend — pod state management**: `pod_coordinator.go`, `pod_heartbeat_handler.go`, `pod_lifecycle_handler.go`
**Backend — status list fixes**: `agentpod_repo.go`, `billing_repo.go`, `service_dashboard.go`, `service_runners.go`, `eventbus_pod.go`, `eventbus_runner.go`
**Runner — liveness simplification**: `grpc_connection_run.go`, `grpc_connection.go`, `grpc_connection_loop.go`, `grpc_handler.go`
**Tests**: `connection_generation_test.go` (new), `pod_miss_counter_test.go` (new), + 3 updated test files

## Test plan

- [x] `go build ./...` passes (backend)
- [x] `go test ./internal/service/runner/... -count=1` — all tests pass
- [x] `go test ./internal/service/admin/... -count=1` — all tests pass
- [ ] CI pipeline passes
- [ ] Deploy to dev environment, verify: kill Runner container → pod list should NOT disappear
- [ ] Verify Runner auto-reconnect → no orphaned→running status flicker in WebSocket events