### PR TITLE
fix(web): extract URL validation out of try/catch for ESLint

### DIFF
--- a/web/src/app/(dashboard)/[org]/runners/[id]/components/RunnerLogsCard.tsx
+++ b/web/src/app/(dashboard)/[org]/runners/[id]/components/RunnerLogsCard.tsx
@@ -150,14 +150,17 @@ export function RunnerLogsCard({ runnerId, runnerStatus }: RunnerLogsCardProps) 
 }
 
 /** M10: validate URL protocol before rendering download link */
-function DownloadLink({ url, label }: { url: string; label: string }) {
-  // Only allow http/https protocols to prevent XSS via javascript: URLs
+function isValidDownloadUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-      return <span className="text-sm text-muted-foreground">-</span>;
-    }
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
   } catch {
+    return false;
+  }
+}
+
+function DownloadLink({ url, label }: { url: string; label: string }) {
+  if (!isValidDownloadUrl(url)) {
     return <span className="text-sm text-muted-foreground">-</span>;
   }
 


### PR DESCRIPTION
## Summary

- Fix ESLint `react-hooks/error-boundaries` error in `RunnerLogsCard.tsx`
- Extract URL protocol validation into pure function `isValidDownloadUrl()` to avoid JSX within try/catch

## Context

Follow-up fix for PR #88 — CI caught this ESLint rule violation after merge.