### PR TITLE
feat(token-usage): add token usage monitoring for AI agents

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -107,6 +107,9 @@ func main() {
 	// Wire AutopilotRepository into PodCoordinator for autopilot event handling
 	podCoordinator.SetAutopilotRepo(services.autopilotRepo)
 
+	// Wire TokenUsageService into PodCoordinator for token usage recording
+	podCoordinator.SetTokenUsageService(services.tokenUsage)
+
 	// Initialize Relay services
 	relayManager := relay.NewManagerWithOptions()
 	relayTokenGenerator := relay.NewTokenGenerator(cfg.JWT.Secret, "agentsmesh-relay")
@@ -297,6 +300,7 @@ func main() {
 		SSO:                  services.sso,
 		SupportTicket:       services.supportTicket,
 		NotificationPrefStore: services.notifPrefStore,
+		TokenUsage:            services.tokenUsage,
 	}
 
 	// Initialize router

--- a/backend/cmd/server/services_init.go
+++ b/backend/cmd/server/services_init.go
@@ -23,6 +23,7 @@ import (
 	fileservice "github.com/anthropics/agentsmesh/backend/internal/service/file"
 	ssoservice "github.com/anthropics/agentsmesh/backend/internal/service/sso"
 	supportticketservice "github.com/anthropics/agentsmesh/backend/internal/service/supportticket"
+	tokenusagesvc "github.com/anthropics/agentsmesh/backend/internal/service/tokenusage"
 	"github.com/anthropics/agentsmesh/backend/internal/service/invitation"
 	"github.com/anthropics/agentsmesh/backend/internal/service/license"
 	loop "github.com/anthropics/agentsmesh/backend/internal/service/loop"
@@ -76,6 +77,7 @@ type serviceContainer struct {
 	loopRun           *loop.LoopRunService
 	sso               *ssoservice.Service
 	supportTicket     *supportticketservice.Service
+	tokenUsage        *tokenusagesvc.Service
 
 	// Notification services
 	notifDispatcher *notifService.Dispatcher
@@ -194,6 +196,10 @@ func initializeServices(cfg *config.Config, db *gorm.DB, redisClient *redis.Clie
 	notifPrefRepo := infra.NewNotificationPreferenceRepository(db)
 	notifPrefStore := notifService.NewPreferenceStore(notifPrefRepo)
 
+	// Initialize token usage service
+	tokenUsageRepo := infra.NewTokenUsageRepository(db)
+	tokenUsageSvc := tokenusagesvc.NewService(tokenUsageRepo, slog.Default())
+
 	return &serviceContainer{
 		auth:               authSvc,
 		user:               userSvc,
@@ -230,6 +236,7 @@ func initializeServices(cfg *config.Config, db *gorm.DB, redisClient *redis.Clie
 		sso:                ssoSvc,
 		supportTicket:      supportTicketSvc,
 		notifPrefStore:     notifPrefStore,
+		tokenUsage:         tokenUsageSvc,
 		podRepo:            podRepo,
 		runnerRepo:         runnerRepo,
 		autopilotRepo:      autopilotRepo,

--- a/backend/internal/api/grpc/runner_adapter_message.go
+++ b/backend/internal/api/grpc/runner_adapter_message.go
@@ -120,6 +120,10 @@ func (a *GRPCRunnerAdapter) handleProtoMessage(ctx context.Context, runnerID int
 	case *runnerv1.RunnerMessage_LogUploadStatus:
 		a.connManager.HandleLogUploadStatus(runnerID, payload.LogUploadStatus)
 
+	case *runnerv1.RunnerMessage_TokenUsage:
+		// Token usage report from Runner (sent when pod exits)
+		a.connManager.HandleTokenUsage(runnerID, payload.TokenUsage)
+
 	default:
 		a.logger.Warn("unknown message type", "runner_id", runnerID)
 	}

--- a/backend/internal/api/rest/v1/routes.go
+++ b/backend/internal/api/rest/v1/routes.go
@@ -89,6 +89,9 @@ func RegisterOrgScopedRoutes(rg *gin.RouterGroup, svc *Services) {
 
 	// Register notification preference routes
 	registerNotificationRoutes(rg, svc)
+
+	// Register token usage routes
+	registerTokenUsageRoutes(rg, svc)
 }
 
 func registerAgentRoutes(rg *gin.RouterGroup, svc *Services) {
@@ -442,4 +445,11 @@ func registerNotificationRoutes(rg *gin.RouterGroup, svc *Services) {
 		notifications.GET("/preferences", handler.GetPreferences)
 		notifications.PUT("/preferences", handler.SetPreference)
 	}
+}
+
+func registerTokenUsageRoutes(rg *gin.RouterGroup, svc *Services) {
+	if svc.TokenUsage == nil {
+		return
+	}
+	RegisterTokenUsageRoutes(rg, svc.TokenUsage)
 }

--- a/backend/internal/api/rest/v1/routes_types.go
+++ b/backend/internal/api/rest/v1/routes_types.go
@@ -30,6 +30,7 @@ import (
 	runnerlogservice "github.com/anthropics/agentsmesh/backend/internal/service/runnerlog"
 	supportticketservice "github.com/anthropics/agentsmesh/backend/internal/service/supportticket"
 	"github.com/anthropics/agentsmesh/backend/internal/service/ticket"
+	tokenusagesvc "github.com/anthropics/agentsmesh/backend/internal/service/tokenusage"
 	"github.com/anthropics/agentsmesh/backend/internal/service/user"
 )
 
@@ -119,4 +120,7 @@ type Services struct {
 
 	// Notification preference store
 	NotificationPrefStore *notifService.PreferenceStore
+
+	// Token usage service
+	TokenUsage *tokenusagesvc.Service
 }

--- a/backend/internal/api/rest/v1/token_usage.go
+++ b/backend/internal/api/rest/v1/token_usage.go
@@ -1,0 +1,175 @@
+package v1
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/anthropics/agentsmesh/backend/internal/domain/tokenusage"
+	"github.com/anthropics/agentsmesh/backend/internal/middleware"
+	tokenusagesvc "github.com/anthropics/agentsmesh/backend/internal/service/tokenusage"
+	"github.com/anthropics/agentsmesh/backend/pkg/apierr"
+	"github.com/gin-gonic/gin"
+	"golang.org/x/sync/errgroup"
+)
+
+// validGranularities defines allowed granularity values.
+var validGranularities = map[string]bool{
+	"day":   true,
+	"week":  true,
+	"month": true,
+}
+
+// TokenUsageHandler handles token usage HTTP requests.
+type TokenUsageHandler struct {
+	svc *tokenusagesvc.Service
+}
+
+// NewTokenUsageHandler creates a new token usage handler.
+func NewTokenUsageHandler(svc *tokenusagesvc.Service) *TokenUsageHandler {
+	return &TokenUsageHandler{svc: svc}
+}
+
+// GetDashboard returns all token usage data in a single response.
+// The 5 queries run concurrently via errgroup for lower latency.
+// GET /token-usage/dashboard?start_time=&end_time=&agent_type=&user_id=&model=&granularity=
+func (h *TokenUsageHandler) GetDashboard(c *gin.Context) {
+	tenant := c.MustGet("tenant").(*middleware.TenantContext)
+	if !isAdminOrOwner(tenant) {
+		apierr.ForbiddenAdmin(c)
+		return
+	}
+
+	filter, err := parseFilter(c)
+	if err != nil {
+		apierr.AbortBadRequest(c, "VALIDATION_FAILED", err.Error())
+		return
+	}
+
+	orgID := tenant.OrganizationID
+	ctx := c.Request.Context()
+
+	var (
+		summary    *tokenusage.UsageSummary
+		timeSeries []tokenusage.TimeSeriesPoint
+		byAgent    []tokenusage.AgentUsage
+		byUser     []tokenusage.UserUsage
+		byModel    []tokenusage.ModelUsage
+	)
+
+	g, gCtx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		var err error
+		summary, err = h.svc.GetSummary(gCtx, orgID, filter)
+		return err
+	})
+	g.Go(func() error {
+		var err error
+		timeSeries, err = h.svc.GetTimeSeries(gCtx, orgID, filter)
+		return err
+	})
+	g.Go(func() error {
+		var err error
+		byAgent, err = h.svc.GetByAgent(gCtx, orgID, filter)
+		return err
+	})
+	g.Go(func() error {
+		var err error
+		byUser, err = h.svc.GetByUser(gCtx, orgID, filter)
+		return err
+	})
+	g.Go(func() error {
+		var err error
+		byModel, err = h.svc.GetByModel(gCtx, orgID, filter)
+		return err
+	})
+
+	if err := g.Wait(); err != nil {
+		slog.Error("failed to get token usage dashboard", "org_id", orgID, "error", err)
+		apierr.InternalError(c, "failed to retrieve token usage data")
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"summary":     summary,
+		"time_series": timeSeries,
+		"by_agent":    byAgent,
+		"by_user":     byUser,
+		"by_model":    byModel,
+	})
+}
+
+// RegisterTokenUsageRoutes registers token usage routes on the given group.
+func RegisterTokenUsageRoutes(rg *gin.RouterGroup, svc *tokenusagesvc.Service) {
+	handler := NewTokenUsageHandler(svc)
+	group := rg.Group("/token-usage")
+	{
+		group.GET("/dashboard", handler.GetDashboard)
+	}
+}
+
+// isAdminOrOwner checks if the tenant has owner or admin role.
+func isAdminOrOwner(tenant *middleware.TenantContext) bool {
+	return tenant.UserRole == "owner" || tenant.UserRole == "admin"
+}
+
+// parseFilter extracts AggregationFilter from query parameters.
+func parseFilter(c *gin.Context) (tokenusage.AggregationFilter, error) {
+	var filter tokenusage.AggregationFilter
+
+	// Default to last 30 days
+	filter.EndTime = time.Now()
+	filter.StartTime = filter.EndTime.AddDate(0, 0, -30)
+
+	if s := c.Query("start_time"); s != "" {
+		t, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			return filter, err
+		}
+		filter.StartTime = t
+	}
+	if s := c.Query("end_time"); s != "" {
+		t, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			return filter, err
+		}
+		filter.EndTime = t
+	}
+
+	if filter.StartTime.After(filter.EndTime) {
+		return filter, fmt.Errorf("start_time must be before end_time")
+	}
+
+	// Cap date range to prevent expensive aggregation queries (max 1 year).
+	const maxDateRange = 366 * 24 * time.Hour
+	if filter.EndTime.Sub(filter.StartTime) > maxDateRange {
+		return filter, fmt.Errorf("date range cannot exceed 366 days")
+	}
+
+	if s := c.Query("granularity"); s != "" {
+		if !validGranularities[s] {
+			return filter, fmt.Errorf("invalid granularity %q, must be one of: day, week, month", s)
+		}
+		filter.Granularity = s
+	} else {
+		filter.Granularity = "day"
+	}
+
+	if s := c.Query("agent_type"); s != "" {
+		filter.AgentTypeSlug = &s
+	}
+	if s := c.Query("user_id"); s != "" {
+		id, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return filter, err
+		}
+		filter.UserID = &id
+	}
+	if s := c.Query("model"); s != "" {
+		filter.Model = &s
+	}
+
+	return filter, nil
+}

--- a/backend/internal/api/rest/v1/token_usage_test.go
+++ b/backend/internal/api/rest/v1/token_usage_test.go
@@ -1,0 +1,176 @@
+package v1
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestContext creates a gin.Context with the given query string for testing.
+func newTestContext(query string) *gin.Context {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/token-usage/dashboard?"+query, nil)
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+	return c
+}
+
+// --- validGranularities ---
+
+func TestValidGranularities(t *testing.T) {
+	assert.True(t, validGranularities["day"])
+	assert.True(t, validGranularities["week"])
+	assert.True(t, validGranularities["month"])
+	assert.False(t, validGranularities["second"])
+	assert.False(t, validGranularities["year"])
+	assert.False(t, validGranularities[""])
+}
+
+// --- isAdminOrOwner ---
+
+func TestIsAdminOrOwner(t *testing.T) {
+	tests := []struct {
+		role     string
+		expected bool
+	}{
+		{"owner", true},
+		{"admin", true},
+		{"member", false},
+		{"viewer", false},
+		{"", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.role, func(t *testing.T) {
+			result := tc.role == "owner" || tc.role == "admin"
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+// --- parseFilter ---
+
+func TestParseFilter_Defaults(t *testing.T) {
+	c := newTestContext("")
+	filter, err := parseFilter(c)
+	require.NoError(t, err)
+
+	assert.Equal(t, "day", filter.Granularity)
+	assert.Nil(t, filter.AgentTypeSlug)
+	assert.Nil(t, filter.UserID)
+	assert.Nil(t, filter.Model)
+	// Default range: last 30 days.
+	assert.WithinDuration(t, time.Now().AddDate(0, 0, -30), filter.StartTime, 5*time.Second)
+	assert.WithinDuration(t, time.Now(), filter.EndTime, 5*time.Second)
+}
+
+func TestParseFilter_ValidGranularities(t *testing.T) {
+	for _, g := range []string{"day", "week", "month"} {
+		t.Run(g, func(t *testing.T) {
+			c := newTestContext("granularity=" + g)
+			filter, err := parseFilter(c)
+			require.NoError(t, err)
+			assert.Equal(t, g, filter.Granularity)
+		})
+	}
+}
+
+func TestParseFilter_InvalidGranularity(t *testing.T) {
+	for _, g := range []string{"hour", "second", "year", "invalid"} {
+		t.Run(g, func(t *testing.T) {
+			c := newTestContext("granularity=" + g)
+			_, err := parseFilter(c)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid granularity")
+		})
+	}
+}
+
+func TestParseFilter_ValidTimeRange(t *testing.T) {
+	start := "2025-01-01T00:00:00Z"
+	end := "2025-01-15T00:00:00Z"
+	c := newTestContext("start_time=" + start + "&end_time=" + end)
+	filter, err := parseFilter(c)
+	require.NoError(t, err)
+
+	expectedStart, _ := time.Parse(time.RFC3339, start)
+	expectedEnd, _ := time.Parse(time.RFC3339, end)
+	assert.True(t, filter.StartTime.Equal(expectedStart))
+	assert.True(t, filter.EndTime.Equal(expectedEnd))
+}
+
+func TestParseFilter_StartAfterEnd(t *testing.T) {
+	c := newTestContext("start_time=2025-06-01T00:00:00Z&end_time=2025-01-01T00:00:00Z")
+	_, err := parseFilter(c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "start_time must be before end_time")
+}
+
+func TestParseFilter_DateRangeExceeds366Days(t *testing.T) {
+	c := newTestContext("start_time=2024-01-01T00:00:00Z&end_time=2025-06-01T00:00:00Z")
+	_, err := parseFilter(c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "366 days")
+}
+
+func TestParseFilter_InvalidDateFormat(t *testing.T) {
+	c := newTestContext("start_time=not-a-date")
+	_, err := parseFilter(c)
+	require.Error(t, err)
+
+	c = newTestContext("end_time=2025/01/01")
+	_, err = parseFilter(c)
+	require.Error(t, err)
+}
+
+func TestParseFilter_OptionalFilters(t *testing.T) {
+	c := newTestContext("agent_type=claude&user_id=42&model=opus")
+	filter, err := parseFilter(c)
+	require.NoError(t, err)
+
+	require.NotNil(t, filter.AgentTypeSlug)
+	assert.Equal(t, "claude", *filter.AgentTypeSlug)
+	require.NotNil(t, filter.UserID)
+	assert.Equal(t, int64(42), *filter.UserID)
+	require.NotNil(t, filter.Model)
+	assert.Equal(t, "opus", *filter.Model)
+}
+
+func TestParseFilter_InvalidUserID(t *testing.T) {
+	c := newTestContext("user_id=abc")
+	_, err := parseFilter(c)
+	require.Error(t, err)
+}
+
+func TestParseFilter_DateRangeExactly366Days(t *testing.T) {
+	now := time.Now().UTC()
+
+	// 367-day range must be rejected.
+	start367 := now.AddDate(0, 0, -367)
+	c := newTestContext("start_time=" + start367.Format(time.RFC3339) + "&end_time=" + now.Format(time.RFC3339))
+	_, err := parseFilter(c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "366 days")
+
+	// 365-day range must be accepted.
+	start365 := now.AddDate(0, 0, -365)
+	c2 := newTestContext("start_time=" + start365.Format(time.RFC3339) + "&end_time=" + now.Format(time.RFC3339))
+	_, err2 := parseFilter(c2)
+	require.NoError(t, err2)
+}
+
+func TestParseFilter_OnlyAgentType(t *testing.T) {
+	// Long agent_type slug — accepted by parseFilter (validation is elsewhere).
+	slug := strings.Repeat("a", 100)
+	c := newTestContext("agent_type=" + slug)
+	filter, err := parseFilter(c)
+	require.NoError(t, err)
+	require.NotNil(t, filter.AgentTypeSlug)
+	assert.Equal(t, slug, *filter.AgentTypeSlug)
+}

--- a/backend/internal/domain/organization/organization.go
+++ b/backend/internal/domain/organization/organization.go
@@ -28,6 +28,10 @@ type Organization struct {
 	CreatedAt time.Time `gorm:"not null;default:now()" json:"created_at"`
 	UpdatedAt time.Time `gorm:"not null;default:now()" json:"updated_at"`
 
+	// Role is populated by ListByUser to indicate the requesting user's role.
+	// Not a DB column — filled via raw scan in the repo query.
+	Role string `gorm:"->" json:"role,omitempty"`
+
 	// Associations
 	Members []Member `gorm:"foreignKey:OrganizationID" json:"members,omitempty"`
 }

--- a/backend/internal/domain/tokenusage/repository.go
+++ b/backend/internal/domain/tokenusage/repository.go
@@ -1,0 +1,14 @@
+package tokenusage
+
+import "context"
+
+// Repository defines the data-access contract for token usage records.
+type Repository interface {
+	Create(ctx context.Context, record *TokenUsage) error
+	CreateBatch(ctx context.Context, records []*TokenUsage) error
+	GetSummary(ctx context.Context, orgID int64, filter AggregationFilter) (*UsageSummary, error)
+	GetTimeSeries(ctx context.Context, orgID int64, filter AggregationFilter) ([]TimeSeriesPoint, error)
+	GetByAgent(ctx context.Context, orgID int64, filter AggregationFilter) ([]AgentUsage, error)
+	GetByUser(ctx context.Context, orgID int64, filter AggregationFilter) ([]UserUsage, error)
+	GetByModel(ctx context.Context, orgID int64, filter AggregationFilter) ([]ModelUsage, error)
+}

--- a/backend/internal/domain/tokenusage/token_usage.go
+++ b/backend/internal/domain/tokenusage/token_usage.go
@@ -1,0 +1,85 @@
+package tokenusage
+
+import "time"
+
+// TokenUsage represents a single model's token consumption within a pod session.
+type TokenUsage struct {
+	ID                  int64      `gorm:"primaryKey" json:"id"`
+	OrganizationID      int64      `gorm:"not null" json:"organization_id"`
+	PodID               *int64     `json:"pod_id"`
+	PodKey              string     `gorm:"size:100;not null" json:"pod_key"`
+	UserID              *int64     `json:"user_id"`
+	RunnerID            *int64     `json:"runner_id"`
+	AgentTypeSlug       string     `gorm:"size:50;not null" json:"agent_type_slug"`
+	Model               string     `gorm:"size:100" json:"model"`
+	InputTokens         int64      `gorm:"not null;default:0" json:"input_tokens"`
+	OutputTokens        int64      `gorm:"not null;default:0" json:"output_tokens"`
+	CacheCreationTokens int64      `gorm:"not null;default:0" json:"cache_creation_tokens"`
+	CacheReadTokens     int64      `gorm:"not null;default:0" json:"cache_read_tokens"`
+	SessionStartedAt    *time.Time `json:"session_started_at,omitempty"`
+	SessionEndedAt      *time.Time `json:"session_ended_at,omitempty"`
+	CreatedAt           time.Time  `gorm:"not null" json:"created_at"`
+}
+
+func (TokenUsage) TableName() string { return "token_usages" }
+
+// AggregationFilter defines query parameters for token usage aggregation.
+type AggregationFilter struct {
+	StartTime     time.Time
+	EndTime       time.Time
+	AgentTypeSlug *string
+	UserID        *int64
+	Model         *string
+	Granularity   string // "day", "week", "month"
+	Limit         int    // Max rows for grouped queries (0 = default 100)
+}
+
+// UsageSummary holds aggregated totals.
+type UsageSummary struct {
+	InputTokens         int64 `json:"input_tokens"`
+	OutputTokens        int64 `json:"output_tokens"`
+	CacheCreationTokens int64 `json:"cache_creation_tokens"`
+	CacheReadTokens     int64 `json:"cache_read_tokens"`
+	TotalTokens         int64 `json:"total_tokens"`
+}
+
+// TimeSeriesPoint holds aggregated totals for a single time period.
+type TimeSeriesPoint struct {
+	Period              time.Time `json:"period"`
+	InputTokens         int64     `json:"input_tokens"`
+	OutputTokens        int64     `json:"output_tokens"`
+	CacheCreationTokens int64     `json:"cache_creation_tokens"`
+	CacheReadTokens     int64     `json:"cache_read_tokens"`
+}
+
+// AgentUsage holds aggregated totals for a single agent type.
+type AgentUsage struct {
+	AgentTypeSlug       string `json:"agent_type"`
+	InputTokens         int64  `json:"input_tokens"`
+	OutputTokens        int64  `json:"output_tokens"`
+	CacheCreationTokens int64  `json:"cache_creation_tokens"`
+	CacheReadTokens     int64  `json:"cache_read_tokens"`
+	TotalTokens         int64  `json:"total_tokens"`
+}
+
+// UserUsage holds aggregated totals for a single user.
+type UserUsage struct {
+	UserID              int64  `json:"user_id"`
+	Username            string `json:"username"`
+	Email               string `json:"email"`
+	InputTokens         int64  `json:"input_tokens"`
+	OutputTokens        int64  `json:"output_tokens"`
+	CacheCreationTokens int64  `json:"cache_creation_tokens"`
+	CacheReadTokens     int64  `json:"cache_read_tokens"`
+	TotalTokens         int64  `json:"total_tokens"`
+}
+
+// ModelUsage holds aggregated totals for a single model.
+type ModelUsage struct {
+	Model               string `json:"model"`
+	InputTokens         int64  `json:"input_tokens"`
+	OutputTokens        int64  `json:"output_tokens"`
+	CacheCreationTokens int64  `json:"cache_creation_tokens"`
+	CacheReadTokens     int64  `json:"cache_read_tokens"`
+	TotalTokens         int64  `json:"total_tokens"`
+}

--- a/backend/internal/infra/organization_repo.go
+++ b/backend/internal/infra/organization_repo.go
@@ -57,6 +57,7 @@ func (r *organizationRepo) Update(ctx context.Context, id int64, updates map[str
 func (r *organizationRepo) ListByUser(ctx context.Context, userID int64) ([]*organization.Organization, error) {
 	var orgs []*organization.Organization
 	err := r.db.WithContext(ctx).
+		Select("organizations.*, organization_members.role AS role").
 		Joins("JOIN organization_members ON organization_members.organization_id = organizations.id").
 		Where("organization_members.user_id = ?", userID).
 		Find(&orgs).Error

--- a/backend/internal/infra/token_usage_repo.go
+++ b/backend/internal/infra/token_usage_repo.go
@@ -1,0 +1,164 @@
+package infra
+
+import (
+	"context"
+
+	"github.com/anthropics/agentsmesh/backend/internal/domain/tokenusage"
+	"gorm.io/gorm"
+)
+
+// Compile-time interface check.
+var _ tokenusage.Repository = (*tokenUsageRepository)(nil)
+
+type tokenUsageRepository struct {
+	db *gorm.DB
+}
+
+// NewTokenUsageRepository creates a new TokenUsageRepository backed by GORM.
+func NewTokenUsageRepository(db *gorm.DB) tokenusage.Repository {
+	return &tokenUsageRepository{db: db}
+}
+
+func (r *tokenUsageRepository) Create(ctx context.Context, record *tokenusage.TokenUsage) error {
+	return r.db.WithContext(ctx).Create(record).Error
+}
+
+func (r *tokenUsageRepository) CreateBatch(ctx context.Context, records []*tokenusage.TokenUsage) error {
+	if len(records) == 0 {
+		return nil
+	}
+	return r.db.WithContext(ctx).Create(records).Error
+}
+
+func (r *tokenUsageRepository) GetSummary(ctx context.Context, orgID int64, f tokenusage.AggregationFilter) (*tokenusage.UsageSummary, error) {
+	var result tokenusage.UsageSummary
+	q := r.db.WithContext(ctx).Model(&tokenusage.TokenUsage{}).
+		Select(`COALESCE(SUM(input_tokens),0) as input_tokens,
+			COALESCE(SUM(output_tokens),0) as output_tokens,
+			COALESCE(SUM(cache_creation_tokens),0) as cache_creation_tokens,
+			COALESCE(SUM(cache_read_tokens),0) as cache_read_tokens,
+			COALESCE(SUM(input_tokens + output_tokens + cache_creation_tokens + cache_read_tokens),0) as total_tokens`).
+		Where("organization_id = ? AND created_at >= ? AND created_at < ?", orgID, f.StartTime, f.EndTime)
+	q = applyOptionalFilters(q, f, false)
+	// Single-row aggregation — LIMIT 1 as a safety net.
+	if err := q.Limit(1).Scan(&result).Error; err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (r *tokenUsageRepository) GetTimeSeries(ctx context.Context, orgID int64, f tokenusage.AggregationFilter) ([]tokenusage.TimeSeriesPoint, error) {
+	granularity := validGranularity(f.Granularity)
+	var results []tokenusage.TimeSeriesPoint
+	q := r.db.WithContext(ctx).Model(&tokenusage.TokenUsage{}).
+		Select("date_trunc(?, created_at) as period, SUM(input_tokens) as input_tokens, SUM(output_tokens) as output_tokens, SUM(cache_creation_tokens) as cache_creation_tokens, SUM(cache_read_tokens) as cache_read_tokens", granularity).
+		Where("organization_id = ? AND created_at >= ? AND created_at < ?", orgID, f.StartTime, f.EndTime).
+		Group("period").
+		Order("period").
+		Limit(1000) // Cap time series data points to prevent DoS on extreme date ranges.
+	q = applyOptionalFilters(q, f, false)
+	if err := q.Scan(&results).Error; err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (r *tokenUsageRepository) GetByAgent(ctx context.Context, orgID int64, f tokenusage.AggregationFilter) ([]tokenusage.AgentUsage, error) {
+	var results []tokenusage.AgentUsage
+	q := r.db.WithContext(ctx).Model(&tokenusage.TokenUsage{}).
+		Select(`agent_type_slug,
+			SUM(input_tokens) as input_tokens,
+			SUM(output_tokens) as output_tokens,
+			SUM(cache_creation_tokens) as cache_creation_tokens,
+			SUM(cache_read_tokens) as cache_read_tokens,
+			SUM(input_tokens + output_tokens + cache_creation_tokens + cache_read_tokens) as total_tokens`).
+		Where("organization_id = ? AND created_at >= ? AND created_at < ?", orgID, f.StartTime, f.EndTime).
+		Group("agent_type_slug").
+		Order("total_tokens DESC").
+		Limit(effectiveLimit(f.Limit))
+	q = applyOptionalFilters(q, f, false)
+	if err := q.Scan(&results).Error; err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (r *tokenUsageRepository) GetByUser(ctx context.Context, orgID int64, f tokenusage.AggregationFilter) ([]tokenusage.UserUsage, error) {
+	var results []tokenusage.UserUsage
+	q := r.db.WithContext(ctx).Model(&tokenusage.TokenUsage{}).
+		Select(`token_usages.user_id,
+			COALESCE(u.name, u.username, 'unknown') as username,
+			COALESCE(u.email, '') as email,
+			SUM(token_usages.input_tokens) as input_tokens,
+			SUM(token_usages.output_tokens) as output_tokens,
+			SUM(token_usages.cache_creation_tokens) as cache_creation_tokens,
+			SUM(token_usages.cache_read_tokens) as cache_read_tokens,
+			SUM(token_usages.input_tokens + token_usages.output_tokens + token_usages.cache_creation_tokens + token_usages.cache_read_tokens) as total_tokens`).
+		Joins("LEFT JOIN users u ON u.id = token_usages.user_id").
+		Where("token_usages.organization_id = ? AND token_usages.created_at >= ? AND token_usages.created_at < ?", orgID, f.StartTime, f.EndTime).
+		Group("token_usages.user_id, u.name, u.username, u.email").
+		Order("total_tokens DESC").
+		Limit(effectiveLimit(f.Limit))
+	q = applyOptionalFilters(q, f, true)
+	if err := q.Scan(&results).Error; err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (r *tokenUsageRepository) GetByModel(ctx context.Context, orgID int64, f tokenusage.AggregationFilter) ([]tokenusage.ModelUsage, error) {
+	var results []tokenusage.ModelUsage
+	q := r.db.WithContext(ctx).Model(&tokenusage.TokenUsage{}).
+		Select(`model,
+			SUM(input_tokens) as input_tokens,
+			SUM(output_tokens) as output_tokens,
+			SUM(cache_creation_tokens) as cache_creation_tokens,
+			SUM(cache_read_tokens) as cache_read_tokens,
+			SUM(input_tokens + output_tokens + cache_creation_tokens + cache_read_tokens) as total_tokens`).
+		Where("organization_id = ? AND created_at >= ? AND created_at < ?", orgID, f.StartTime, f.EndTime).
+		Group("model").
+		Order("total_tokens DESC").
+		Limit(effectiveLimit(f.Limit))
+	q = applyOptionalFilters(q, f, false)
+	if err := q.Scan(&results).Error; err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+// validGranularity returns a safe granularity value (whitelist).
+func validGranularity(g string) string {
+	switch g {
+	case "day", "week", "month":
+		return g
+	default:
+		return "day"
+	}
+}
+
+// applyOptionalFilters applies optional WHERE clauses for agent type, user, and model.
+// When qualified is true, column names are prefixed with "token_usages." for JOIN queries.
+func applyOptionalFilters(q *gorm.DB, f tokenusage.AggregationFilter, qualified bool) *gorm.DB {
+	prefix := ""
+	if qualified {
+		prefix = "token_usages."
+	}
+	if f.AgentTypeSlug != nil {
+		q = q.Where(prefix+"agent_type_slug = ?", *f.AgentTypeSlug)
+	}
+	if f.UserID != nil {
+		q = q.Where(prefix+"user_id = ?", *f.UserID)
+	}
+	if f.Model != nil {
+		q = q.Where(prefix+"model = ?", *f.Model)
+	}
+	return q
+}
+
+// effectiveLimit returns the limit to use, defaulting to 100 if not set.
+func effectiveLimit(limit int) int {
+	if limit > 0 {
+		return limit
+	}
+	return 100
+}

--- a/backend/internal/infra/token_usage_repo_test.go
+++ b/backend/internal/infra/token_usage_repo_test.go
@@ -1,0 +1,533 @@
+package infra
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/anthropics/agentsmesh/backend/internal/domain/tokenusage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// setupTokenUsageTestDB creates an in-memory SQLite database with the token_usages table.
+func setupTokenUsageTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		DisableForeignKeyConstraintWhenMigrating: true,
+		Logger:                                   logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+
+	err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS token_usages (
+			id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+			organization_id       INTEGER NOT NULL,
+			pod_id                INTEGER,
+			pod_key               TEXT NOT NULL,
+			user_id               INTEGER NOT NULL,
+			runner_id             INTEGER NOT NULL,
+			agent_type_slug       TEXT NOT NULL,
+			model                 TEXT,
+			input_tokens          INTEGER NOT NULL DEFAULT 0,
+			output_tokens         INTEGER NOT NULL DEFAULT 0,
+			cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+			cache_read_tokens     INTEGER NOT NULL DEFAULT 0,
+			session_started_at    DATETIME,
+			session_ended_at      DATETIME,
+			created_at            DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)
+	`).Error
+	require.NoError(t, err)
+
+	// Minimal users table for GetByUser JOIN.
+	err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS users (
+			id       INTEGER PRIMARY KEY AUTOINCREMENT,
+			name     TEXT,
+			username TEXT,
+			email    TEXT
+		)
+	`).Error
+	require.NoError(t, err)
+
+	return db
+}
+
+// seedUsers inserts test users for JOIN tests.
+func seedUsers(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	require.NoError(t, db.Exec(`INSERT INTO users (id, name, username, email) VALUES (1, 'Alice', 'alice', 'alice@test.com')`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users (id, name, username, email) VALUES (2, 'Bob', 'bob', 'bob@test.com')`).Error)
+}
+
+func int64Ptr(v int64) *int64 { return &v }
+
+func newTestRecord(orgID, userID, runnerID int64, agentType, model string, input, output int64, createdAt time.Time) *tokenusage.TokenUsage {
+	return &tokenusage.TokenUsage{
+		OrganizationID: orgID,
+		PodKey:         "pod-test",
+		UserID:         int64Ptr(userID),
+		RunnerID:       int64Ptr(runnerID),
+		AgentTypeSlug:  agentType,
+		Model:          model,
+		InputTokens:    input,
+		OutputTokens:   output,
+		CreatedAt:      createdAt,
+	}
+}
+
+// --- Create / CreateBatch ---
+
+func TestTokenUsageRepo_Create(t *testing.T) {
+	db := setupTokenUsageTestDB(t)
+	repo := NewTokenUsageRepository(db)
+	ctx := context.Background()
+
+	record := newTestRecord(1, 10, 20, "claude", "opus", 100, 50, time.Now())
+	require.NoError(t, repo.Create(ctx, record))
+	assert.NotZero(t, record.ID)
+}
+
+func TestTokenUsageRepo_CreateBatch(t *testing.T) {
+	db := setupTokenUsageTestDB(t)
+	repo := NewTokenUsageRepository(db)
+	ctx := context.Background()
+
+	t.Run("inserts multiple records", func(t *testing.T) {
+		now := time.Now()
+		records := []*tokenusage.TokenUsage{
+			newTestRecord(1, 10, 20, "claude", "opus", 100, 50, now),
+			newTestRecord(1, 10, 20, "claude", "sonnet", 200, 100, now),
+		}
+		require.NoError(t, repo.CreateBatch(ctx, records))
+		assert.NotZero(t, records[0].ID)
+		assert.NotZero(t, records[1].ID)
+	})
+
+	t.Run("empty slice is no-op", func(t *testing.T) {
+		require.NoError(t, repo.CreateBatch(ctx, nil))
+		require.NoError(t, repo.CreateBatch(ctx, []*tokenusage.TokenUsage{}))
+	})
+}
+
+// --- GetSummary ---
+
+func TestTokenUsageRepo_GetSummary(t *testing.T) {
+	db := setupTokenUsageTestDB(t)
+	repo := NewTokenUsageRepository(db)
+	ctx := context.Background()
+
+	now := time.Now()
+	yesterday := now.Add(-24 * time.Hour)
+	lastWeek := now.Add(-7 * 24 * time.Hour)
+
+	// Seed data: two records within range, one outside.
+	require.NoError(t, repo.Create(ctx, &tokenusage.TokenUsage{
+		OrganizationID: 1, PodKey: "p1", UserID: int64Ptr(1), RunnerID: int64Ptr(1),
+		AgentTypeSlug: "claude", Model: "opus",
+		InputTokens: 100, OutputTokens: 50, CacheCreationTokens: 10, CacheReadTokens: 5,
+		CreatedAt: yesterday,
+	}))
+	require.NoError(t, repo.Create(ctx, &tokenusage.TokenUsage{
+		OrganizationID: 1, PodKey: "p2", UserID: int64Ptr(2), RunnerID: int64Ptr(1),
+		AgentTypeSlug: "aider", Model: "gpt4",
+		InputTokens: 200, OutputTokens: 100, CacheCreationTokens: 20, CacheReadTokens: 10,
+		CreatedAt: yesterday,
+	}))
+	// Outside range.
+	require.NoError(t, repo.Create(ctx, &tokenusage.TokenUsage{
+		OrganizationID: 1, PodKey: "p3", UserID: int64Ptr(1), RunnerID: int64Ptr(1),
+		AgentTypeSlug: "claude", Model: "opus",
+		InputTokens: 9999, OutputTokens: 9999,
+		CreatedAt: lastWeek.Add(-24 * time.Hour),
+	}))
+	// Different org.
+	require.NoError(t, repo.Create(ctx, &tokenusage.TokenUsage{
+		OrganizationID: 99, PodKey: "p4", UserID: int64Ptr(1), RunnerID: int64Ptr(1),
+		AgentTypeSlug: "claude", Model: "opus",
+		InputTokens: 8888, OutputTokens: 8888,
+		CreatedAt: yesterday,
+	}))
+
+	filter := tokenusage.AggregationFilter{
+		StartTime: lastWeek,
+		EndTime:   now.Add(time.Hour),
+	}
+
+	t.Run("aggregates within range for org", func(t *testing.T) {
+		result, err := repo.GetSummary(ctx, 1, filter)
+		require.NoError(t, err)
+		assert.Equal(t, int64(300), result.InputTokens)
+		assert.Equal(t, int64(150), result.OutputTokens)
+		assert.Equal(t, int64(30), result.CacheCreationTokens)
+		assert.Equal(t, int64(15), result.CacheReadTokens)
+		assert.Equal(t, int64(495), result.TotalTokens)
+	})
+
+	t.Run("filters by agent_type", func(t *testing.T) {
+		agent := "claude"
+		f := filter
+		f.AgentTypeSlug = &agent
+		result, err := repo.GetSummary(ctx, 1, f)
+		require.NoError(t, err)
+		assert.Equal(t, int64(100), result.InputTokens)
+	})
+
+	t.Run("filters by user_id", func(t *testing.T) {
+		uid := int64(2)
+		f := filter
+		f.UserID = &uid
+		result, err := repo.GetSummary(ctx, 1, f)
+		require.NoError(t, err)
+		assert.Equal(t, int64(200), result.InputTokens)
+	})
+
+	t.Run("filters by model", func(t *testing.T) {
+		model := "gpt4"
+		f := filter
+		f.Model = &model
+		result, err := repo.GetSummary(ctx, 1, f)
+		require.NoError(t, err)
+		assert.Equal(t, int64(200), result.InputTokens)
+	})
+
+	t.Run("empty result returns zeros", func(t *testing.T) {
+		result, err := repo.GetSummary(ctx, 999, filter)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), result.InputTokens)
+		assert.Equal(t, int64(0), result.TotalTokens)
+	})
+}
+
+// --- GetTimeSeries ---
+
+func TestTokenUsageRepo_GetTimeSeries(t *testing.T) {
+	db := setupTokenUsageTestDB(t)
+	repo := NewTokenUsageRepository(db)
+	ctx := context.Background()
+
+	// SQLite does not have date_trunc; it uses strftime. Skip if SQLite cannot handle it.
+	// We test the code path rather than exact SQL compatibility.
+	day1 := time.Date(2025, 1, 10, 12, 0, 0, 0, time.UTC)
+	day2 := time.Date(2025, 1, 11, 14, 0, 0, 0, time.UTC)
+
+	require.NoError(t, repo.Create(ctx, &tokenusage.TokenUsage{
+		OrganizationID: 1, PodKey: "p1", UserID: int64Ptr(1), RunnerID: int64Ptr(1),
+		AgentTypeSlug: "claude", Model: "opus",
+		InputTokens: 100, OutputTokens: 50,
+		CreatedAt: day1,
+	}))
+	require.NoError(t, repo.Create(ctx, &tokenusage.TokenUsage{
+		OrganizationID: 1, PodKey: "p2", UserID: int64Ptr(1), RunnerID: int64Ptr(1),
+		AgentTypeSlug: "claude", Model: "opus",
+		InputTokens: 200, OutputTokens: 100,
+		CreatedAt: day2,
+	}))
+
+	filter := tokenusage.AggregationFilter{
+		StartTime:   day1.Add(-time.Hour),
+		EndTime:     day2.Add(time.Hour),
+		Granularity: "day",
+	}
+
+	// date_trunc is PostgreSQL-specific; SQLite will error.
+	// This validates the code path compiles and runs without panic.
+	_, err := repo.GetTimeSeries(ctx, 1, filter)
+	// Accept either success (PostgreSQL) or error (SQLite lacks date_trunc).
+	if err != nil {
+		assert.Contains(t, err.Error(), "date_trunc")
+	}
+}
+
+// --- GetByAgent ---
+
+func TestTokenUsageRepo_GetByAgent(t *testing.T) {
+	db := setupTokenUsageTestDB(t)
+	repo := NewTokenUsageRepository(db)
+	ctx := context.Background()
+
+	now := time.Now()
+	require.NoError(t, repo.Create(ctx, &tokenusage.TokenUsage{
+		OrganizationID: 1, PodKey: "p1", UserID: int64Ptr(1), RunnerID: int64Ptr(1),
+		AgentTypeSlug: "claude", Model: "opus",
+		InputTokens: 100, OutputTokens: 50,
+		CreatedAt: now,
+	}))
+	require.NoError(t, repo.Create(ctx, &tokenusage.TokenUsage{
+		OrganizationID: 1, PodKey: "p2", UserID: int64Ptr(1), RunnerID: int64Ptr(1),
+		AgentTypeSlug: "claude", Model: "sonnet",
+		InputTokens: 200, OutputTokens: 100,
+		CreatedAt: now,
+	}))
+	require.NoError(t, repo.Create(ctx, &tokenusage.TokenUsage{
+		OrganizationID: 1, PodKey: "p3", UserID: int64Ptr(2), RunnerID: int64Ptr(1),
+		AgentTypeSlug: "aider", Model: "gpt4",
+		InputTokens: 300, OutputTokens: 150,
+		CreatedAt: now,
+	}))
+
+	filter := tokenusage.AggregationFilter{
+		StartTime: now.Add(-time.Hour),
+		EndTime:   now.Add(time.Hour),
+	}
+
+	results, err := repo.GetByAgent(ctx, 1, filter)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	// Ordered by total_tokens DESC: claude (450) > aider (450) — order may vary.
+	agentMap := map[string]tokenusage.AgentUsage{}
+	for _, r := range results {
+		agentMap[r.AgentTypeSlug] = r
+	}
+	assert.Equal(t, int64(300), agentMap["claude"].InputTokens)
+	assert.Equal(t, int64(300), agentMap["aider"].InputTokens)
+}
+
+// --- GetByUser ---
+
+func TestTokenUsageRepo_GetByUser(t *testing.T) {
+	db := setupTokenUsageTestDB(t)
+	seedUsers(t, db)
+	repo := NewTokenUsageRepository(db)
+	ctx := context.Background()
+
+	now := time.Now()
+	require.NoError(t, repo.Create(ctx, &tokenusage.TokenUsage{
+		OrganizationID: 1, PodKey: "p1", UserID: int64Ptr(1), RunnerID: int64Ptr(1),
+		AgentTypeSlug: "claude", Model: "opus",
+		InputTokens: 100, OutputTokens: 50,
+		CreatedAt: now,
+	}))
+	require.NoError(t, repo.Create(ctx, &tokenusage.TokenUsage{
+		OrganizationID: 1, PodKey: "p2", UserID: int64Ptr(2), RunnerID: int64Ptr(1),
+		AgentTypeSlug: "aider", Model: "gpt4",
+		InputTokens: 200, OutputTokens: 100,
+		CreatedAt: now,
+	}))
+
+	filter := tokenusage.AggregationFilter{
+		StartTime: now.Add(-time.Hour),
+		EndTime:   now.Add(time.Hour),
+	}
+
+	results, err := repo.GetByUser(ctx, 1, filter)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	userMap := map[int64]tokenusage.UserUsage{}
+	for _, r := range results {
+		userMap[r.UserID] = r
+	}
+	assert.Equal(t, int64(100), userMap[1].InputTokens)
+	assert.Equal(t, "Alice", userMap[1].Username)
+	assert.Equal(t, "alice@test.com", userMap[1].Email)
+	assert.Equal(t, int64(200), userMap[2].InputTokens)
+}
+
+// --- GetByModel ---
+
+func TestTokenUsageRepo_GetByModel(t *testing.T) {
+	db := setupTokenUsageTestDB(t)
+	repo := NewTokenUsageRepository(db)
+	ctx := context.Background()
+
+	now := time.Now()
+	require.NoError(t, repo.Create(ctx, &tokenusage.TokenUsage{
+		OrganizationID: 1, PodKey: "p1", UserID: int64Ptr(1), RunnerID: int64Ptr(1),
+		AgentTypeSlug: "claude", Model: "opus",
+		InputTokens: 100, OutputTokens: 50,
+		CreatedAt: now,
+	}))
+	require.NoError(t, repo.Create(ctx, &tokenusage.TokenUsage{
+		OrganizationID: 1, PodKey: "p2", UserID: int64Ptr(1), RunnerID: int64Ptr(1),
+		AgentTypeSlug: "claude", Model: "sonnet",
+		InputTokens: 200, OutputTokens: 100,
+		CreatedAt: now,
+	}))
+	require.NoError(t, repo.Create(ctx, &tokenusage.TokenUsage{
+		OrganizationID: 1, PodKey: "p3", UserID: int64Ptr(1), RunnerID: int64Ptr(1),
+		AgentTypeSlug: "claude", Model: "opus",
+		InputTokens: 50, OutputTokens: 25,
+		CreatedAt: now,
+	}))
+
+	filter := tokenusage.AggregationFilter{
+		StartTime: now.Add(-time.Hour),
+		EndTime:   now.Add(time.Hour),
+	}
+
+	results, err := repo.GetByModel(ctx, 1, filter)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	modelMap := map[string]tokenusage.ModelUsage{}
+	for _, r := range results {
+		modelMap[r.Model] = r
+	}
+	assert.Equal(t, int64(150), modelMap["opus"].InputTokens)
+	assert.Equal(t, int64(200), modelMap["sonnet"].InputTokens)
+}
+
+// --- Helper function tests ---
+
+func TestValidGranularity(t *testing.T) {
+	assert.Equal(t, "day", validGranularity("day"))
+	assert.Equal(t, "week", validGranularity("week"))
+	assert.Equal(t, "month", validGranularity("month"))
+	assert.Equal(t, "day", validGranularity(""))
+	assert.Equal(t, "day", validGranularity("hour"))
+	assert.Equal(t, "day", validGranularity("year"))
+}
+
+func TestEffectiveLimit(t *testing.T) {
+	assert.Equal(t, 100, effectiveLimit(0))
+	assert.Equal(t, 100, effectiveLimit(-1))
+	assert.Equal(t, 50, effectiveLimit(50))
+	assert.Equal(t, 1, effectiveLimit(1))
+}
+
+// --- EndTime boundary (half-open interval) ---
+
+func TestTokenUsageRepo_EndTimeBoundary(t *testing.T) {
+	db := setupTokenUsageTestDB(t)
+	repo := NewTokenUsageRepository(db)
+	ctx := context.Background()
+
+	// Record exactly at the EndTime boundary — should be EXCLUDED (half-open: [start, end)).
+	boundary := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	beforeBoundary := boundary.Add(-time.Hour)
+
+	require.NoError(t, repo.Create(ctx, &tokenusage.TokenUsage{
+		OrganizationID: 1, PodKey: "in-range", UserID: int64Ptr(1), RunnerID: int64Ptr(1),
+		AgentTypeSlug: "claude", Model: "opus",
+		InputTokens: 100, OutputTokens: 50,
+		CreatedAt: beforeBoundary,
+	}))
+	require.NoError(t, repo.Create(ctx, &tokenusage.TokenUsage{
+		OrganizationID: 1, PodKey: "at-boundary", UserID: int64Ptr(1), RunnerID: int64Ptr(1),
+		AgentTypeSlug: "claude", Model: "opus",
+		InputTokens: 999, OutputTokens: 999,
+		CreatedAt: boundary, // exactly at EndTime
+	}))
+
+	filter := tokenusage.AggregationFilter{
+		StartTime: boundary.Add(-24 * time.Hour),
+		EndTime:   boundary, // half-open: record at this exact time should be excluded
+	}
+
+	summary, err := repo.GetSummary(ctx, 1, filter)
+	require.NoError(t, err)
+	assert.Equal(t, int64(100), summary.InputTokens, "record at exact EndTime must be excluded")
+	assert.Equal(t, int64(50), summary.OutputTokens)
+}
+
+// --- applyOptionalFilters combined filters ---
+
+func TestTokenUsageRepo_CombinedFilters(t *testing.T) {
+	db := setupTokenUsageTestDB(t)
+	seedUsers(t, db)
+	repo := NewTokenUsageRepository(db)
+	ctx := context.Background()
+
+	now := time.Now()
+	// Record matching all filters.
+	require.NoError(t, repo.Create(ctx, &tokenusage.TokenUsage{
+		OrganizationID: 1, PodKey: "match", UserID: int64Ptr(1), RunnerID: int64Ptr(1),
+		AgentTypeSlug: "claude", Model: "opus",
+		InputTokens: 100, OutputTokens: 50,
+		CreatedAt: now,
+	}))
+	// Same agent but different model — should be excluded by model filter.
+	require.NoError(t, repo.Create(ctx, &tokenusage.TokenUsage{
+		OrganizationID: 1, PodKey: "wrong-model", UserID: int64Ptr(1), RunnerID: int64Ptr(1),
+		AgentTypeSlug: "claude", Model: "sonnet",
+		InputTokens: 200, OutputTokens: 100,
+		CreatedAt: now,
+	}))
+	// Same model but different agent — should be excluded by agent filter.
+	require.NoError(t, repo.Create(ctx, &tokenusage.TokenUsage{
+		OrganizationID: 1, PodKey: "wrong-agent", UserID: int64Ptr(1), RunnerID: int64Ptr(1),
+		AgentTypeSlug: "aider", Model: "opus",
+		InputTokens: 300, OutputTokens: 150,
+		CreatedAt: now,
+	}))
+
+	agent := "claude"
+	model := "opus"
+	uid := int64(1)
+	filter := tokenusage.AggregationFilter{
+		StartTime:     now.Add(-time.Hour),
+		EndTime:       now.Add(time.Hour),
+		AgentTypeSlug: &agent,
+		Model:         &model,
+		UserID:        &uid,
+	}
+
+	t.Run("GetSummary with combined filters", func(t *testing.T) {
+		summary, err := repo.GetSummary(ctx, 1, filter)
+		require.NoError(t, err)
+		assert.Equal(t, int64(100), summary.InputTokens)
+	})
+
+	t.Run("GetByUser with combined filters (qualified columns)", func(t *testing.T) {
+		results, err := repo.GetByUser(ctx, 1, filter)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, int64(100), results[0].InputTokens)
+		assert.Equal(t, "Alice", results[0].Username)
+	})
+
+	t.Run("GetByAgent with combined filters", func(t *testing.T) {
+		results, err := repo.GetByAgent(ctx, 1, filter)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, "claude", results[0].AgentTypeSlug)
+		assert.Equal(t, int64(100), results[0].InputTokens)
+	})
+
+	t.Run("GetByModel with combined filters", func(t *testing.T) {
+		results, err := repo.GetByModel(ctx, 1, filter)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, "opus", results[0].Model)
+		assert.Equal(t, int64(100), results[0].InputTokens)
+	})
+}
+
+// --- Org isolation ---
+
+func TestTokenUsageRepo_OrgIsolation(t *testing.T) {
+	db := setupTokenUsageTestDB(t)
+	repo := NewTokenUsageRepository(db)
+	ctx := context.Background()
+
+	now := time.Now()
+	// Org 1 record.
+	require.NoError(t, repo.Create(ctx, &tokenusage.TokenUsage{
+		OrganizationID: 1, PodKey: "p1", UserID: int64Ptr(1), RunnerID: int64Ptr(1),
+		AgentTypeSlug: "claude", Model: "opus",
+		InputTokens: 100, OutputTokens: 50,
+		CreatedAt: now,
+	}))
+	// Org 2 record.
+	require.NoError(t, repo.Create(ctx, &tokenusage.TokenUsage{
+		OrganizationID: 2, PodKey: "p2", UserID: int64Ptr(2), RunnerID: int64Ptr(2),
+		AgentTypeSlug: "aider", Model: "gpt4",
+		InputTokens: 999, OutputTokens: 999,
+		CreatedAt: now,
+	}))
+
+	filter := tokenusage.AggregationFilter{
+		StartTime: now.Add(-time.Hour),
+		EndTime:   now.Add(time.Hour),
+	}
+
+	summary, err := repo.GetSummary(ctx, 1, filter)
+	require.NoError(t, err)
+	assert.Equal(t, int64(100), summary.InputTokens, "org 2 data must not leak into org 1")
+}

--- a/backend/internal/service/runner/connection_manager.go
+++ b/backend/internal/service/runner/connection_manager.go
@@ -68,6 +68,9 @@ type RunnerConnectionManager struct {
 	onAutopilotCreated    func(runnerID int64, data *runnerv1.AutopilotCreatedEvent)
 	onAutopilotTerminated func(runnerID int64, data *runnerv1.AutopilotTerminatedEvent)
 	onAutopilotThinking   func(runnerID int64, data *runnerv1.AutopilotThinkingEvent)
+
+	// Token usage callback
+	onTokenUsage func(runnerID int64, data *runnerv1.TokenUsageReport)
 }
 
 // grpcConnectionShard holds a subset of gRPC connections with its own lock.

--- a/backend/internal/service/runner/connection_manager_callbacks.go
+++ b/backend/internal/service/runner/connection_manager_callbacks.go
@@ -111,6 +111,13 @@ func (cm *RunnerConnectionManager) GetDisconnectCallback() func(runnerID int64) 
 	return cm.onDisconnect
 }
 
+// ==================== Token Usage Callback Setter ====================
+
+// SetTokenUsageCallback sets the token usage report callback (Proto type)
+func (cm *RunnerConnectionManager) SetTokenUsageCallback(fn func(runnerID int64, data *runnerv1.TokenUsageReport)) {
+	cm.onTokenUsage = fn
+}
+
 // ==================== Upgrade Callback Setters ====================
 
 // SetUpgradeStatusCallback sets the upgrade status callback (Proto type)

--- a/backend/internal/service/runner/connection_manager_handlers.go
+++ b/backend/internal/service/runner/connection_manager_handlers.go
@@ -123,6 +123,16 @@ func (cm *RunnerConnectionManager) HandleOSCTitle(runnerID int64, data *runnerv1
 	}
 }
 
+// ==================== Token Usage Handler ====================
+
+// HandleTokenUsage handles token usage report from runner (Proto type)
+func (cm *RunnerConnectionManager) HandleTokenUsage(runnerID int64, data *runnerv1.TokenUsageReport) {
+	cm.UpdateHeartbeat(runnerID)
+	if cm.onTokenUsage != nil {
+		cm.onTokenUsage(runnerID, data)
+	}
+}
+
 // ==================== Upgrade Event Handlers ====================
 
 // HandleUpgradeStatus handles upgrade status event from runner (Proto type)

--- a/backend/internal/service/runner/pod_token_usage_handler.go
+++ b/backend/internal/service/runner/pod_token_usage_handler.go
@@ -1,0 +1,91 @@
+package runner
+
+import (
+	"context"
+	"time"
+
+	tokenusagesvc "github.com/anthropics/agentsmesh/backend/internal/service/tokenusage"
+	runnerv1 "github.com/anthropics/agentsmesh/proto/gen/go/runner/v1"
+)
+
+// SetTokenUsageService wires the token usage callback.
+// The PodCoordinator looks up pod info (org, user, agent type) and delegates
+// recording to the TokenUsageService.
+func (pc *PodCoordinator) SetTokenUsageService(svc *tokenusagesvc.Service) {
+	pc.connectionManager.SetTokenUsageCallback(func(runnerID int64, data *runnerv1.TokenUsageReport) {
+		pc.handleTokenUsage(runnerID, data, svc)
+	})
+}
+
+func (pc *PodCoordinator) handleTokenUsage(runnerID int64, data *runnerv1.TokenUsageReport, svc *tokenusagesvc.Service) {
+	if len(data.Models) == 0 || data.PodKey == "" {
+		return
+	}
+
+	// Cap the number of model entries to prevent abuse.
+	// Use a local slice to avoid mutating the caller's proto message.
+	const maxModels = 50
+	models := data.Models
+	if len(models) > maxModels {
+		pc.logger.Warn("token usage report truncated: too many models",
+			"pod_key", data.PodKey,
+			"runner_id", runnerID,
+			"count", len(models),
+		)
+		models = models[:maxModels]
+	}
+
+	// Use a bounded context so DB issues don't block indefinitely.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Look up the pod to retrieve org, user, and agent type info.
+	pod, err := pc.podRepo.GetByKey(ctx, data.PodKey)
+	if err != nil {
+		pc.logger.Error("failed to look up pod for token usage",
+			"pod_key", data.PodKey,
+			"runner_id", runnerID,
+			"error", err,
+		)
+		return
+	}
+
+	// Verify that the reporting runner actually owns this pod.
+	if pod.RunnerID != runnerID {
+		pc.logger.Warn("token usage rejected: runner does not own pod",
+			"pod_key", data.PodKey,
+			"runner_id", runnerID,
+			"pod_runner_id", pod.RunnerID,
+		)
+		return
+	}
+
+	// Determine agent type slug from the pod's association.
+	agentTypeSlug := "unknown"
+	if pod.AgentType != nil {
+		agentTypeSlug = pod.AgentType.Slug
+	} else if pod.CustomAgentType != nil {
+		agentTypeSlug = pod.CustomAgentType.Slug
+	}
+	// Enforce DB column length limit (VARCHAR(50)).
+	const maxSlugLen = 50
+	if len(agentTypeSlug) > maxSlugLen {
+		agentTypeSlug = agentTypeSlug[:maxSlugLen]
+	}
+
+	// Pass a report with the (possibly truncated) model list.
+	report := &runnerv1.TokenUsageReport{
+		PodKey: data.PodKey,
+		Models: models,
+	}
+	svc.RecordUsage(
+		ctx,
+		pod.OrganizationID,
+		&pod.ID,
+		data.PodKey,
+		pod.CreatedByID,
+		runnerID,
+		agentTypeSlug,
+		report,
+	)
+}

--- a/backend/internal/service/tokenusage/service.go
+++ b/backend/internal/service/tokenusage/service.go
@@ -1,0 +1,118 @@
+package tokenusage
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/anthropics/agentsmesh/backend/internal/domain/tokenusage"
+	runnerv1 "github.com/anthropics/agentsmesh/proto/gen/go/runner/v1"
+)
+
+// Service handles token usage recording and querying.
+type Service struct {
+	repo   tokenusage.Repository
+	logger *slog.Logger
+}
+
+// NewService creates a new token usage service.
+func NewService(repo tokenusage.Repository, logger *slog.Logger) *Service {
+	return &Service{repo: repo, logger: logger}
+}
+
+// RecordUsage persists token usage from a gRPC TokenUsageReport.
+// It creates one record per model reported by the runner.
+func (s *Service) RecordUsage(
+	ctx context.Context,
+	orgID int64,
+	podID *int64,
+	podKey string,
+	userID int64,
+	runnerID int64,
+	agentTypeSlug string,
+	report *runnerv1.TokenUsageReport,
+) {
+	if podKey == "" || orgID <= 0 || report == nil || len(report.Models) == 0 {
+		return
+	}
+
+	now := time.Now()
+	records := make([]*tokenusage.TokenUsage, 0, len(report.Models))
+	for _, m := range report.Models {
+		// Skip entries with negative token values (defensive).
+		if m.InputTokens < 0 || m.OutputTokens < 0 || m.CacheCreationTokens < 0 || m.CacheReadTokens < 0 {
+			s.logger.Warn("skipping token usage entry with negative values",
+				"pod_key", podKey,
+				"model", m.Model,
+			)
+			continue
+		}
+		// Enforce DB column length limits on string fields.
+		if len(m.Model) > 100 {
+			s.logger.Warn("skipping token usage entry: model name exceeds 100 bytes",
+				"pod_key", podKey,
+				"model_len", len(m.Model),
+			)
+			continue
+		}
+		uid, rid := userID, runnerID
+		records = append(records, &tokenusage.TokenUsage{
+			OrganizationID:      orgID,
+			PodID:               podID,
+			PodKey:              podKey,
+			UserID:              &uid,
+			RunnerID:            &rid,
+			AgentTypeSlug:       agentTypeSlug,
+			Model:               m.Model,
+			InputTokens:         m.InputTokens,
+			OutputTokens:        m.OutputTokens,
+			CacheCreationTokens: m.CacheCreationTokens,
+			CacheReadTokens:     m.CacheReadTokens,
+			CreatedAt:           now,
+		})
+	}
+
+	if len(records) == 0 {
+		return
+	}
+
+	if err := s.repo.CreateBatch(ctx, records); err != nil {
+		s.logger.Error("failed to record token usage batch",
+			"pod_key", podKey,
+			"models", len(records),
+			"error", err,
+		)
+		return
+	}
+
+	s.logger.Debug("token usage recorded",
+		"pod_key", podKey,
+		"models", len(records),
+		"org_id", orgID,
+	)
+}
+
+// GetSummary returns aggregated totals for the given organization and filter.
+func (s *Service) GetSummary(ctx context.Context, orgID int64, filter tokenusage.AggregationFilter) (*tokenusage.UsageSummary, error) {
+	return s.repo.GetSummary(ctx, orgID, filter)
+}
+
+// GetTimeSeries returns time-bucketed aggregation for the given organization.
+func (s *Service) GetTimeSeries(ctx context.Context, orgID int64, filter tokenusage.AggregationFilter) ([]tokenusage.TimeSeriesPoint, error) {
+	return s.repo.GetTimeSeries(ctx, orgID, filter)
+}
+
+// GetByAgent returns usage grouped by agent type slug.
+func (s *Service) GetByAgent(ctx context.Context, orgID int64, filter tokenusage.AggregationFilter) ([]tokenusage.AgentUsage, error) {
+	return s.repo.GetByAgent(ctx, orgID, filter)
+}
+
+// GetByUser returns usage grouped by user ID.
+func (s *Service) GetByUser(ctx context.Context, orgID int64, filter tokenusage.AggregationFilter) ([]tokenusage.UserUsage, error) {
+	return s.repo.GetByUser(ctx, orgID, filter)
+}
+
+// GetByModel returns usage grouped by model name.
+func (s *Service) GetByModel(ctx context.Context, orgID int64, filter tokenusage.AggregationFilter) ([]tokenusage.ModelUsage, error) {
+	return s.repo.GetByModel(ctx, orgID, filter)
+}

--- a/backend/internal/service/tokenusage/service_test.go
+++ b/backend/internal/service/tokenusage/service_test.go
@@ -1,0 +1,211 @@
+package tokenusage
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/anthropics/agentsmesh/backend/internal/domain/tokenusage"
+	runnerv1 "github.com/anthropics/agentsmesh/proto/gen/go/runner/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockRepository implements tokenusage.Repository for testing.
+type mockRepository struct {
+	records []*tokenusage.TokenUsage
+	summary *tokenusage.UsageSummary
+	series  []tokenusage.TimeSeriesPoint
+	agents  []tokenusage.AgentUsage
+	users   []tokenusage.UserUsage
+	models  []tokenusage.ModelUsage
+	err     error
+}
+
+func (m *mockRepository) Create(_ context.Context, record *tokenusage.TokenUsage) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.records = append(m.records, record)
+	return nil
+}
+
+func (m *mockRepository) CreateBatch(_ context.Context, records []*tokenusage.TokenUsage) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.records = append(m.records, records...)
+	return nil
+}
+
+func (m *mockRepository) GetSummary(_ context.Context, _ int64, _ tokenusage.AggregationFilter) (*tokenusage.UsageSummary, error) {
+	return m.summary, m.err
+}
+
+func (m *mockRepository) GetTimeSeries(_ context.Context, _ int64, _ tokenusage.AggregationFilter) ([]tokenusage.TimeSeriesPoint, error) {
+	return m.series, m.err
+}
+
+func (m *mockRepository) GetByAgent(_ context.Context, _ int64, _ tokenusage.AggregationFilter) ([]tokenusage.AgentUsage, error) {
+	return m.agents, m.err
+}
+
+func (m *mockRepository) GetByUser(_ context.Context, _ int64, _ tokenusage.AggregationFilter) ([]tokenusage.UserUsage, error) {
+	return m.users, m.err
+}
+
+func (m *mockRepository) GetByModel(_ context.Context, _ int64, _ tokenusage.AggregationFilter) ([]tokenusage.ModelUsage, error) {
+	return m.models, m.err
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func TestRecordUsage_CreatesOneRecordPerModel(t *testing.T) {
+	repo := &mockRepository{}
+	svc := NewService(repo, testLogger())
+	podID := int64(42)
+
+	report := &runnerv1.TokenUsageReport{
+		PodKey: "test-pod-key",
+		Models: []*runnerv1.TokenModelUsage{
+			{Model: "claude-sonnet-4-20250514", InputTokens: 1000, OutputTokens: 200},
+			{Model: "claude-opus-4-20250514", InputTokens: 500, OutputTokens: 100, CacheCreationTokens: 50},
+		},
+	}
+
+	svc.RecordUsage(context.Background(), 1, &podID, "test-pod-key", 10, 20, "claude", report)
+
+	require.Len(t, repo.records, 2)
+
+	assert.Equal(t, "claude-sonnet-4-20250514", repo.records[0].Model)
+	assert.Equal(t, int64(1000), repo.records[0].InputTokens)
+	assert.Equal(t, int64(200), repo.records[0].OutputTokens)
+	assert.Equal(t, int64(1), repo.records[0].OrganizationID)
+	require.NotNil(t, repo.records[0].UserID)
+	assert.Equal(t, int64(10), *repo.records[0].UserID)
+	require.NotNil(t, repo.records[0].RunnerID)
+	assert.Equal(t, int64(20), *repo.records[0].RunnerID)
+	assert.Equal(t, "claude", repo.records[0].AgentTypeSlug)
+
+	assert.Equal(t, "claude-opus-4-20250514", repo.records[1].Model)
+	assert.Equal(t, int64(50), repo.records[1].CacheCreationTokens)
+}
+
+func TestRecordUsage_EmptyReport(t *testing.T) {
+	repo := &mockRepository{}
+	svc := NewService(repo, testLogger())
+
+	report := &runnerv1.TokenUsageReport{
+		PodKey: "test-pod-key",
+		Models: []*runnerv1.TokenModelUsage{},
+	}
+
+	svc.RecordUsage(context.Background(), 1, nil, "test-pod-key", 10, 20, "claude", report)
+
+	assert.Empty(t, repo.records)
+}
+
+func TestRecordUsage_HandlesDBError(t *testing.T) {
+	repo := &mockRepository{err: assert.AnError}
+	svc := NewService(repo, testLogger())
+
+	report := &runnerv1.TokenUsageReport{
+		PodKey: "test-pod-key",
+		Models: []*runnerv1.TokenModelUsage{
+			{Model: "model-a", InputTokens: 100, OutputTokens: 50},
+			{Model: "model-b", InputTokens: 200, OutputTokens: 100},
+		},
+	}
+
+	// Should not panic even though repo returns errors.
+	svc.RecordUsage(context.Background(), 1, nil, "test-pod-key", 10, 20, "claude", report)
+	assert.Empty(t, repo.records, "no records should be stored when batch insert fails")
+}
+
+func TestRecordUsage_SkipsNegativeValues(t *testing.T) {
+	repo := &mockRepository{}
+	svc := NewService(repo, testLogger())
+
+	report := &runnerv1.TokenUsageReport{
+		PodKey: "test-pod-key",
+		Models: []*runnerv1.TokenModelUsage{
+			{Model: "valid", InputTokens: 100, OutputTokens: 50},
+			{Model: "negative", InputTokens: -999, OutputTokens: 50},
+		},
+	}
+
+	svc.RecordUsage(context.Background(), 1, nil, "test-pod-key", 10, 20, "claude", report)
+	require.Len(t, repo.records, 1)
+	assert.Equal(t, "valid", repo.records[0].Model)
+}
+
+func TestRecordUsage_SkipsOversizedModelName(t *testing.T) {
+	repo := &mockRepository{}
+	svc := NewService(repo, testLogger())
+
+	longModel := make([]byte, 101)
+	for i := range longModel {
+		longModel[i] = 'x'
+	}
+
+	report := &runnerv1.TokenUsageReport{
+		PodKey: "test-pod-key",
+		Models: []*runnerv1.TokenModelUsage{
+			{Model: string(longModel), InputTokens: 100, OutputTokens: 50},
+			{Model: "short-model", InputTokens: 200, OutputTokens: 100},
+		},
+	}
+
+	svc.RecordUsage(context.Background(), 1, nil, "test-pod-key", 10, 20, "claude", report)
+	require.Len(t, repo.records, 1, "oversized model name should be skipped")
+	assert.Equal(t, "short-model", repo.records[0].Model)
+}
+
+func TestRecordUsage_AcceptsModelNameAtLimit(t *testing.T) {
+	repo := &mockRepository{}
+	svc := NewService(repo, testLogger())
+
+	exactModel := make([]byte, 100)
+	for i := range exactModel {
+		exactModel[i] = 'a'
+	}
+
+	report := &runnerv1.TokenUsageReport{
+		PodKey: "test-pod-key",
+		Models: []*runnerv1.TokenModelUsage{
+			{Model: string(exactModel), InputTokens: 100, OutputTokens: 50},
+		},
+	}
+
+	svc.RecordUsage(context.Background(), 1, nil, "test-pod-key", 10, 20, "claude", report)
+	require.Len(t, repo.records, 1, "model name at exactly 100 bytes should be accepted")
+}
+
+func TestGetSummary_DelegatesToRepo(t *testing.T) {
+	expected := &tokenusage.UsageSummary{
+		InputTokens:  1000,
+		OutputTokens: 500,
+		TotalTokens:  1500,
+	}
+	repo := &mockRepository{summary: expected}
+	svc := NewService(repo, testLogger())
+
+	result, err := svc.GetSummary(context.Background(), 1, tokenusage.AggregationFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestGetByAgent_DelegatesToRepo(t *testing.T) {
+	expected := []tokenusage.AgentUsage{
+		{AgentTypeSlug: "claude", InputTokens: 1000, TotalTokens: 1500},
+	}
+	repo := &mockRepository{agents: expected}
+	svc := NewService(repo, testLogger())
+
+	result, err := svc.GetByAgent(context.Background(), 1, tokenusage.AggregationFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
+}

--- a/backend/migrations/000076_add_token_usages.down.sql
+++ b/backend/migrations/000076_add_token_usages.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS token_usages;

--- a/backend/migrations/000076_add_token_usages.up.sql
+++ b/backend/migrations/000076_add_token_usages.up.sql
@@ -1,0 +1,24 @@
+-- Token usage records: one row per model per pod session
+CREATE TABLE token_usages (
+    id                    BIGSERIAL PRIMARY KEY,
+    organization_id       BIGINT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    pod_id                BIGINT REFERENCES pods(id) ON DELETE SET NULL,
+    pod_key               VARCHAR(100) NOT NULL,
+    user_id               BIGINT REFERENCES users(id) ON DELETE SET NULL,
+    runner_id             BIGINT REFERENCES runners(id) ON DELETE SET NULL,
+    agent_type_slug       VARCHAR(50) NOT NULL,
+    model                 VARCHAR(100),
+    input_tokens          BIGINT NOT NULL DEFAULT 0,
+    output_tokens         BIGINT NOT NULL DEFAULT 0,
+    cache_creation_tokens BIGINT NOT NULL DEFAULT 0,
+    cache_read_tokens     BIGINT NOT NULL DEFAULT 0,
+    session_started_at    TIMESTAMPTZ,
+    session_ended_at      TIMESTAMPTZ,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_token_usages_org_created ON token_usages(organization_id, created_at);
+CREATE INDEX idx_token_usages_org_agent   ON token_usages(organization_id, agent_type_slug, created_at);
+CREATE INDEX idx_token_usages_org_user    ON token_usages(organization_id, user_id, created_at);
+CREATE INDEX idx_token_usages_pod_key     ON token_usages(pod_key);
+CREATE INDEX idx_token_usages_org_model   ON token_usages(organization_id, model, created_at);

--- a/deploy/dev/traefik/dynamic/http.yml
+++ b/deploy/dev/traefik/dynamic/http.yml
@@ -8,6 +8,7 @@ http:
         - web
       rule: "PathPrefix(`/api`) || PathPrefix(`/health`)"
       service: backend-api
+      priority: 100
 
     relay:
       entryPoints:

--- a/proto/gen/go/runner/v1/runner.pb.go
+++ b/proto/gen/go/runner/v1/runner.pb.go
@@ -49,6 +49,7 @@ type RunnerMessage struct {
 	//	*RunnerMessage_Pong
 	//	*RunnerMessage_UpgradeStatus
 	//	*RunnerMessage_LogUploadStatus
+	//	*RunnerMessage_TokenUsage
 	Payload       isRunnerMessage_Payload `protobuf_oneof:"payload"`
 	Timestamp     int64                   `protobuf:"varint,15,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -299,6 +300,15 @@ func (x *RunnerMessage) GetLogUploadStatus() *LogUploadStatusEvent {
 	return nil
 }
 
+func (x *RunnerMessage) GetTokenUsage() *TokenUsageReport {
+	if x != nil {
+		if x, ok := x.Payload.(*RunnerMessage_TokenUsage); ok {
+			return x.TokenUsage
+		}
+	}
+	return nil
+}
+
 func (x *RunnerMessage) GetTimestamp() int64 {
 	if x != nil {
 		return x.Timestamp
@@ -407,6 +417,11 @@ type RunnerMessage_LogUploadStatus struct {
 	LogUploadStatus *LogUploadStatusEvent `protobuf:"bytes,24,opt,name=log_upload_status,json=logUploadStatus,proto3,oneof"`
 }
 
+type RunnerMessage_TokenUsage struct {
+	// Token 用量报告（Runner -> Backend，Pod 退出时上报）
+	TokenUsage *TokenUsageReport `protobuf:"bytes,25,opt,name=token_usage,json=tokenUsage,proto3,oneof"`
+}
+
 func (*RunnerMessage_Initialize) isRunnerMessage_Payload() {}
 
 func (*RunnerMessage_Initialized) isRunnerMessage_Payload() {}
@@ -452,6 +467,8 @@ func (*RunnerMessage_Pong) isRunnerMessage_Payload() {}
 func (*RunnerMessage_UpgradeStatus) isRunnerMessage_Payload() {}
 
 func (*RunnerMessage_LogUploadStatus) isRunnerMessage_Payload() {}
+
+func (*RunnerMessage_TokenUsage) isRunnerMessage_Payload() {}
 
 // InitializeRequest Runner 初始化请求
 type InitializeRequest struct {
@@ -5053,11 +5070,142 @@ func (x *LogUploadStatusEvent) GetSizeBytes() int64 {
 	return 0
 }
 
+// TokenUsageReport Pod 退出时上报的 Token 用量（Runner -> Backend）
+// 一个 Pod 可能使用多个模型，因此按模型拆分
+type TokenUsageReport struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	PodKey        string                 `protobuf:"bytes,1,opt,name=pod_key,json=podKey,proto3" json:"pod_key,omitempty"`
+	Models        []*TokenModelUsage     `protobuf:"bytes,2,rep,name=models,proto3" json:"models,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TokenUsageReport) Reset() {
+	*x = TokenUsageReport{}
+	mi := &file_runner_v1_runner_proto_msgTypes[66]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TokenUsageReport) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TokenUsageReport) ProtoMessage() {}
+
+func (x *TokenUsageReport) ProtoReflect() protoreflect.Message {
+	mi := &file_runner_v1_runner_proto_msgTypes[66]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TokenUsageReport.ProtoReflect.Descriptor instead.
+func (*TokenUsageReport) Descriptor() ([]byte, []int) {
+	return file_runner_v1_runner_proto_rawDescGZIP(), []int{66}
+}
+
+func (x *TokenUsageReport) GetPodKey() string {
+	if x != nil {
+		return x.PodKey
+	}
+	return ""
+}
+
+func (x *TokenUsageReport) GetModels() []*TokenModelUsage {
+	if x != nil {
+		return x.Models
+	}
+	return nil
+}
+
+// TokenModelUsage 单个模型的 Token 用量
+type TokenModelUsage struct {
+	state               protoimpl.MessageState `protogen:"open.v1"`
+	Model               string                 `protobuf:"bytes,1,opt,name=model,proto3" json:"model,omitempty"` // 模型名称（如 "claude-sonnet-4-20250514"）
+	InputTokens         int64                  `protobuf:"varint,2,opt,name=input_tokens,json=inputTokens,proto3" json:"input_tokens,omitempty"`
+	OutputTokens        int64                  `protobuf:"varint,3,opt,name=output_tokens,json=outputTokens,proto3" json:"output_tokens,omitempty"`
+	CacheCreationTokens int64                  `protobuf:"varint,4,opt,name=cache_creation_tokens,json=cacheCreationTokens,proto3" json:"cache_creation_tokens,omitempty"`
+	CacheReadTokens     int64                  `protobuf:"varint,5,opt,name=cache_read_tokens,json=cacheReadTokens,proto3" json:"cache_read_tokens,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
+}
+
+func (x *TokenModelUsage) Reset() {
+	*x = TokenModelUsage{}
+	mi := &file_runner_v1_runner_proto_msgTypes[67]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TokenModelUsage) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TokenModelUsage) ProtoMessage() {}
+
+func (x *TokenModelUsage) ProtoReflect() protoreflect.Message {
+	mi := &file_runner_v1_runner_proto_msgTypes[67]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TokenModelUsage.ProtoReflect.Descriptor instead.
+func (*TokenModelUsage) Descriptor() ([]byte, []int) {
+	return file_runner_v1_runner_proto_rawDescGZIP(), []int{67}
+}
+
+func (x *TokenModelUsage) GetModel() string {
+	if x != nil {
+		return x.Model
+	}
+	return ""
+}
+
+func (x *TokenModelUsage) GetInputTokens() int64 {
+	if x != nil {
+		return x.InputTokens
+	}
+	return 0
+}
+
+func (x *TokenModelUsage) GetOutputTokens() int64 {
+	if x != nil {
+		return x.OutputTokens
+	}
+	return 0
+}
+
+func (x *TokenModelUsage) GetCacheCreationTokens() int64 {
+	if x != nil {
+		return x.CacheCreationTokens
+	}
+	return 0
+}
+
+func (x *TokenModelUsage) GetCacheReadTokens() int64 {
+	if x != nil {
+		return x.CacheReadTokens
+	}
+	return 0
+}
+
 var File_runner_v1_runner_proto protoreflect.FileDescriptor
 
 const file_runner_v1_runner_proto_rawDesc = "" +
 	"\n" +
-	"\x16runner/v1/runner.proto\x12\trunner.v1\"\x91\r\n" +
+	"\x16runner/v1/runner.proto\x12\trunner.v1\"\xd1\r\n" +
 	"\rRunnerMessage\x12>\n" +
 	"\n" +
 	"initialize\x18\x01 \x01(\v2\x1c.runner.v1.InitializeRequestH\x00R\n" +
@@ -5087,7 +5235,9 @@ const file_runner_v1_runner_proto_rawDesc = "" +
 	"mcpRequest\x12*\n" +
 	"\x04pong\x18\x16 \x01(\v2\x14.runner.v1.PongEventH\x00R\x04pong\x12F\n" +
 	"\x0eupgrade_status\x18\x17 \x01(\v2\x1d.runner.v1.UpgradeStatusEventH\x00R\rupgradeStatus\x12M\n" +
-	"\x11log_upload_status\x18\x18 \x01(\v2\x1f.runner.v1.LogUploadStatusEventH\x00R\x0flogUploadStatus\x12\x1c\n" +
+	"\x11log_upload_status\x18\x18 \x01(\v2\x1f.runner.v1.LogUploadStatusEventH\x00R\x0flogUploadStatus\x12>\n" +
+	"\vtoken_usage\x18\x19 \x01(\v2\x1b.runner.v1.TokenUsageReportH\x00R\n" +
+	"tokenUsage\x12\x1c\n" +
 	"\ttimestamp\x18\x0f \x01(\x03R\ttimestampB\t\n" +
 	"\apayload\"v\n" +
 	"\x11InitializeRequest\x12)\n" +
@@ -5444,7 +5594,16 @@ const file_runner_v1_runner_proto_rawDesc = "" +
 	"\amessage\x18\x04 \x01(\tR\amessage\x12\x14\n" +
 	"\x05error\x18\x05 \x01(\tR\x05error\x12\x1d\n" +
 	"\n" +
-	"size_bytes\x18\x06 \x01(\x03R\tsizeBytes2R\n" +
+	"size_bytes\x18\x06 \x01(\x03R\tsizeBytes\"_\n" +
+	"\x10TokenUsageReport\x12\x17\n" +
+	"\apod_key\x18\x01 \x01(\tR\x06podKey\x122\n" +
+	"\x06models\x18\x02 \x03(\v2\x1a.runner.v1.TokenModelUsageR\x06models\"\xcf\x01\n" +
+	"\x0fTokenModelUsage\x12\x14\n" +
+	"\x05model\x18\x01 \x01(\tR\x05model\x12!\n" +
+	"\finput_tokens\x18\x02 \x01(\x03R\vinputTokens\x12#\n" +
+	"\routput_tokens\x18\x03 \x01(\x03R\foutputTokens\x122\n" +
+	"\x15cache_creation_tokens\x18\x04 \x01(\x03R\x13cacheCreationTokens\x12*\n" +
+	"\x11cache_read_tokens\x18\x05 \x01(\x03R\x0fcacheReadTokens2R\n" +
 	"\rRunnerService\x12A\n" +
 	"\aConnect\x12\x18.runner.v1.RunnerMessage\x1a\x18.runner.v1.ServerMessage(\x010\x01B\x9a\x01\n" +
 	"\rcom.runner.v1B\vRunnerProtoP\x01Z7github.com/anthropic/agentmesh/proto/runner/v1;runnerv1\xa2\x02\x03RXX\xaa\x02\tRunner.V1\xca\x02\tRunner\\V1\xe2\x02\x15Runner\\V1\\GPBMetadata\xea\x02\n" +
@@ -5462,7 +5621,7 @@ func file_runner_v1_runner_proto_rawDescGZIP() []byte {
 	return file_runner_v1_runner_proto_rawDescData
 }
 
-var file_runner_v1_runner_proto_msgTypes = make([]protoimpl.MessageInfo, 68)
+var file_runner_v1_runner_proto_msgTypes = make([]protoimpl.MessageInfo, 70)
 var file_runner_v1_runner_proto_goTypes = []any{
 	(*RunnerMessage)(nil),              // 0: runner.v1.RunnerMessage
 	(*InitializeRequest)(nil),          // 1: runner.v1.InitializeRequest
@@ -5530,8 +5689,10 @@ var file_runner_v1_runner_proto_goTypes = []any{
 	(*UpgradeStatusEvent)(nil),         // 63: runner.v1.UpgradeStatusEvent
 	(*UploadLogsCommand)(nil),          // 64: runner.v1.UploadLogsCommand
 	(*LogUploadStatusEvent)(nil),       // 65: runner.v1.LogUploadStatusEvent
-	nil,                                // 66: runner.v1.ErrorEvent.DetailsEntry
-	nil,                                // 67: runner.v1.CreatePodCommand.EnvVarsEntry
+	(*TokenUsageReport)(nil),           // 66: runner.v1.TokenUsageReport
+	(*TokenModelUsage)(nil),            // 67: runner.v1.TokenModelUsage
+	nil,                                // 68: runner.v1.ErrorEvent.DetailsEntry
+	nil,                                // 69: runner.v1.CreatePodCommand.EnvVarsEntry
 }
 var file_runner_v1_runner_proto_depIdxs = []int32{
 	1,  // 0: runner.v1.RunnerMessage.initialize:type_name -> runner.v1.InitializeRequest
@@ -5557,58 +5718,60 @@ var file_runner_v1_runner_proto_depIdxs = []int32{
 	60, // 20: runner.v1.RunnerMessage.pong:type_name -> runner.v1.PongEvent
 	63, // 21: runner.v1.RunnerMessage.upgrade_status:type_name -> runner.v1.UpgradeStatusEvent
 	65, // 22: runner.v1.RunnerMessage.log_upload_status:type_name -> runner.v1.LogUploadStatusEvent
-	2,  // 23: runner.v1.InitializeRequest.runner_info:type_name -> runner.v1.RunnerInfo
-	4,  // 24: runner.v1.InitializedConfirm.agent_versions:type_name -> runner.v1.AgentVersionInfo
-	6,  // 25: runner.v1.HeartbeatData.pods:type_name -> runner.v1.PodInfo
-	7,  // 26: runner.v1.HeartbeatData.relay_connections:type_name -> runner.v1.RelayConnectionInfo
-	4,  // 27: runner.v1.HeartbeatData.agent_versions:type_name -> runner.v1.AgentVersionInfo
-	66, // 28: runner.v1.ErrorEvent.details:type_name -> runner.v1.ErrorEvent.DetailsEntry
-	16, // 29: runner.v1.ServerMessage.initialize_result:type_name -> runner.v1.InitializeResult
-	19, // 30: runner.v1.ServerMessage.create_pod:type_name -> runner.v1.CreatePodCommand
-	23, // 31: runner.v1.ServerMessage.terminate_pod:type_name -> runner.v1.TerminatePodCommand
-	24, // 32: runner.v1.ServerMessage.terminal_input:type_name -> runner.v1.TerminalInputCommand
-	25, // 33: runner.v1.ServerMessage.terminal_resize:type_name -> runner.v1.TerminalResizeCommand
-	26, // 34: runner.v1.ServerMessage.send_prompt:type_name -> runner.v1.SendPromptCommand
-	27, // 35: runner.v1.ServerMessage.terminal_redraw:type_name -> runner.v1.TerminalRedrawCommand
-	28, // 36: runner.v1.ServerMessage.subscribe_terminal:type_name -> runner.v1.SubscribeTerminalCommand
-	29, // 37: runner.v1.ServerMessage.unsubscribe_terminal:type_name -> runner.v1.UnsubscribeTerminalCommand
-	31, // 38: runner.v1.ServerMessage.query_sandboxes:type_name -> runner.v1.QuerySandboxesCommand
-	47, // 39: runner.v1.ServerMessage.create_autopilot:type_name -> runner.v1.CreateAutopilotCommand
-	40, // 40: runner.v1.ServerMessage.autopilot_control:type_name -> runner.v1.AutopilotControlCommand
-	57, // 41: runner.v1.ServerMessage.mcp_response:type_name -> runner.v1.McpResponse
-	59, // 42: runner.v1.ServerMessage.ping:type_name -> runner.v1.PingCommand
-	61, // 43: runner.v1.ServerMessage.heartbeat_ack:type_name -> runner.v1.HeartbeatAck
-	62, // 44: runner.v1.ServerMessage.upgrade_runner:type_name -> runner.v1.UpgradeRunnerCommand
-	64, // 45: runner.v1.ServerMessage.upload_logs:type_name -> runner.v1.UploadLogsCommand
-	17, // 46: runner.v1.InitializeResult.server_info:type_name -> runner.v1.ServerInfo
-	18, // 47: runner.v1.InitializeResult.agent_types:type_name -> runner.v1.AgentTypeInfo
-	67, // 48: runner.v1.CreatePodCommand.env_vars:type_name -> runner.v1.CreatePodCommand.EnvVarsEntry
-	21, // 49: runner.v1.CreatePodCommand.files_to_create:type_name -> runner.v1.FileToCreate
-	22, // 50: runner.v1.CreatePodCommand.sandbox_config:type_name -> runner.v1.SandboxConfig
-	20, // 51: runner.v1.CreatePodCommand.resources_to_download:type_name -> runner.v1.ResourceToDownload
-	32, // 52: runner.v1.QuerySandboxesCommand.queries:type_name -> runner.v1.SandboxQuery
-	34, // 53: runner.v1.SandboxesStatusEvent.sandboxes:type_name -> runner.v1.SandboxStatus
-	38, // 54: runner.v1.AutopilotStatusEvent.status:type_name -> runner.v1.AutopilotStatus
-	44, // 55: runner.v1.AutopilotControlCommand.pause:type_name -> runner.v1.AutopilotPauseAction
-	45, // 56: runner.v1.AutopilotControlCommand.resume:type_name -> runner.v1.AutopilotResumeAction
-	46, // 57: runner.v1.AutopilotControlCommand.stop:type_name -> runner.v1.AutopilotStopAction
-	41, // 58: runner.v1.AutopilotControlCommand.approve:type_name -> runner.v1.AutopilotApproveAction
-	42, // 59: runner.v1.AutopilotControlCommand.takeover:type_name -> runner.v1.AutopilotTakeoverAction
-	43, // 60: runner.v1.AutopilotControlCommand.handback:type_name -> runner.v1.AutopilotHandbackAction
-	19, // 61: runner.v1.CreateAutopilotCommand.pod_config:type_name -> runner.v1.CreatePodCommand
-	48, // 62: runner.v1.CreateAutopilotCommand.config:type_name -> runner.v1.AutopilotConfig
-	52, // 63: runner.v1.AutopilotThinkingEvent.action:type_name -> runner.v1.AutopilotAction
-	53, // 64: runner.v1.AutopilotThinkingEvent.progress:type_name -> runner.v1.AutopilotProgress
-	54, // 65: runner.v1.AutopilotThinkingEvent.help_request:type_name -> runner.v1.AutopilotHelpRequest
-	55, // 66: runner.v1.AutopilotHelpRequest.suggestions:type_name -> runner.v1.AutopilotHelpSuggestion
-	58, // 67: runner.v1.McpResponse.error:type_name -> runner.v1.McpError
-	0,  // 68: runner.v1.RunnerService.Connect:input_type -> runner.v1.RunnerMessage
-	15, // 69: runner.v1.RunnerService.Connect:output_type -> runner.v1.ServerMessage
-	69, // [69:70] is the sub-list for method output_type
-	68, // [68:69] is the sub-list for method input_type
-	68, // [68:68] is the sub-list for extension type_name
-	68, // [68:68] is the sub-list for extension extendee
-	0,  // [0:68] is the sub-list for field type_name
+	66, // 23: runner.v1.RunnerMessage.token_usage:type_name -> runner.v1.TokenUsageReport
+	2,  // 24: runner.v1.InitializeRequest.runner_info:type_name -> runner.v1.RunnerInfo
+	4,  // 25: runner.v1.InitializedConfirm.agent_versions:type_name -> runner.v1.AgentVersionInfo
+	6,  // 26: runner.v1.HeartbeatData.pods:type_name -> runner.v1.PodInfo
+	7,  // 27: runner.v1.HeartbeatData.relay_connections:type_name -> runner.v1.RelayConnectionInfo
+	4,  // 28: runner.v1.HeartbeatData.agent_versions:type_name -> runner.v1.AgentVersionInfo
+	68, // 29: runner.v1.ErrorEvent.details:type_name -> runner.v1.ErrorEvent.DetailsEntry
+	16, // 30: runner.v1.ServerMessage.initialize_result:type_name -> runner.v1.InitializeResult
+	19, // 31: runner.v1.ServerMessage.create_pod:type_name -> runner.v1.CreatePodCommand
+	23, // 32: runner.v1.ServerMessage.terminate_pod:type_name -> runner.v1.TerminatePodCommand
+	24, // 33: runner.v1.ServerMessage.terminal_input:type_name -> runner.v1.TerminalInputCommand
+	25, // 34: runner.v1.ServerMessage.terminal_resize:type_name -> runner.v1.TerminalResizeCommand
+	26, // 35: runner.v1.ServerMessage.send_prompt:type_name -> runner.v1.SendPromptCommand
+	27, // 36: runner.v1.ServerMessage.terminal_redraw:type_name -> runner.v1.TerminalRedrawCommand
+	28, // 37: runner.v1.ServerMessage.subscribe_terminal:type_name -> runner.v1.SubscribeTerminalCommand
+	29, // 38: runner.v1.ServerMessage.unsubscribe_terminal:type_name -> runner.v1.UnsubscribeTerminalCommand
+	31, // 39: runner.v1.ServerMessage.query_sandboxes:type_name -> runner.v1.QuerySandboxesCommand
+	47, // 40: runner.v1.ServerMessage.create_autopilot:type_name -> runner.v1.CreateAutopilotCommand
+	40, // 41: runner.v1.ServerMessage.autopilot_control:type_name -> runner.v1.AutopilotControlCommand
+	57, // 42: runner.v1.ServerMessage.mcp_response:type_name -> runner.v1.McpResponse
+	59, // 43: runner.v1.ServerMessage.ping:type_name -> runner.v1.PingCommand
+	61, // 44: runner.v1.ServerMessage.heartbeat_ack:type_name -> runner.v1.HeartbeatAck
+	62, // 45: runner.v1.ServerMessage.upgrade_runner:type_name -> runner.v1.UpgradeRunnerCommand
+	64, // 46: runner.v1.ServerMessage.upload_logs:type_name -> runner.v1.UploadLogsCommand
+	17, // 47: runner.v1.InitializeResult.server_info:type_name -> runner.v1.ServerInfo
+	18, // 48: runner.v1.InitializeResult.agent_types:type_name -> runner.v1.AgentTypeInfo
+	69, // 49: runner.v1.CreatePodCommand.env_vars:type_name -> runner.v1.CreatePodCommand.EnvVarsEntry
+	21, // 50: runner.v1.CreatePodCommand.files_to_create:type_name -> runner.v1.FileToCreate
+	22, // 51: runner.v1.CreatePodCommand.sandbox_config:type_name -> runner.v1.SandboxConfig
+	20, // 52: runner.v1.CreatePodCommand.resources_to_download:type_name -> runner.v1.ResourceToDownload
+	32, // 53: runner.v1.QuerySandboxesCommand.queries:type_name -> runner.v1.SandboxQuery
+	34, // 54: runner.v1.SandboxesStatusEvent.sandboxes:type_name -> runner.v1.SandboxStatus
+	38, // 55: runner.v1.AutopilotStatusEvent.status:type_name -> runner.v1.AutopilotStatus
+	44, // 56: runner.v1.AutopilotControlCommand.pause:type_name -> runner.v1.AutopilotPauseAction
+	45, // 57: runner.v1.AutopilotControlCommand.resume:type_name -> runner.v1.AutopilotResumeAction
+	46, // 58: runner.v1.AutopilotControlCommand.stop:type_name -> runner.v1.AutopilotStopAction
+	41, // 59: runner.v1.AutopilotControlCommand.approve:type_name -> runner.v1.AutopilotApproveAction
+	42, // 60: runner.v1.AutopilotControlCommand.takeover:type_name -> runner.v1.AutopilotTakeoverAction
+	43, // 61: runner.v1.AutopilotControlCommand.handback:type_name -> runner.v1.AutopilotHandbackAction
+	19, // 62: runner.v1.CreateAutopilotCommand.pod_config:type_name -> runner.v1.CreatePodCommand
+	48, // 63: runner.v1.CreateAutopilotCommand.config:type_name -> runner.v1.AutopilotConfig
+	52, // 64: runner.v1.AutopilotThinkingEvent.action:type_name -> runner.v1.AutopilotAction
+	53, // 65: runner.v1.AutopilotThinkingEvent.progress:type_name -> runner.v1.AutopilotProgress
+	54, // 66: runner.v1.AutopilotThinkingEvent.help_request:type_name -> runner.v1.AutopilotHelpRequest
+	55, // 67: runner.v1.AutopilotHelpRequest.suggestions:type_name -> runner.v1.AutopilotHelpSuggestion
+	58, // 68: runner.v1.McpResponse.error:type_name -> runner.v1.McpError
+	67, // 69: runner.v1.TokenUsageReport.models:type_name -> runner.v1.TokenModelUsage
+	0,  // 70: runner.v1.RunnerService.Connect:input_type -> runner.v1.RunnerMessage
+	15, // 71: runner.v1.RunnerService.Connect:output_type -> runner.v1.ServerMessage
+	71, // [71:72] is the sub-list for method output_type
+	70, // [70:71] is the sub-list for method input_type
+	70, // [70:70] is the sub-list for extension type_name
+	70, // [70:70] is the sub-list for extension extendee
+	0,  // [0:70] is the sub-list for field type_name
 }
 
 func init() { file_runner_v1_runner_proto_init() }
@@ -5640,6 +5803,7 @@ func file_runner_v1_runner_proto_init() {
 		(*RunnerMessage_Pong)(nil),
 		(*RunnerMessage_UpgradeStatus)(nil),
 		(*RunnerMessage_LogUploadStatus)(nil),
+		(*RunnerMessage_TokenUsage)(nil),
 	}
 	file_runner_v1_runner_proto_msgTypes[15].OneofWrappers = []any{
 		(*ServerMessage_InitializeResult)(nil),
@@ -5674,7 +5838,7 @@ func file_runner_v1_runner_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_runner_v1_runner_proto_rawDesc), len(file_runner_v1_runner_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   68,
+			NumMessages:   70,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/runner/v1/runner.proto
+++ b/proto/runner/v1/runner.proto
@@ -45,6 +45,8 @@ message RunnerMessage {
     UpgradeStatusEvent upgrade_status = 23;
     // 日志上传状态回报（Runner -> Backend）
     LogUploadStatusEvent log_upload_status = 24;
+    // Token 用量报告（Runner -> Backend，Pod 退出时上报）
+    TokenUsageReport token_usage = 25;
   }
   int64 timestamp = 15;
 }
@@ -641,4 +643,22 @@ message LogUploadStatusEvent {
   string message = 4;          // 人类可读状态信息
   string error = 5;            // phase=failed 时的错误信息
   int64 size_bytes = 6;        // 日志包大小（字节）
+}
+
+// ==================== Token Usage 相关消息 ====================
+
+// TokenUsageReport Pod 退出时上报的 Token 用量（Runner -> Backend）
+// 一个 Pod 可能使用多个模型，因此按模型拆分
+message TokenUsageReport {
+  string pod_key = 1;
+  repeated TokenModelUsage models = 2;
+}
+
+// TokenModelUsage 单个模型的 Token 用量
+message TokenModelUsage {
+  string model = 1;                     // 模型名称（如 "claude-sonnet-4-20250514"）
+  int64 input_tokens = 2;
+  int64 output_tokens = 3;
+  int64 cache_creation_tokens = 4;
+  int64 cache_read_tokens = 5;
 }

--- a/runner/internal/client/grpc_sender_token_usage.go
+++ b/runner/internal/client/grpc_sender_token_usage.go
@@ -1,0 +1,21 @@
+package client
+
+import (
+	"time"
+
+	runnerv1 "github.com/anthropics/agentsmesh/proto/gen/go/runner/v1"
+)
+
+// SendTokenUsage sends a token usage report to the server (control message).
+func (c *GRPCConnection) SendTokenUsage(podKey string, models []*runnerv1.TokenModelUsage) error {
+	msg := &runnerv1.RunnerMessage{
+		Payload: &runnerv1.RunnerMessage_TokenUsage{
+			TokenUsage: &runnerv1.TokenUsageReport{
+				PodKey: podKey,
+				Models: models,
+			},
+		},
+		Timestamp: time.Now().UnixMilli(),
+	}
+	return c.sendControl(msg)
+}

--- a/runner/internal/client/interface.go
+++ b/runner/internal/client/interface.go
@@ -67,6 +67,9 @@ type ConnectionSender interface {
 
 	// SendLogUploadStatus sends a log upload status event to the server.
 	SendLogUploadStatus(event *runnerv1.LogUploadStatusEvent) error
+
+	// SendTokenUsage sends a token usage report to the server.
+	SendTokenUsage(podKey string, models []*runnerv1.TokenModelUsage) error
 }
 
 // ConnectionMonitor defines methods for monitoring connection health.

--- a/runner/internal/client/mock_connection.go
+++ b/runner/internal/client/mock_connection.go
@@ -248,6 +248,20 @@ func (m *MockConnection) SendLogUploadStatus(event *runnerv1.LogUploadStatusEven
 	return nil
 }
 
+// SendTokenUsage records a token usage report.
+func (m *MockConnection) SendTokenUsage(podKey string, models []*runnerv1.TokenModelUsage) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.SendErr != nil {
+		return m.SendErr
+	}
+	m.Events = append(m.Events, EventCall{
+		Type: "token_usage",
+		Data: map[string]any{"pod_key": podKey, "models": models},
+	})
+	return nil
+}
+
 // SendMessage records a raw RunnerMessage.
 func (m *MockConnection) SendMessage(msg *runnerv1.RunnerMessage) error {
 	m.mu.Lock()

--- a/runner/internal/client/rpc_test.go
+++ b/runner/internal/client/rpc_test.go
@@ -46,8 +46,9 @@ func (m *mockSender) SendOSCNotification(string, string, string) error    { retu
 func (m *mockSender) SendOSCTitle(string, string) error                   { return nil }
 func (m *mockSender) SendRequestRelayToken(string, string) error          { return nil }
 func (m *mockSender) SendSandboxesStatus(string, []*SandboxStatusInfo) error { return nil }
-func (m *mockSender) SendUpgradeStatus(*runnerv1.UpgradeStatusEvent) error      { return nil }
-func (m *mockSender) SendLogUploadStatus(*runnerv1.LogUploadStatusEvent) error  { return nil }
+func (m *mockSender) SendUpgradeStatus(*runnerv1.UpgradeStatusEvent) error       { return nil }
+func (m *mockSender) SendLogUploadStatus(*runnerv1.LogUploadStatusEvent) error   { return nil }
+func (m *mockSender) SendTokenUsage(string, []*runnerv1.TokenModelUsage) error   { return nil }
 func (m *mockSender) QueueLength() int                                       { return 0 }
 func (m *mockSender) QueueCapacity() int                                  { return 100 }
 func (m *mockSender) QueueUsage() float64                                 { return 0 }

--- a/runner/internal/runner/handler_events.go
+++ b/runner/internal/runner/handler_events.go
@@ -2,10 +2,13 @@ package runner
 
 import (
 	"fmt"
+	"time"
 
+	runnerv1 "github.com/anthropics/agentsmesh/proto/gen/go/runner/v1"
 	"github.com/anthropics/agentsmesh/runner/internal/client"
 	"github.com/anthropics/agentsmesh/runner/internal/logger"
 	"github.com/anthropics/agentsmesh/runner/internal/terminal/vt"
+	"github.com/anthropics/agentsmesh/runner/internal/tokenusage"
 )
 
 // createOSCHandler creates an OSC handler that sends terminal notifications to the server.
@@ -141,6 +144,48 @@ func (h *RunnerMessageHandler) createExitHandler(podKey string) func(int) {
 		if err := h.conn.SendPodTerminated(podKey, int32(exitCode), earlyOutput); err != nil {
 			log.Error("Failed to send pod terminated event", "error", err)
 		}
+
+		// Async token usage collection — runs after termination event is sent.
+		// Uses the agent's LaunchCommand as agentType to select the parser.
+		// podStartedAt scopes collection to only this session's files.
+		agentType := pod.AgentType
+		sandboxPath := pod.SandboxPath
+		podStartedAt := pod.StartedAt
+		go h.collectAndSendTokenUsage(podKey, agentType, sandboxPath, podStartedAt)
+	}
+}
+
+// collectAndSendTokenUsage collects token usage and sends it to the backend.
+// This is called asynchronously after pod termination and must never panic.
+func (h *RunnerMessageHandler) collectAndSendTokenUsage(podKey, agentType, sandboxPath string, podStartedAt time.Time) {
+	log := logger.Pod()
+
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("Panic in token usage collection", "pod_key", podKey, "panic", r)
+		}
+	}()
+
+	usage := tokenusage.Collect(agentType, sandboxPath, podStartedAt)
+	if usage == nil {
+		return
+	}
+
+	models := make([]*runnerv1.TokenModelUsage, 0, len(usage.Models))
+	for _, m := range usage.Sorted() {
+		models = append(models, &runnerv1.TokenModelUsage{
+			Model:               m.Model,
+			InputTokens:         m.InputTokens,
+			OutputTokens:        m.OutputTokens,
+			CacheCreationTokens: m.CacheCreationTokens,
+			CacheReadTokens:     m.CacheReadTokens,
+		})
+	}
+
+	if err := h.conn.SendTokenUsage(podKey, models); err != nil {
+		log.Warn("Failed to send token usage report", "pod_key", podKey, "error", err)
+	} else {
+		log.Info("Token usage report sent", "pod_key", podKey, "models", len(models))
 	}
 }
 

--- a/runner/internal/runner/message_handler.go
+++ b/runner/internal/runner/message_handler.go
@@ -271,6 +271,14 @@ func (h *RunnerMessageHandler) OnTerminatePod(req client.TerminatePodRequest) er
 	}
 
 	h.sendPodTerminated(req.PodKey)
+
+	// Async token usage collection — same as createExitHandler.
+	// Capture values before goroutine to avoid race.
+	agentType := pod.AgentType
+	sandboxPath := pod.SandboxPath
+	podStartedAt := pod.StartedAt
+	go h.collectAndSendTokenUsage(req.PodKey, agentType, sandboxPath, podStartedAt)
+
 	log.Info("Pod terminated", "pod_key", req.PodKey)
 	return nil
 }

--- a/runner/internal/runner/pod_builder_build.go
+++ b/runner/internal/runner/pod_builder_build.go
@@ -107,7 +107,7 @@ func (b *PodBuilder) Build(ctx context.Context) (*Pod, error) {
 	pod := &Pod{
 		ID:              b.cmd.PodKey,
 		PodKey:          b.cmd.PodKey,
-		AgentType:       "", // Could be extracted from command if needed
+		AgentType:       b.cmd.LaunchCommand,
 		Branch:          branchName,
 		SandboxPath:     sandboxRoot,
 		Clipboard:       b.deps.Clipboard,

--- a/runner/internal/runner/runner_lifecycle.go
+++ b/runner/internal/runner/runner_lifecycle.go
@@ -128,6 +128,13 @@ func (r *Runner) stopAllPods() {
 		go func(p *Pod) {
 			defer wg.Done()
 			log.Debug("Stopping pod", "pod_key", p.PodKey)
+
+			// Capture metadata before cleanup for token usage collection.
+			podKey := p.PodKey
+			agentType := p.AgentType
+			sandboxPath := p.SandboxPath
+			podStartedAt := p.StartedAt
+
 			p.DisconnectRelay()
 			p.StopStateDetector()
 			if p.Aggregator != nil {
@@ -137,19 +144,29 @@ func (r *Runner) stopAllPods() {
 				p.Terminal.Stop()
 			}
 			r.podStore.Delete(p.PodKey)
+
+			// Collect token usage synchronously (best-effort).
+			// Token files live in HOME (~/.claude/, ~/.codex/), not in sandbox,
+			// so they survive Terminal.Stop(). gRPC is still alive at this point.
+			r.messageHandler.collectAndSendTokenUsage(podKey, agentType, sandboxPath, podStartedAt)
 		}(pod)
 	}
 
 	// Total timeout: fits within Windows SCM 20s limit
-	// (leaves headroom for autopilot stop + supervisor teardown)
+	// (leaves headroom for autopilot stop + supervisor teardown).
+	// Use a timer so we can stop it on success, preventing the
+	// wg.Wait goroutine from leaking on timeout.
+	timer := time.NewTimer(15 * time.Second)
+	defer timer.Stop()
+
 	done := make(chan struct{})
 	go func() { wg.Wait(); close(done) }()
 
 	select {
 	case <-done:
 		log.Info("All pods stopped successfully")
-	case <-time.After(15 * time.Second):
-		log.Warn("Timeout waiting for pods to stop", "count", len(pods))
+	case <-timer.C:
+		log.Warn("Timeout waiting for pods to stop — some token usage data may be lost", "count", len(pods))
 	}
 }
 

--- a/runner/internal/tokenusage/collector.go
+++ b/runner/internal/tokenusage/collector.go
@@ -1,0 +1,51 @@
+package tokenusage
+
+import (
+	"time"
+
+	"github.com/anthropics/agentsmesh/runner/internal/logger"
+)
+
+// Collect gathers token usage for a pod session.
+// agentType is the LaunchCommand (e.g., "claude", "aider").
+// sandboxPath is the pod's sandbox root directory.
+// podStartedAt is the pod's start time; only files modified after this time are processed.
+// Returns nil if no parser is available or no usage data is found.
+func Collect(agentType, sandboxPath string, podStartedAt time.Time) *TokenUsage {
+	log := logger.Pod()
+
+	parser := GetParser(agentType)
+	if parser == nil {
+		log.Debug("No token usage parser for agent type", "agent_type", agentType)
+		return nil
+	}
+
+	usage, err := parser.Parse(sandboxPath, podStartedAt)
+	if err != nil {
+		log.Warn("Token usage collection failed",
+			"agent_type", agentType,
+			"sandbox_path", sandboxPath,
+			"error", err,
+		)
+		return nil
+	}
+
+	if usage == nil || usage.IsEmpty() {
+		log.Debug("No token usage data found", "agent_type", agentType)
+		return nil
+	}
+
+	// Log summary
+	for _, m := range usage.Sorted() {
+		log.Info("Token usage collected",
+			"agent_type", agentType,
+			"model", m.Model,
+			"input", m.InputTokens,
+			"output", m.OutputTokens,
+			"cache_creation", m.CacheCreationTokens,
+			"cache_read", m.CacheReadTokens,
+		)
+	}
+
+	return usage
+}

--- a/runner/internal/tokenusage/parser.go
+++ b/runner/internal/tokenusage/parser.go
@@ -1,0 +1,70 @@
+// Package tokenusage provides token usage collection from AI agent session files.
+// Parsers are best-effort: errors are logged but never block pod termination.
+package tokenusage
+
+import "time"
+
+// ModelUsage holds aggregated token counts for a single model.
+type ModelUsage struct {
+	Model               string
+	InputTokens         int64
+	OutputTokens        int64
+	CacheCreationTokens int64
+	CacheReadTokens     int64
+}
+
+// TokenUsage holds the aggregated token usage across all models for a pod session.
+type TokenUsage struct {
+	// Models maps model name to its aggregated usage.
+	Models map[string]*ModelUsage
+}
+
+// NewTokenUsage creates an empty TokenUsage.
+func NewTokenUsage() *TokenUsage {
+	return &TokenUsage{Models: make(map[string]*ModelUsage)}
+}
+
+// Add accumulates usage for a given model.
+func (t *TokenUsage) Add(model string, input, output, cacheCreation, cacheRead int64) {
+	m, ok := t.Models[model]
+	if !ok {
+		m = &ModelUsage{Model: model}
+		t.Models[model] = m
+	}
+	m.InputTokens += input
+	m.OutputTokens += output
+	m.CacheCreationTokens += cacheCreation
+	m.CacheReadTokens += cacheRead
+}
+
+// IsEmpty returns true if no usage was collected.
+func (t *TokenUsage) IsEmpty() bool {
+	return len(t.Models) == 0
+}
+
+// Sorted returns models sorted by name for deterministic output.
+func (t *TokenUsage) Sorted() []*ModelUsage {
+	if len(t.Models) == 0 {
+		return nil
+	}
+	result := make([]*ModelUsage, 0, len(t.Models))
+	for _, m := range t.Models {
+		result = append(result, m)
+	}
+	// Sort by model name for deterministic ordering
+	for i := 1; i < len(result); i++ {
+		for j := i; j > 0 && result[j].Model < result[j-1].Model; j-- {
+			result[j], result[j-1] = result[j-1], result[j]
+		}
+	}
+	return result
+}
+
+// TokenParser defines the interface for agent-specific token usage parsers.
+type TokenParser interface {
+	// Parse collects token usage from session files.
+	// sandboxPath is the pod's sandbox root directory.
+	// podStartedAt is the pod's start time; only files modified after this time are processed.
+	// Returns nil usage if no session files are found (not an error).
+	Parse(sandboxPath string, podStartedAt time.Time) (*TokenUsage, error)
+}

--- a/runner/internal/tokenusage/parser_aider.go
+++ b/runner/internal/tokenusage/parser_aider.go
@@ -1,0 +1,120 @@
+package tokenusage
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/anthropics/agentsmesh/runner/internal/logger"
+)
+
+// AiderParser parses Aider markdown chat history files.
+// Aider writes chat history to:
+//   - {sandboxPath}/workspace/.aider.chat.history.md
+//   - {sandboxPath}/.aider.chat.history.md
+//
+// Token lines look like:
+//
+//	> Tokens: 12k sent, 3.4k received, 45k cache write, 123k cache read
+//	> Tokens: 1,234 sent, 567 received
+type AiderParser struct{}
+
+// tokenLineRe matches Aider's token summary lines.
+var tokenLineRe = regexp.MustCompile(`>\s*Tokens:\s*(.+)`)
+
+// tokenValueRe extracts a numeric value with optional k/m suffix and a label.
+var tokenValueRe = regexp.MustCompile(`([\d,]+(?:\.\d+)?)\s*([kmKM])?\s+(sent|received|cache\s+write|cache\s+read)`)
+
+func (p *AiderParser) Parse(sandboxPath string, podStartedAt time.Time) (*TokenUsage, error) {
+	usage := NewTokenUsage()
+
+	candidates := []string{
+		filepath.Join(sandboxPath, "workspace", ".aider.chat.history.md"),
+		filepath.Join(sandboxPath, ".aider.chat.history.md"),
+	}
+
+	for _, path := range candidates {
+		if !isModifiedAfter(path, podStartedAt) {
+			continue
+		}
+		if err := parseAiderHistoryFile(path, usage); err != nil {
+			logger.Pod().Warn("Aider parser: file parse error", "file", path, "error", err)
+		}
+	}
+
+	if usage.IsEmpty() {
+		return nil, nil
+	}
+	return usage, nil
+}
+
+func parseAiderHistoryFile(path string, usage *TokenUsage) error {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		match := tokenLineRe.FindStringSubmatch(line)
+		if match == nil {
+			continue
+		}
+
+		tokenStr := match[1]
+		var sent, received, cacheWrite, cacheRead int64
+
+		for _, m := range tokenValueRe.FindAllStringSubmatch(tokenStr, -1) {
+			value := parseTokenValue(m[1], m[2])
+			label := strings.ToLower(m[3])
+			switch {
+			case label == "sent":
+				sent = value
+			case label == "received":
+				received = value
+			case strings.Contains(label, "cache") && strings.Contains(label, "write"):
+				cacheWrite = value
+			case strings.Contains(label, "cache") && strings.Contains(label, "read"):
+				cacheRead = value
+			}
+		}
+
+		if sent > 0 || received > 0 {
+			// Aider doesn't report model name in token lines; use a generic label
+			usage.Add("aider-unknown", sent, received, cacheWrite, cacheRead)
+		}
+	}
+
+	return scanner.Err()
+}
+
+// parseTokenValue parses a numeric string with optional k/m suffix.
+// Examples: "12" -> 12, "3.4k" -> 3400, "1,234" -> 1234
+func parseTokenValue(numStr, suffix string) int64 {
+	// Remove commas
+	numStr = strings.ReplaceAll(numStr, ",", "")
+
+	val, err := strconv.ParseFloat(numStr, 64)
+	if err != nil {
+		return 0
+	}
+
+	switch strings.ToLower(suffix) {
+	case "k":
+		val *= 1000
+	case "m":
+		val *= 1_000_000
+	}
+
+	return int64(val)
+}

--- a/runner/internal/tokenusage/parser_claude.go
+++ b/runner/internal/tokenusage/parser_claude.go
@@ -1,0 +1,114 @@
+package tokenusage
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/anthropics/agentsmesh/runner/internal/logger"
+)
+
+// ClaudeParser parses Claude Code JSONL session files.
+// Claude Code writes conversation history to JSONL files under:
+//   - {sandboxPath}/.claude/projects/**/*.jsonl (pod-specific)
+//
+// Only files modified after podStartedAt are processed to avoid
+// re-counting historical sessions from previous pod runs.
+type ClaudeParser struct{}
+
+// claudeJSONLEntry represents a single line in a Claude Code JSONL file.
+type claudeJSONLEntry struct {
+	Type    string `json:"type"`
+	Message struct {
+		Model string `json:"model"`
+		Usage struct {
+			InputTokens              int64 `json:"input_tokens"`
+			OutputTokens             int64 `json:"output_tokens"`
+			CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+			CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+		} `json:"usage"`
+	} `json:"message"`
+}
+
+func (p *ClaudeParser) Parse(sandboxPath string, podStartedAt time.Time) (*TokenUsage, error) {
+	usage := NewTokenUsage()
+
+	// Only scan sandbox-local path — this is the current pod's project directory.
+	// Scanning HOME would pick up sessions from other pods/projects.
+	pattern := filepath.Join(sandboxPath, ".claude", "projects", "*", "*.jsonl")
+
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		logger.Pod().Warn("Claude parser: glob error", "pattern", pattern, "error", err)
+		return nil, nil
+	}
+
+	for _, f := range files {
+		if !isModifiedAfter(f, podStartedAt) {
+			continue
+		}
+		if err := parseClaudeJSONLFile(f, usage); err != nil {
+			logger.Pod().Warn("Claude parser: file parse error", "file", f, "error", err)
+		}
+	}
+
+	if usage.IsEmpty() {
+		return nil, nil
+	}
+	return usage, nil
+}
+
+func parseClaudeJSONLFile(path string, usage *TokenUsage) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	// Allow large lines (up to 10MB) for JSONL entries with large content.
+	// Claude Code JSONL can contain full conversation history with tool results.
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var entry claudeJSONLEntry
+		if err := json.Unmarshal(line, &entry); err != nil {
+			continue // Skip malformed lines
+		}
+
+		if entry.Type != "assistant" || entry.Message.Model == "" {
+			continue
+		}
+
+		u := entry.Message.Usage
+		if u.InputTokens == 0 && u.OutputTokens == 0 {
+			continue
+		}
+
+		usage.Add(
+			entry.Message.Model,
+			u.InputTokens,
+			u.OutputTokens,
+			u.CacheCreationInputTokens,
+			u.CacheReadInputTokens,
+		)
+	}
+
+	return scanner.Err()
+}
+
+// isModifiedAfter returns true if the file's modification time is at or after the given time.
+func isModifiedAfter(path string, after time.Time) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !info.ModTime().Before(after)
+}

--- a/runner/internal/tokenusage/parser_codex.go
+++ b/runner/internal/tokenusage/parser_codex.go
@@ -1,0 +1,133 @@
+package tokenusage
+
+import (
+	"bufio"
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/anthropics/agentsmesh/runner/internal/logger"
+)
+
+// CodexParser parses Codex CLI JSONL session files.
+// Codex CLI writes session data to JSONL files under:
+//   - {HOME}/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl
+//
+// Only files modified after podStartedAt are processed.
+type CodexParser struct{}
+
+// codexUsageFields holds token count fields shared by nested and flat structures.
+type codexUsageFields struct {
+	InputTokens              int64 `json:"input_tokens"`
+	OutputTokens             int64 `json:"output_tokens"`
+	CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+}
+
+// codexJSONLEntry represents a Codex CLI JSONL entry with usage info.
+// Codex emits two formats: nested (message.model + message.usage) and flat (model + usage).
+type codexJSONLEntry struct {
+	Type    string `json:"type"`
+	Message struct {
+		Model string           `json:"model"`
+		Usage codexUsageFields `json:"usage"`
+	} `json:"message"`
+	// Flat structure (alternative format)
+	Model string            `json:"model"`
+	Usage *codexUsageFields `json:"usage"`
+}
+
+func (p *CodexParser) Parse(sandboxPath string, podStartedAt time.Time) (*TokenUsage, error) {
+	usage := NewTokenUsage()
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		logger.Pod().Warn("Codex parser: cannot get home dir", "error", err)
+		return nil, nil
+	}
+
+	sessionsDir := filepath.Join(home, ".codex", "sessions")
+	if _, err := os.Stat(sessionsDir); os.IsNotExist(err) {
+		return nil, nil
+	}
+
+	// Walk the sessions directory to find all .jsonl files at any depth
+	// (Codex uses YYYY/MM/DD subdirectory structure)
+	err = filepath.WalkDir(sessionsDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // skip inaccessible entries
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".jsonl") {
+			return nil
+		}
+		if !isModifiedAfter(path, podStartedAt) {
+			return nil
+		}
+		if parseErr := parseCodexJSONLFile(path, usage); parseErr != nil {
+			logger.Pod().Warn("Codex parser: file parse error", "file", path, "error", parseErr)
+		}
+		return nil
+	})
+	if err != nil {
+		logger.Pod().Warn("Codex parser: walk error", "dir", sessionsDir, "error", err)
+	}
+
+	if usage.IsEmpty() {
+		return nil, nil
+	}
+	return usage, nil
+}
+
+func parseCodexJSONLFile(path string, usage *TokenUsage) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var entry codexJSONLEntry
+		if err := json.Unmarshal(line, &entry); err != nil {
+			continue
+		}
+
+		// Try nested message.usage structure first (like Claude)
+		if entry.Message.Model != "" && (entry.Message.Usage.InputTokens > 0 || entry.Message.Usage.OutputTokens > 0) {
+			usage.Add(
+				entry.Message.Model,
+				entry.Message.Usage.InputTokens,
+				entry.Message.Usage.OutputTokens,
+				entry.Message.Usage.CacheCreationInputTokens,
+				entry.Message.Usage.CacheReadInputTokens,
+			)
+			continue
+		}
+
+		// Try flat structure
+		if entry.Model != "" && entry.Usage != nil && (entry.Usage.InputTokens > 0 || entry.Usage.OutputTokens > 0) {
+			usage.Add(
+				entry.Model,
+				entry.Usage.InputTokens,
+				entry.Usage.OutputTokens,
+				entry.Usage.CacheCreationInputTokens,
+				entry.Usage.CacheReadInputTokens,
+			)
+		}
+	}
+
+	return scanner.Err()
+}

--- a/runner/internal/tokenusage/parser_opencode.go
+++ b/runner/internal/tokenusage/parser_opencode.go
@@ -1,0 +1,119 @@
+package tokenusage
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/anthropics/agentsmesh/runner/internal/logger"
+)
+
+// OpenCodeParser parses OpenCode JSON message files.
+// OpenCode writes message files to:
+//   - {HOME}/.local/share/opencode/storage/message/*/msg_*.json
+//
+// Only files modified after podStartedAt are processed.
+type OpenCodeParser struct{}
+
+// openCodeMessage represents an OpenCode message JSON file.
+type openCodeMessage struct {
+	Model string `json:"model"`
+	Usage struct {
+		InputTokens              int64 `json:"input_tokens"`
+		OutputTokens             int64 `json:"output_tokens"`
+		CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+		CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+	} `json:"usage"`
+	// Alternative field names
+	TokenUsage *struct {
+		PromptTokens     int64 `json:"prompt_tokens"`
+		CompletionTokens int64 `json:"completion_tokens"`
+		CachedTokens     int64 `json:"cached_tokens"`
+	} `json:"token_usage"`
+}
+
+func (p *OpenCodeParser) Parse(sandboxPath string, podStartedAt time.Time) (*TokenUsage, error) {
+	usage := NewTokenUsage()
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		logger.Pod().Warn("OpenCode parser: cannot get home dir", "error", err)
+		return nil, nil
+	}
+
+	pattern := filepath.Join(home, ".local", "share", "opencode", "storage", "message", "*", "msg_*.json")
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		logger.Pod().Warn("OpenCode parser: glob error", "pattern", pattern, "error", err)
+		return nil, nil
+	}
+
+	for _, f := range files {
+		if !isModifiedAfter(f, podStartedAt) {
+			continue
+		}
+		if err := parseOpenCodeFile(f, usage); err != nil {
+			logger.Pod().Warn("OpenCode parser: file parse error", "file", f, "error", err)
+		}
+	}
+
+	if usage.IsEmpty() {
+		return nil, nil
+	}
+	return usage, nil
+}
+
+// maxOpenCodeFileSize caps the size of individual OpenCode JSON message files
+// to prevent OOM when encountering unexpectedly large files.
+const maxOpenCodeFileSize = 10 * 1024 * 1024 // 10 MB
+
+func parseOpenCodeFile(path string, usage *TokenUsage) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if info.Size() > maxOpenCodeFileSize {
+		logger.Pod().Warn("OpenCode parser: skipping oversized file", "file", path, "size", info.Size())
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	var msg openCodeMessage
+	if err := json.Unmarshal(data, &msg); err != nil {
+		return nil // Skip malformed files
+	}
+
+	model := msg.Model
+	if model == "" {
+		model = "opencode-unknown"
+	}
+
+	// Try primary usage structure
+	if msg.Usage.InputTokens > 0 || msg.Usage.OutputTokens > 0 {
+		usage.Add(
+			model,
+			msg.Usage.InputTokens,
+			msg.Usage.OutputTokens,
+			msg.Usage.CacheCreationInputTokens,
+			msg.Usage.CacheReadInputTokens,
+		)
+		return nil
+	}
+
+	// Try alternative token_usage structure
+	if msg.TokenUsage != nil && (msg.TokenUsage.PromptTokens > 0 || msg.TokenUsage.CompletionTokens > 0) {
+		usage.Add(
+			model,
+			msg.TokenUsage.PromptTokens,
+			msg.TokenUsage.CompletionTokens,
+			0,
+			msg.TokenUsage.CachedTokens,
+		)
+	}
+
+	return nil
+}

--- a/runner/internal/tokenusage/parser_registry.go
+++ b/runner/internal/tokenusage/parser_registry.go
@@ -1,0 +1,25 @@
+package tokenusage
+
+import "strings"
+
+// parserRegistry maps agent command/slug to its parser.
+var parserRegistry = map[string]TokenParser{
+	"claude":     &ClaudeParser{},
+	"claude-code": &ClaudeParser{},
+	"codex":      &CodexParser{},
+	"codex-cli":  &CodexParser{},
+	"aider":      &AiderParser{},
+	"opencode":   &OpenCodeParser{},
+}
+
+// GetParser returns a TokenParser for the given agent type.
+// The agent type is typically the LaunchCommand (e.g., "claude", "aider").
+// Returns nil if no parser is registered for the agent type.
+func GetParser(agentType string) TokenParser {
+	// Normalize: lowercase, strip path prefix (e.g., "/usr/bin/claude" -> "claude")
+	name := strings.ToLower(agentType)
+	if idx := strings.LastIndexAny(name, "/\\"); idx >= 0 {
+		name = name[idx+1:]
+	}
+	return parserRegistry[name]
+}

--- a/runner/internal/tokenusage/parser_test.go
+++ b/runner/internal/tokenusage/parser_test.go
@@ -1,0 +1,393 @@
+package tokenusage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// epoch is a zero time used as podStartedAt when we want all files to pass the mtime filter.
+var epoch = time.Time{}
+
+// --- TokenUsage tests ---
+
+func TestTokenUsage_Add(t *testing.T) {
+	u := NewTokenUsage()
+	u.Add("model-a", 100, 50, 10, 20)
+	u.Add("model-a", 200, 100, 30, 40)
+	u.Add("model-b", 300, 150, 0, 0)
+
+	assert.Len(t, u.Models, 2)
+	assert.Equal(t, int64(300), u.Models["model-a"].InputTokens)
+	assert.Equal(t, int64(150), u.Models["model-a"].OutputTokens)
+	assert.Equal(t, int64(40), u.Models["model-a"].CacheCreationTokens)
+	assert.Equal(t, int64(60), u.Models["model-a"].CacheReadTokens)
+	assert.Equal(t, int64(300), u.Models["model-b"].InputTokens)
+}
+
+func TestTokenUsage_IsEmpty(t *testing.T) {
+	u := NewTokenUsage()
+	assert.True(t, u.IsEmpty())
+	u.Add("m", 1, 0, 0, 0)
+	assert.False(t, u.IsEmpty())
+}
+
+func TestTokenUsage_Sorted(t *testing.T) {
+	u := NewTokenUsage()
+	u.Add("z-model", 1, 0, 0, 0)
+	u.Add("a-model", 2, 0, 0, 0)
+	u.Add("m-model", 3, 0, 0, 0)
+
+	sorted := u.Sorted()
+	require.Len(t, sorted, 3)
+	assert.Equal(t, "a-model", sorted[0].Model)
+	assert.Equal(t, "m-model", sorted[1].Model)
+	assert.Equal(t, "z-model", sorted[2].Model)
+}
+
+// --- Claude parser tests ---
+
+func TestClaudeParser_ParseJSONLFile(t *testing.T) {
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, ".claude", "projects", "testproject")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+
+	jsonl := `{"type":"user","message":{"content":"hello"}}
+{"type":"assistant","message":{"model":"claude-sonnet-4-20250514","usage":{"input_tokens":1000,"output_tokens":500,"cache_creation_input_tokens":100,"cache_read_input_tokens":200}}}
+{"type":"assistant","message":{"model":"claude-sonnet-4-20250514","usage":{"input_tokens":2000,"output_tokens":800,"cache_creation_input_tokens":0,"cache_read_input_tokens":300}}}
+{"type":"assistant","message":{"model":"claude-opus-4-20250514","usage":{"input_tokens":500,"output_tokens":200,"cache_creation_input_tokens":50,"cache_read_input_tokens":0}}}
+invalid json line
+{"type":"assistant","message":{"model":"","usage":{"input_tokens":10,"output_tokens":5}}}
+`
+	filePath := filepath.Join(projectDir, "session.jsonl")
+	require.NoError(t, os.WriteFile(filePath, []byte(jsonl), 0o644))
+
+	// Test the internal file parser directly to avoid HOME directory interference
+	usage := NewTokenUsage()
+	err := parseClaudeJSONLFile(filePath, usage)
+	require.NoError(t, err)
+
+	assert.Len(t, usage.Models, 2)
+
+	sonnet := usage.Models["claude-sonnet-4-20250514"]
+	require.NotNil(t, sonnet)
+	assert.Equal(t, int64(3000), sonnet.InputTokens)
+	assert.Equal(t, int64(1300), sonnet.OutputTokens)
+	assert.Equal(t, int64(100), sonnet.CacheCreationTokens)
+	assert.Equal(t, int64(500), sonnet.CacheReadTokens)
+
+	opus := usage.Models["claude-opus-4-20250514"]
+	require.NotNil(t, opus)
+	assert.Equal(t, int64(500), opus.InputTokens)
+	assert.Equal(t, int64(200), opus.OutputTokens)
+}
+
+func TestClaudeParser_Parse_SandboxOnly(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	projectDir := filepath.Join(dir, ".claude", "projects", "testproject")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+
+	jsonl := `{"type":"assistant","message":{"model":"claude-sonnet-4-20250514","usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "session.jsonl"), []byte(jsonl), 0o644))
+
+	parser := &ClaudeParser{}
+	// epoch allows all files through the mtime filter
+	usage, err := parser.Parse(dir, epoch)
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	assert.Len(t, usage.Models, 1)
+}
+
+func TestClaudeParser_NoFiles(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir) // Override HOME to avoid scanning real files
+	parser := &ClaudeParser{}
+	usage, err := parser.Parse(dir, epoch)
+	assert.NoError(t, err)
+	assert.Nil(t, usage)
+}
+
+func TestClaudeParser_SkipsOldFiles(t *testing.T) {
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, ".claude", "projects", "testproject")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+
+	jsonl := `{"type":"assistant","message":{"model":"claude-sonnet-4-20250514","usage":{"input_tokens":100,"output_tokens":50}}}`
+	filePath := filepath.Join(projectDir, "old-session.jsonl")
+	require.NoError(t, os.WriteFile(filePath, []byte(jsonl), 0o644))
+
+	// Set file mtime to the past
+	pastTime := time.Now().Add(-1 * time.Hour)
+	require.NoError(t, os.Chtimes(filePath, pastTime, pastTime))
+
+	parser := &ClaudeParser{}
+	// podStartedAt is recent, so old file should be skipped
+	usage, err := parser.Parse(dir, time.Now().Add(-1*time.Minute))
+	require.NoError(t, err)
+	assert.Nil(t, usage, "old session file should be skipped")
+}
+
+// --- Codex parser tests ---
+
+func TestCodexParser_ParseNestedFormat(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a fake HOME-based codex session dir
+	sessionDir := filepath.Join(dir, "sessions", "sess1")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+
+	jsonl := `{"type":"assistant","message":{"model":"gpt-4o","usage":{"input_tokens":500,"output_tokens":200,"cache_creation_input_tokens":0,"cache_read_input_tokens":100}}}
+{"type":"user","message":{"content":"test"}}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "session.jsonl"), []byte(jsonl), 0o644))
+
+	usage := NewTokenUsage()
+	err := parseCodexJSONLFile(filepath.Join(sessionDir, "session.jsonl"), usage)
+	require.NoError(t, err)
+
+	assert.Len(t, usage.Models, 1)
+	m := usage.Models["gpt-4o"]
+	require.NotNil(t, m)
+	assert.Equal(t, int64(500), m.InputTokens)
+	assert.Equal(t, int64(200), m.OutputTokens)
+	assert.Equal(t, int64(100), m.CacheReadTokens)
+}
+
+func TestCodexParser_ParseFlatFormat(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "session.jsonl")
+
+	jsonl := `{"model":"o3-mini","usage":{"input_tokens":1000,"output_tokens":400}}
+`
+	require.NoError(t, os.WriteFile(file, []byte(jsonl), 0o644))
+
+	usage := NewTokenUsage()
+	err := parseCodexJSONLFile(file, usage)
+	require.NoError(t, err)
+
+	assert.Len(t, usage.Models, 1)
+	m := usage.Models["o3-mini"]
+	require.NotNil(t, m)
+	assert.Equal(t, int64(1000), m.InputTokens)
+	assert.Equal(t, int64(400), m.OutputTokens)
+}
+
+// --- Aider parser tests ---
+
+func TestAiderParser_Parse(t *testing.T) {
+	dir := t.TempDir()
+	wsDir := filepath.Join(dir, "workspace")
+	require.NoError(t, os.MkdirAll(wsDir, 0o755))
+
+	history := `# Chat History
+
+## User
+Hello
+
+## Assistant
+Hi there!
+
+> Tokens: 12k sent, 3.4k received, 45k cache write, 123k cache read
+
+## User
+Do something
+
+## Assistant
+Done.
+
+> Tokens: 1,234 sent, 567 received
+
+Some other line
+> Not a token line
+`
+	require.NoError(t, os.WriteFile(filepath.Join(wsDir, ".aider.chat.history.md"), []byte(history), 0o644))
+
+	parser := &AiderParser{}
+	usage, err := parser.Parse(dir, epoch)
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+
+	m := usage.Models["aider-unknown"]
+	require.NotNil(t, m)
+	// 12000 + 1234 = 13234
+	assert.Equal(t, int64(13234), m.InputTokens)
+	// 3400 + 567 = 3967
+	assert.Equal(t, int64(3967), m.OutputTokens)
+	assert.Equal(t, int64(45000), m.CacheCreationTokens)
+	assert.Equal(t, int64(123000), m.CacheReadTokens)
+}
+
+func TestAiderParser_SkipsOldFiles(t *testing.T) {
+	dir := t.TempDir()
+	wsDir := filepath.Join(dir, "workspace")
+	require.NoError(t, os.MkdirAll(wsDir, 0o755))
+
+	history := "> Tokens: 500 sent, 200 received\n"
+	filePath := filepath.Join(wsDir, ".aider.chat.history.md")
+	require.NoError(t, os.WriteFile(filePath, []byte(history), 0o644))
+
+	// Set file mtime to the past
+	pastTime := time.Now().Add(-1 * time.Hour)
+	require.NoError(t, os.Chtimes(filePath, pastTime, pastTime))
+
+	parser := &AiderParser{}
+	// podStartedAt is recent, so old file should be skipped
+	usage, err := parser.Parse(dir, time.Now().Add(-1*time.Minute))
+	require.NoError(t, err)
+	assert.Nil(t, usage, "old aider history file should be skipped")
+}
+
+func TestAiderParser_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	parser := &AiderParser{}
+	usage, err := parser.Parse(dir, epoch)
+	assert.NoError(t, err)
+	assert.Nil(t, usage)
+}
+
+func TestParseTokenValue(t *testing.T) {
+	tests := []struct {
+		num    string
+		suffix string
+		want   int64
+	}{
+		{"12", "", 12},
+		{"12", "k", 12000},
+		{"3.4", "k", 3400},
+		{"1,234", "", 1234},
+		{"1.5", "m", 1500000},
+		{"0", "", 0},
+		{"abc", "", 0},
+	}
+
+	for _, tt := range tests {
+		got := parseTokenValue(tt.num, tt.suffix)
+		assert.Equal(t, tt.want, got, "parseTokenValue(%q, %q)", tt.num, tt.suffix)
+	}
+}
+
+// --- OpenCode parser tests ---
+
+func TestOpenCodeParser_ParsePrimaryUsage(t *testing.T) {
+	dir := t.TempDir()
+	msgDir := filepath.Join(dir, "sess1")
+	require.NoError(t, os.MkdirAll(msgDir, 0o755))
+
+	msg := `{"model":"claude-3-haiku","usage":{"input_tokens":800,"output_tokens":300,"cache_creation_input_tokens":50,"cache_read_input_tokens":100}}`
+	require.NoError(t, os.WriteFile(filepath.Join(msgDir, "msg_001.json"), []byte(msg), 0o644))
+
+	usage := NewTokenUsage()
+	err := parseOpenCodeFile(filepath.Join(msgDir, "msg_001.json"), usage)
+	require.NoError(t, err)
+
+	m := usage.Models["claude-3-haiku"]
+	require.NotNil(t, m)
+	assert.Equal(t, int64(800), m.InputTokens)
+	assert.Equal(t, int64(300), m.OutputTokens)
+	assert.Equal(t, int64(50), m.CacheCreationTokens)
+	assert.Equal(t, int64(100), m.CacheReadTokens)
+}
+
+func TestOpenCodeParser_ParseAlternativeUsage(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "msg_002.json")
+
+	msg := `{"model":"gpt-4","token_usage":{"prompt_tokens":1000,"completion_tokens":500,"cached_tokens":200}}`
+	require.NoError(t, os.WriteFile(file, []byte(msg), 0o644))
+
+	usage := NewTokenUsage()
+	err := parseOpenCodeFile(file, usage)
+	require.NoError(t, err)
+
+	m := usage.Models["gpt-4"]
+	require.NotNil(t, m)
+	assert.Equal(t, int64(1000), m.InputTokens)
+	assert.Equal(t, int64(500), m.OutputTokens)
+	assert.Equal(t, int64(200), m.CacheReadTokens)
+}
+
+// --- Registry tests ---
+
+func TestGetParser(t *testing.T) {
+	tests := []struct {
+		agentType string
+		wantNil   bool
+	}{
+		{"claude", false},
+		{"claude-code", false},
+		{"codex", false},
+		{"codex-cli", false},
+		{"aider", false},
+		{"opencode", false},
+		{"unknown-agent", true},
+		{"/usr/bin/claude", false},
+		{"C:\\bin\\claude", false},
+		{"Claude", false},  // case insensitive
+		{"AIDER", false},
+	}
+
+	for _, tt := range tests {
+		parser := GetParser(tt.agentType)
+		if tt.wantNil {
+			assert.Nil(t, parser, "GetParser(%q) should be nil", tt.agentType)
+		} else {
+			assert.NotNil(t, parser, "GetParser(%q) should not be nil", tt.agentType)
+		}
+	}
+}
+
+// --- Collector tests ---
+
+func TestCollect_UnknownAgent(t *testing.T) {
+	usage := Collect("unknown-agent", t.TempDir(), epoch)
+	assert.Nil(t, usage)
+}
+
+func TestCollect_NoData(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	usage := Collect("claude", dir, epoch)
+	assert.Nil(t, usage)
+}
+
+func TestCollect_WithData(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	projectDir := filepath.Join(dir, ".claude", "projects", "testproject")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+
+	jsonl := `{"type":"assistant","message":{"model":"claude-sonnet-4-20250514","usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "s.jsonl"), []byte(jsonl), 0o644))
+
+	usage := Collect("claude", dir, epoch)
+	require.NotNil(t, usage)
+	assert.Len(t, usage.Models, 1)
+}
+
+// --- mtime filter tests ---
+
+func TestIsModifiedAfter(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "test.txt")
+	require.NoError(t, os.WriteFile(file, []byte("data"), 0o644))
+
+	// File just created, should be after epoch
+	assert.True(t, isModifiedAfter(file, epoch))
+
+	// File should be after a time far in the past
+	assert.True(t, isModifiedAfter(file, time.Now().Add(-24*time.Hour)))
+
+	// File should not be after a future time
+	assert.False(t, isModifiedAfter(file, time.Now().Add(24*time.Hour)))
+
+	// Non-existent file
+	assert.False(t, isModifiedAfter(filepath.Join(dir, "nonexistent"), epoch))
+}

--- a/web/src/app/(dashboard)/[org]/settings/page.tsx
+++ b/web/src/app/(dashboard)/[org]/settings/page.tsx
@@ -4,7 +4,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useAuthStore } from "@/stores/auth";
 import { Button } from "@/components/ui/button";
 import { LanguageSettings, ThemeSettings, NotificationSettings, AgentCredentialsSettings, AgentConfigPage, GitSettingsContent } from "@/components/settings";
-import { GeneralSettings, MembersSettings, BillingSettings, RunnersSettings, APIKeysSettings, ExtensionsSettings } from "@/components/settings/organization";
+import { GeneralSettings, MembersSettings, BillingSettings, RunnersSettings, APIKeysSettings, ExtensionsSettings, UsageSettings } from "@/components/settings/organization";
 import { useTranslations } from "next-intl";
 import { LogOut, User, Mail } from "lucide-react";
 
@@ -52,6 +52,8 @@ export default function SettingsPage() {
         return <APIKeysSettings t={t} />;
       case "billing":
         return <BillingSettings t={t} />;
+      case "usage":
+        return <UsageSettings t={t} />;
       default:
         return <GeneralSettings org={currentOrg} t={t} />;
     }

--- a/web/src/components/ide/sidebar/SettingsSidebarContent.tsx
+++ b/web/src/components/ide/sidebar/SettingsSidebarContent.tsx
@@ -20,6 +20,7 @@ import {
   Sparkles,
   KeyRound,
   Puzzle,
+  BarChart3,
 } from "lucide-react";
 
 interface SettingsSidebarContentProps {
@@ -75,11 +76,15 @@ export function SettingsSidebarContent({ className }: SettingsSidebarContentProp
   }, []);
 
   // Organization settings tabs (removed "agents" - now in personal settings)
+  const isOrgAdminOrOwner = currentOrg?.role === "owner" || currentOrg?.role === "admin";
   const orgSettingsTabs: TabItem[] = [
     { id: "general", labelKey: "ide.sidebar.settings.tabs.general", icon: Settings },
     { id: "members", labelKey: "ide.sidebar.settings.tabs.members", icon: Users },
     { id: "extensions", labelKey: "ide.sidebar.settings.tabs.extensions", icon: Puzzle },
     { id: "api-keys", labelKey: "ide.sidebar.settings.tabs.apiKeys", icon: KeyRound },
+    ...(isOrgAdminOrOwner
+      ? [{ id: "usage", labelKey: "ide.sidebar.settings.tabs.usage", icon: BarChart3 }]
+      : []),
     { id: "billing", labelKey: "ide.sidebar.settings.tabs.billing", icon: CreditCard },
   ];
 

--- a/web/src/components/settings/organization/UsageSettings.tsx
+++ b/web/src/components/settings/organization/UsageSettings.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import {
+  tokenUsageApi,
+  type TokenUsageSummary,
+  type TokenUsageTimeSeriesPoint,
+  type TokenUsageByAgent,
+  type TokenUsageByUser,
+  type TokenUsageByModel,
+  type TokenUsageQueryParams,
+} from "@/lib/api/token-usage";
+import type { TranslationFn } from "./GeneralSettings";
+import {
+  UsageOverviewCards,
+  UsageTimeSeriesChart,
+  UsageByAgentChart,
+  UsageByUserTable,
+  UsageByModelTable,
+  UsageFilters,
+  type TimeRange,
+  type Granularity,
+} from "./usage";
+
+interface UsageSettingsProps {
+  t: TranslationFn;
+}
+
+const validTimeRanges: TimeRange[] = ["7d", "30d", "90d"];
+const validGranularities: Granularity[] = ["day", "week", "month"];
+
+function isValidTimeRange(v: string | null): v is TimeRange {
+  return v !== null && validTimeRanges.includes(v as TimeRange);
+}
+
+function isValidGranularity(v: string | null): v is Granularity {
+  return v !== null && validGranularities.includes(v as Granularity);
+}
+
+function getTimeRangeDates(tr: TimeRange): { start: string; end: string } {
+  const now = new Date();
+  const end = now.toISOString();
+  const days = tr === "7d" ? 7 : tr === "30d" ? 30 : 90;
+  const start = new Date(now.getTime() - days * 24 * 60 * 60 * 1000).toISOString();
+  return { start, end };
+}
+
+function UsageLoadingSkeleton() {
+  return (
+    <div className="space-y-6 animate-pulse">
+      <div className="h-8 bg-muted rounded w-48" />
+      <div className="h-4 bg-muted rounded w-96" />
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-5">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className="border border-border rounded-lg p-4">
+            <div className="h-4 bg-muted rounded w-20 mb-2" />
+            <div className="h-8 bg-muted rounded w-24" />
+          </div>
+        ))}
+      </div>
+      <div className="border border-border rounded-lg p-6">
+        <div className="h-4 bg-muted rounded w-40 mb-4" />
+        <div className="h-64 bg-muted rounded" />
+      </div>
+    </div>
+  );
+}
+
+export function UsageSettings({ t }: UsageSettingsProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // Initialize filter state from URL params (fallback to defaults).
+  const [timeRange, setTimeRange] = useState<TimeRange>(() => {
+    const v = searchParams.get("timeRange");
+    return isValidTimeRange(v) ? v : "30d";
+  });
+  const [granularity, setGranularity] = useState<Granularity>(() => {
+    const v = searchParams.get("granularity");
+    return isValidGranularity(v) ? v : "day";
+  });
+  const [agentType, setAgentType] = useState(() => searchParams.get("agentType") || "");
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [summary, setSummary] = useState<TokenUsageSummary | null>(null);
+  const [timeSeries, setTimeSeries] = useState<TokenUsageTimeSeriesPoint[]>([]);
+  const [byAgent, setByAgent] = useState<TokenUsageByAgent[]>([]);
+  const [byUser, setByUser] = useState<TokenUsageByUser[]>([]);
+  const [byModel, setByModel] = useState<TokenUsageByModel[]>([]);
+
+  // Agent type list derived from unfiltered data to avoid circular dependency:
+  // selecting an agent filter would otherwise shrink the filter options list.
+  const [allAgentTypes, setAllAgentTypes] = useState<string[]>([]);
+
+  // AbortController ref to cancel in-flight requests on filter changes.
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Stable ref for translation function — avoids re-fetching when `t` identity changes
+  // (e.g., on every render from next-intl).
+  const tRef = useRef(t);
+  tRef.current = t;
+
+  // Sync filter state to URL (shallow replace, no navigation).
+  useEffect(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    // Always preserve existing scope/tab params.
+    if (timeRange !== "30d") {
+      params.set("timeRange", timeRange);
+    } else {
+      params.delete("timeRange");
+    }
+    if (granularity !== "day") {
+      params.set("granularity", granularity);
+    } else {
+      params.delete("granularity");
+    }
+    if (agentType) {
+      params.set("agentType", agentType);
+    } else {
+      params.delete("agentType");
+    }
+
+    const newQuery = params.toString();
+    const currentQuery = searchParams.toString();
+    if (newQuery !== currentQuery) {
+      router.replace(`?${newQuery}`, { scroll: false });
+    }
+  }, [timeRange, granularity, agentType, searchParams, router]);
+
+  const loadData = useCallback(async () => {
+    // Cancel any in-flight request from the previous filter change.
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setLoading(true);
+    setError(null);
+    const { start, end } = getTimeRangeDates(timeRange);
+    const params: TokenUsageQueryParams = {
+      start_time: start,
+      end_time: end,
+      granularity,
+      agent_type: agentType || undefined,
+    };
+
+    try {
+      const data = await tokenUsageApi.getDashboard(params, controller.signal);
+
+      // Guard against stale responses: if abort() was called after the fetch
+      // resolved but before we reach here, skip the state update.
+      if (controller.signal.aborted) return;
+
+      setSummary(data.summary ?? null);
+      setTimeSeries(data.time_series ?? []);
+      setByAgent(data.by_agent ?? []);
+      setByUser(data.by_user ?? []);
+      setByModel(data.by_model ?? []);
+
+      // Update agent type list only from unfiltered requests to break
+      // the circular dependency (filtered byAgent → fewer filter options).
+      if (!agentType && data.by_agent) {
+        setAllAgentTypes(
+          [...new Set(data.by_agent.map((a) => a.agent_type))].filter(Boolean)
+        );
+      }
+    } catch (err: unknown) {
+      // Ignore aborted requests — a newer request is in flight.
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      setError(tRef.current("settings.usagePage.loadFailed"));
+    } finally {
+      setLoading(false);
+    }
+  }, [timeRange, granularity, agentType]);
+
+  useEffect(() => {
+    loadData();
+    // Cleanup: abort on unmount.
+    return () => abortRef.current?.abort();
+  }, [loadData]);
+
+  // Show full skeleton only on initial load. For subsequent filter changes,
+  // keep the existing data visible to avoid jarring flicker.
+  if (loading && !summary) {
+    return <UsageLoadingSkeleton />;
+  }
+
+  if (error && !summary) {
+    return (
+      <div className="space-y-6">
+        <div className="border border-border rounded-lg p-6">
+          <p className="text-destructive">{error}</p>
+          <Button variant="outline" className="mt-4" onClick={loadData}>
+            {t("settings.usagePage.retry")}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h2 className="text-lg font-semibold">{t("settings.usagePage.title")}</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          {t("settings.usagePage.description")}
+        </p>
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <div className="p-4 rounded-lg bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400 border border-red-200 dark:border-red-800">
+          {error}
+        </div>
+      )}
+
+      {/* Filters */}
+      <UsageFilters
+        timeRange={timeRange}
+        granularity={granularity}
+        agentType={agentType}
+        onTimeRangeChange={setTimeRange}
+        onGranularityChange={setGranularity}
+        onAgentTypeChange={setAgentType}
+        agentTypes={allAgentTypes}
+        t={t}
+      />
+
+      {/* Overview Cards */}
+      <UsageOverviewCards summary={summary} t={t} />
+
+      {/* Time Series Chart */}
+      <UsageTimeSeriesChart data={timeSeries} t={t} />
+
+      {/* By Agent Chart */}
+      <UsageByAgentChart data={byAgent} t={t} />
+
+      {/* By User & By Model Tables (side by side on large screens) */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <UsageByUserTable data={byUser} t={t} />
+        <UsageByModelTable data={byModel} t={t} />
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/settings/organization/index.ts
+++ b/web/src/components/settings/organization/index.ts
@@ -4,3 +4,4 @@ export { BillingSettings } from "./BillingSettings";
 export { RunnersSettings } from "./RunnersSettings";
 export { APIKeysSettings } from "./APIKeysSettings";
 export { ExtensionsSettings } from "./ExtensionsSettings";
+export { UsageSettings } from "./UsageSettings";

--- a/web/src/components/settings/organization/usage/UsageByAgentChart.tsx
+++ b/web/src/components/settings/organization/usage/UsageByAgentChart.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useMemo } from "react";
+import { useTheme } from "next-themes";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from "recharts";
+import type { TokenUsageByAgent } from "@/lib/api/token-usage";
+import type { TranslationFn } from "../GeneralSettings";
+import { formatTokenCount } from "./format";
+import { resolveChartColors } from "./chart-colors";
+
+interface UsageByAgentChartProps {
+  data: TokenUsageByAgent[];
+  t: TranslationFn;
+}
+
+export function UsageByAgentChart({ data, t }: UsageByAgentChartProps) {
+  const { resolvedTheme } = useTheme();
+  const colors = useMemo(() => resolveChartColors(resolvedTheme === "dark"), [resolvedTheme]);
+  const chartData = useMemo(
+    () =>
+      data.map((item) => ({
+        name: item.agent_type,
+        input_tokens: item.input_tokens,
+        output_tokens: item.output_tokens,
+        cache_creation_tokens: item.cache_creation_tokens,
+        cache_read_tokens: item.cache_read_tokens,
+      })),
+    [data]
+  );
+
+  if (data.length === 0) {
+    return (
+      <div className="border border-border rounded-lg p-6">
+        <h3 className="text-sm font-medium mb-4">{t("settings.usagePage.byAgentTitle")}</h3>
+        <p className="text-sm text-muted-foreground text-center py-8">
+          {t("settings.usagePage.noData")}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border border-border rounded-lg p-6">
+      <h3 className="text-sm font-medium mb-4">{t("settings.usagePage.byAgentTitle")}</h3>
+      <div role="img" aria-label={t("settings.usagePage.byAgentTitle")}>
+        <ResponsiveContainer width="100%" height={Math.min(600, Math.max(200, data.length * 50 + 60))}>
+          <BarChart data={chartData} layout="vertical" margin={{ top: 5, right: 20, left: 80, bottom: 5 }}>
+            <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+            <XAxis type="number" tickFormatter={formatTokenCount} tick={{ fontSize: 12 }} />
+            <YAxis type="category" dataKey="name" tick={{ fontSize: 12 }} width={70} />
+            <Tooltip
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              formatter={(value: any, name: any) => [formatTokenCount(Number(value)), name]}
+              contentStyle={{
+                backgroundColor: "hsl(var(--popover))",
+                border: "1px solid hsl(var(--border))",
+                borderRadius: "6px",
+                fontSize: "12px",
+              }}
+            />
+            <Legend />
+            <Bar dataKey="input_tokens" name={t("settings.usagePage.inputTokens")} fill={colors.input} stackId="stack" />
+            <Bar dataKey="output_tokens" name={t("settings.usagePage.outputTokens")} fill={colors.output} stackId="stack" />
+            <Bar dataKey="cache_creation_tokens" name={t("settings.usagePage.cacheCreationTokens")} fill={colors.cacheCreation} stackId="stack" />
+            <Bar dataKey="cache_read_tokens" name={t("settings.usagePage.cacheReadTokens")} fill={colors.cacheRead} stackId="stack" />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/settings/organization/usage/UsageByModelTable.tsx
+++ b/web/src/components/settings/organization/usage/UsageByModelTable.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import type { TokenUsageByModel } from "@/lib/api/token-usage";
+import type { TranslationFn } from "../GeneralSettings";
+import { formatTokenCount, formatNumber } from "./format";
+
+interface UsageByModelTableProps {
+  data: TokenUsageByModel[];
+  t: TranslationFn;
+}
+
+export function UsageByModelTable({ data, t }: UsageByModelTableProps) {
+  const sorted = [...data].sort((a, b) => b.total_tokens - a.total_tokens);
+
+  return (
+    <div className="border border-border rounded-lg p-6">
+      <h3 className="text-sm font-medium mb-4">{t("settings.usagePage.byModelTitle")}</h3>
+      {sorted.length === 0 ? (
+        <p className="text-sm text-muted-foreground text-center py-8">
+          {t("settings.usagePage.noData")}
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <caption className="sr-only">{t("settings.usagePage.byModelTitle")}</caption>
+            <thead>
+              <tr className="border-b border-border text-left">
+                <th scope="col" className="pb-2 font-medium text-muted-foreground">
+                  {t("settings.usagePage.columnModel")}
+                </th>
+                <th scope="col" className="pb-2 font-medium text-muted-foreground text-right">
+                  {t("settings.usagePage.inputTokens")}
+                </th>
+                <th scope="col" className="pb-2 font-medium text-muted-foreground text-right">
+                  {t("settings.usagePage.outputTokens")}
+                </th>
+                <th scope="col" className="pb-2 font-medium text-muted-foreground text-right">
+                  {t("settings.usagePage.totalTokens")}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((model) => (
+                <tr key={model.model} className="border-b border-border/50 last:border-0">
+                  <td className="py-2 font-medium">{model.model?.trim() || t("settings.usagePage.unknown")}</td>
+                  <td className="py-2 text-right" title={formatNumber(model.input_tokens)}>
+                    {formatTokenCount(model.input_tokens)}
+                  </td>
+                  <td className="py-2 text-right" title={formatNumber(model.output_tokens)}>
+                    {formatTokenCount(model.output_tokens)}
+                  </td>
+                  <td className="py-2 text-right font-medium" title={formatNumber(model.total_tokens)}>
+                    {formatTokenCount(model.total_tokens)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/settings/organization/usage/UsageByUserTable.tsx
+++ b/web/src/components/settings/organization/usage/UsageByUserTable.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import type { TokenUsageByUser } from "@/lib/api/token-usage";
+import type { TranslationFn } from "../GeneralSettings";
+import { formatTokenCount, formatNumber } from "./format";
+
+interface UsageByUserTableProps {
+  data: TokenUsageByUser[];
+  t: TranslationFn;
+}
+
+export function UsageByUserTable({ data, t }: UsageByUserTableProps) {
+  const sorted = [...data].sort((a, b) => b.total_tokens - a.total_tokens);
+
+  return (
+    <div className="border border-border rounded-lg p-6">
+      <h3 className="text-sm font-medium mb-4">{t("settings.usagePage.byUserTitle")}</h3>
+      {sorted.length === 0 ? (
+        <p className="text-sm text-muted-foreground text-center py-8">
+          {t("settings.usagePage.noData")}
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <caption className="sr-only">{t("settings.usagePage.byUserTitle")}</caption>
+            <thead>
+              <tr className="border-b border-border text-left">
+                <th scope="col" className="pb-2 font-medium text-muted-foreground">
+                  {t("settings.usagePage.columnUser")}
+                </th>
+                <th scope="col" className="pb-2 font-medium text-muted-foreground text-right">
+                  {t("settings.usagePage.inputTokens")}
+                </th>
+                <th scope="col" className="pb-2 font-medium text-muted-foreground text-right">
+                  {t("settings.usagePage.outputTokens")}
+                </th>
+                <th scope="col" className="pb-2 font-medium text-muted-foreground text-right">
+                  {t("settings.usagePage.totalTokens")}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((user) => (
+                <tr key={user.user_id} className="border-b border-border/50 last:border-0">
+                  <td className="py-2">
+                    <div className="font-medium">{user.username}</div>
+                    <div className="text-xs text-muted-foreground">{user.email}</div>
+                  </td>
+                  <td className="py-2 text-right" title={formatNumber(user.input_tokens)}>
+                    {formatTokenCount(user.input_tokens)}
+                  </td>
+                  <td className="py-2 text-right" title={formatNumber(user.output_tokens)}>
+                    {formatTokenCount(user.output_tokens)}
+                  </td>
+                  <td className="py-2 text-right font-medium" title={formatNumber(user.total_tokens)}>
+                    {formatTokenCount(user.total_tokens)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/settings/organization/usage/UsageFilters.tsx
+++ b/web/src/components/settings/organization/usage/UsageFilters.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import type { TranslationFn } from "../GeneralSettings";
+
+export type TimeRange = "7d" | "30d" | "90d";
+export type Granularity = "day" | "week" | "month";
+
+interface UsageFiltersProps {
+  timeRange: TimeRange;
+  granularity: Granularity;
+  agentType: string;
+  onTimeRangeChange: (range: TimeRange) => void;
+  onGranularityChange: (granularity: Granularity) => void;
+  onAgentTypeChange: (agentType: string) => void;
+  agentTypes: string[];
+  t: TranslationFn;
+}
+
+const timeRangeOptions: { value: TimeRange; labelKey: string }[] = [
+  { value: "7d", labelKey: "settings.usagePage.filters.last7Days" },
+  { value: "30d", labelKey: "settings.usagePage.filters.last30Days" },
+  { value: "90d", labelKey: "settings.usagePage.filters.last90Days" },
+];
+
+const granularityOptions: { value: Granularity; labelKey: string }[] = [
+  { value: "day", labelKey: "settings.usagePage.filters.day" },
+  { value: "week", labelKey: "settings.usagePage.filters.week" },
+  { value: "month", labelKey: "settings.usagePage.filters.month" },
+];
+
+export function UsageFilters({
+  timeRange,
+  granularity,
+  agentType,
+  onTimeRangeChange,
+  onGranularityChange,
+  onAgentTypeChange,
+  agentTypes,
+  t,
+}: UsageFiltersProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      {/* Time Range */}
+      <div className="flex items-center gap-1.5">
+        <span className="text-sm text-muted-foreground">
+          {t("settings.usagePage.filters.timeRange")}:
+        </span>
+        <div className="inline-flex rounded-md border border-border overflow-hidden">
+          {timeRangeOptions.map((opt) => (
+            <button
+              key={opt.value}
+              className={`px-3 py-1 text-sm transition-colors ${
+                timeRange === opt.value
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-background text-muted-foreground hover:bg-muted"
+              }`}
+              onClick={() => onTimeRangeChange(opt.value)}
+            >
+              {t(opt.labelKey)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Granularity */}
+      <div className="flex items-center gap-1.5">
+        <span className="text-sm text-muted-foreground">
+          {t("settings.usagePage.filters.granularity")}:
+        </span>
+        <div className="inline-flex rounded-md border border-border overflow-hidden">
+          {granularityOptions.map((opt) => (
+            <button
+              key={opt.value}
+              className={`px-3 py-1 text-sm transition-colors ${
+                granularity === opt.value
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-background text-muted-foreground hover:bg-muted"
+              }`}
+              onClick={() => onGranularityChange(opt.value)}
+            >
+              {t(opt.labelKey)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Agent Type */}
+      <div className="flex items-center gap-1.5">
+        <span className="text-sm text-muted-foreground">
+          {t("settings.usagePage.filters.agentType")}:
+        </span>
+        <select
+          value={agentType}
+          onChange={(e) => onAgentTypeChange(e.target.value)}
+          disabled={agentTypes.length === 0}
+          className="rounded-md border border-border bg-background px-3 py-1 text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <option value="">{t("settings.usagePage.filters.allAgents")}</option>
+          {agentTypes.map((agentSlug) => (
+            <option key={agentSlug} value={agentSlug}>
+              {agentSlug}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/settings/organization/usage/UsageOverviewCards.tsx
+++ b/web/src/components/settings/organization/usage/UsageOverviewCards.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import type { TokenUsageSummary } from "@/lib/api/token-usage";
+import type { TranslationFn } from "../GeneralSettings";
+import { formatTokenCount, formatNumber } from "./format";
+
+interface UsageOverviewCardsProps {
+  summary: TokenUsageSummary | null;
+  t: TranslationFn;
+}
+
+interface StatCardProps {
+  label: string;
+  value: number;
+  color: string;
+}
+
+function StatCard({ label, value, color }: StatCardProps) {
+  return (
+    <div className="border border-border rounded-lg p-4">
+      <p className="text-sm text-muted-foreground mb-1">{label}</p>
+      <p className={`text-2xl font-bold ${color}`} title={formatNumber(value)}>
+        {formatTokenCount(value)}
+      </p>
+    </div>
+  );
+}
+
+export function UsageOverviewCards({ summary, t }: UsageOverviewCardsProps) {
+  const cards: StatCardProps[] = [
+    {
+      label: t("settings.usagePage.inputTokens"),
+      value: summary?.input_tokens ?? 0,
+      color: "text-blue-600 dark:text-blue-400",
+    },
+    {
+      label: t("settings.usagePage.outputTokens"),
+      value: summary?.output_tokens ?? 0,
+      color: "text-emerald-600 dark:text-emerald-400",
+    },
+    {
+      label: t("settings.usagePage.cacheCreationTokens"),
+      value: summary?.cache_creation_tokens ?? 0,
+      color: "text-purple-600 dark:text-purple-400",
+    },
+    {
+      label: t("settings.usagePage.cacheReadTokens"),
+      value: summary?.cache_read_tokens ?? 0,
+      color: "text-amber-600 dark:text-amber-400",
+    },
+    {
+      label: t("settings.usagePage.totalTokens"),
+      value: summary?.total_tokens ?? 0,
+      color: "text-foreground",
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-5">
+      {cards.map((card) => (
+        <StatCard key={card.label} {...card} />
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/settings/organization/usage/UsageTimeSeriesChart.tsx
+++ b/web/src/components/settings/organization/usage/UsageTimeSeriesChart.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useMemo } from "react";
+import { useTheme } from "next-themes";
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from "recharts";
+import type { TokenUsageTimeSeriesPoint } from "@/lib/api/token-usage";
+import type { TranslationFn } from "../GeneralSettings";
+import { formatTokenCount } from "./format";
+import { resolveChartColors } from "./chart-colors";
+
+interface UsageTimeSeriesChartProps {
+  data: TokenUsageTimeSeriesPoint[];
+  t: TranslationFn;
+}
+
+function formatDate(timestamp: string): string {
+  const date = new Date(timestamp);
+  const now = new Date();
+  // Include year when timestamp is in a different year (e.g., 90-day ranges crossing year boundary).
+  const opts: Intl.DateTimeFormatOptions =
+    date.getFullYear() !== now.getFullYear()
+      ? { year: "numeric", month: "short", day: "numeric" }
+      : { month: "short", day: "numeric" };
+  return new Intl.DateTimeFormat(undefined, opts).format(date);
+}
+
+export function UsageTimeSeriesChart({ data, t }: UsageTimeSeriesChartProps) {
+  const { resolvedTheme } = useTheme();
+  const colors = useMemo(() => resolveChartColors(resolvedTheme === "dark"), [resolvedTheme]);
+  const chartData = useMemo(
+    () => data.map((point) => ({ ...point, date: formatDate(point.period) })),
+    [data]
+  );
+
+  if (data.length === 0) {
+    return (
+      <div className="border border-border rounded-lg p-6">
+        <h3 className="text-sm font-medium mb-4">{t("settings.usagePage.timeSeriesTitle")}</h3>
+        <p className="text-sm text-muted-foreground text-center py-8">
+          {t("settings.usagePage.noData")}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border border-border rounded-lg p-6">
+      <h3 className="text-sm font-medium mb-4">{t("settings.usagePage.timeSeriesTitle")}</h3>
+      <div role="img" aria-label={t("settings.usagePage.timeSeriesTitle")}>
+        <ResponsiveContainer width="100%" height={300}>
+          <AreaChart data={chartData} margin={{ top: 5, right: 20, left: 10, bottom: 5 }}>
+            <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+            <XAxis dataKey="date" className="text-xs" tick={{ fontSize: 12 }} />
+            <YAxis tickFormatter={formatTokenCount} className="text-xs" tick={{ fontSize: 12 }} />
+            <Tooltip
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              formatter={(value: any, name: any) => [formatTokenCount(Number(value)), name]}
+              labelFormatter={(label: string) => label}
+              contentStyle={{
+                backgroundColor: "hsl(var(--popover))",
+                border: "1px solid hsl(var(--border))",
+                borderRadius: "6px",
+                fontSize: "12px",
+              }}
+            />
+            <Legend />
+            <Area
+              type="monotone"
+              dataKey="input_tokens"
+              name={t("settings.usagePage.inputTokens")}
+              stackId="1"
+              stroke={colors.input}
+              fill={colors.input}
+              fillOpacity={0.3}
+            />
+            <Area
+              type="monotone"
+              dataKey="output_tokens"
+              name={t("settings.usagePage.outputTokens")}
+              stackId="1"
+              stroke={colors.output}
+              fill={colors.output}
+              fillOpacity={0.3}
+            />
+            <Area
+              type="monotone"
+              dataKey="cache_creation_tokens"
+              name={t("settings.usagePage.cacheCreationTokens")}
+              stackId="1"
+              stroke={colors.cacheCreation}
+              fill={colors.cacheCreation}
+              fillOpacity={0.3}
+            />
+            <Area
+              type="monotone"
+              dataKey="cache_read_tokens"
+              name={t("settings.usagePage.cacheReadTokens")}
+              stackId="1"
+              stroke={colors.cacheRead}
+              fill={colors.cacheRead}
+              fillOpacity={0.3}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/settings/organization/usage/chart-colors.ts
+++ b/web/src/components/settings/organization/usage/chart-colors.ts
@@ -1,0 +1,23 @@
+/**
+ * Chart color palette with light/dark mode variants.
+ *
+ * Light mode uses deeper tones (600 level) for good contrast on white backgrounds.
+ * Dark mode uses brighter tones (400 level) so areas/bars remain visible on dark backgrounds.
+ */
+export const chartColors = {
+  input: { light: "#2563eb", dark: "#60a5fa" }, // blue-600 / blue-400
+  output: { light: "#059669", dark: "#34d399" }, // emerald-600 / emerald-400
+  cacheCreation: { light: "#9333ea", dark: "#c084fc" }, // purple-600 / purple-300
+  cacheRead: { light: "#d97706", dark: "#fbbf24" }, // amber-600 / amber-400
+} as const;
+
+/** Returns resolved hex colors based on current theme. */
+export function resolveChartColors(isDark: boolean) {
+  const mode = isDark ? "dark" : "light";
+  return {
+    input: chartColors.input[mode],
+    output: chartColors.output[mode],
+    cacheCreation: chartColors.cacheCreation[mode],
+    cacheRead: chartColors.cacheRead[mode],
+  };
+}

--- a/web/src/components/settings/organization/usage/format.test.ts
+++ b/web/src/components/settings/organization/usage/format.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { formatTokenCount, formatNumber } from "./format";
+
+describe("formatTokenCount", () => {
+  it("returns '0' for non-finite values", () => {
+    expect(formatTokenCount(NaN)).toBe("0");
+    expect(formatTokenCount(Infinity)).toBe("0");
+    expect(formatTokenCount(-Infinity)).toBe("0");
+  });
+
+  it("returns raw number for values below 1000", () => {
+    expect(formatTokenCount(0)).toBe("0");
+    expect(formatTokenCount(1)).toBe("1");
+    expect(formatTokenCount(999)).toBe("999");
+  });
+
+  it("formats thousands with K suffix", () => {
+    expect(formatTokenCount(1000)).toBe("1.0K");
+    expect(formatTokenCount(1500)).toBe("1.5K");
+    expect(formatTokenCount(12345)).toBe("12.3K");
+    expect(formatTokenCount(999000)).toBe("999.0K");
+  });
+
+  it("promotes to M when K would round to 1000.0K", () => {
+    // 999950 / 1000 = 999.95, which would round to "1000.0K"
+    expect(formatTokenCount(999950)).toBe("1.00M");
+    expect(formatTokenCount(999999)).toBe("1.00M");
+  });
+
+  it("formats millions with M suffix", () => {
+    expect(formatTokenCount(1_000_000)).toBe("1.00M");
+    expect(formatTokenCount(1_234_567)).toBe("1.23M");
+    expect(formatTokenCount(999_000_000)).toBe("999.00M");
+  });
+
+  it("formats billions with B suffix", () => {
+    expect(formatTokenCount(1_000_000_000)).toBe("1.00B");
+    expect(formatTokenCount(2_500_000_000)).toBe("2.50B");
+  });
+
+  it("formats trillions with T suffix", () => {
+    expect(formatTokenCount(1_000_000_000_000)).toBe("1.00T");
+  });
+});
+
+describe("formatNumber", () => {
+  it("returns '0' for non-finite values", () => {
+    expect(formatNumber(NaN)).toBe("0");
+    expect(formatNumber(Infinity)).toBe("0");
+  });
+
+  it("formats with locale separators", () => {
+    // The exact output depends on locale, but it should be a string
+    const result = formatNumber(1234567);
+    expect(typeof result).toBe("string");
+    expect(result.length).toBeGreaterThan(0);
+  });
+});

--- a/web/src/components/settings/organization/usage/format.ts
+++ b/web/src/components/settings/organization/usage/format.ts
@@ -1,0 +1,33 @@
+/**
+ * Format large numbers into human-readable strings.
+ * Examples: 1234567 -> "1.23M", 12345 -> "12.3K", 999 -> "999"
+ */
+export function formatTokenCount(value: number): string {
+  if (!Number.isFinite(value)) return "0";
+  if (value >= 1_000_000_000_000) {
+    return `${(value / 1_000_000_000_000).toFixed(2)}T`;
+  }
+  if (value >= 1_000_000_000) {
+    return `${(value / 1_000_000_000).toFixed(2)}B`;
+  }
+  if (value >= 1_000_000) {
+    return `${(value / 1_000_000).toFixed(2)}M`;
+  }
+  if (value >= 1_000) {
+    // Avoid "1000.0K" — promote to M when rounding crosses the boundary.
+    const k = value / 1_000;
+    if (k >= 999.95) {
+      return `${(value / 1_000_000).toFixed(2)}M`;
+    }
+    return `${k.toFixed(1)}K`;
+  }
+  return String(value);
+}
+
+/**
+ * Format a number with locale-aware thousand separators.
+ */
+export function formatNumber(value: number): string {
+  if (!Number.isFinite(value)) return "0";
+  return value.toLocaleString();
+}

--- a/web/src/components/settings/organization/usage/index.ts
+++ b/web/src/components/settings/organization/usage/index.ts
@@ -1,0 +1,9 @@
+export { UsageOverviewCards } from "./UsageOverviewCards";
+export { UsageTimeSeriesChart } from "./UsageTimeSeriesChart";
+export { UsageByAgentChart } from "./UsageByAgentChart";
+export { UsageByUserTable } from "./UsageByUserTable";
+export { UsageByModelTable } from "./UsageByModelTable";
+export { UsageFilters } from "./UsageFilters";
+export type { TimeRange, Granularity } from "./UsageFilters";
+export { formatTokenCount, formatNumber } from "./format";
+export { chartColors, resolveChartColors } from "./chart-colors";

--- a/web/src/lib/api/base.ts
+++ b/web/src/lib/api/base.ts
@@ -10,6 +10,7 @@ export interface RequestOptions {
   body?: unknown;
   headers?: Record<string, string>;
   skipAuthRefresh?: boolean; // Skip token refresh for auth endpoints
+  signal?: AbortSignal; // AbortController signal to cancel in-flight requests
 }
 
 export interface ApiErrorData {
@@ -95,7 +96,7 @@ export async function request<T>(
   endpoint: string,
   options: RequestOptions = {}
 ): Promise<T> {
-  const { method = "GET", body, headers = {}, skipAuthRefresh = false } = options;
+  const { method = "GET", body, headers = {}, skipAuthRefresh = false, signal } = options;
   const { token } = useAuthStore.getState();
 
   const requestHeaders: Record<string, string> = {
@@ -111,6 +112,7 @@ export async function request<T>(
     method,
     headers: requestHeaders,
     body: body ? JSON.stringify(body) : undefined,
+    signal,
   });
 
   // Handle 401 Unauthorized - try to refresh token
@@ -126,6 +128,7 @@ export async function request<T>(
         method,
         headers: requestHeaders,
         body: body ? JSON.stringify(body) : undefined,
+        signal,
       });
 
       if (!retryResponse.ok) {

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -202,3 +202,14 @@ export type { NotificationPreference } from "./notification";
 // SSO
 export { ssoApi, getSSOAuthURL } from "./sso";
 export type { SSOConfig, SSODiscoverResponse } from "./sso";
+
+// Token Usage
+export { tokenUsageApi } from "./token-usage";
+export type {
+  TokenUsageSummary,
+  TokenUsageTimeSeriesPoint,
+  TokenUsageByAgent,
+  TokenUsageByUser,
+  TokenUsageByModel,
+  TokenUsageQueryParams,
+} from "./token-usage";

--- a/web/src/lib/api/organization.ts
+++ b/web/src/lib/api/organization.ts
@@ -20,6 +20,7 @@ export interface OrganizationData {
   id: number;
   name: string;
   slug: string;
+  role?: string;
   logo_url?: string;
   subscription_plan?: string;
   subscription_status?: string;

--- a/web/src/lib/api/token-usage.ts
+++ b/web/src/lib/api/token-usage.ts
@@ -1,0 +1,87 @@
+import { request, orgPath } from "./base";
+
+// Token usage types — aligned with Backend domain/tokenusage structs
+
+export interface TokenUsageSummary {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_creation_tokens: number;
+  total_tokens: number;
+}
+
+export interface TokenUsageTimeSeriesPoint {
+  period: string; // ISO 8601 timestamp from date_trunc
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_creation_tokens: number;
+}
+
+export interface TokenUsageByAgent {
+  agent_type: string; // agent_type_slug
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_creation_tokens: number;
+  total_tokens: number;
+}
+
+export interface TokenUsageByUser {
+  user_id: number;
+  username: string;
+  email: string;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_creation_tokens: number;
+  total_tokens: number;
+}
+
+export interface TokenUsageByModel {
+  model: string;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_creation_tokens: number;
+  total_tokens: number;
+}
+
+export interface TokenUsageQueryParams {
+  start_time?: string;
+  end_time?: string;
+  agent_type?: string;
+  user_id?: number;
+  model?: string;
+  granularity?: "day" | "week" | "month";
+}
+
+// TokenUsageDashboard is the response from GET /token-usage/dashboard.
+export interface TokenUsageDashboard {
+  summary: TokenUsageSummary;
+  time_series: TokenUsageTimeSeriesPoint[];
+  by_agent: TokenUsageByAgent[];
+  by_user: TokenUsageByUser[];
+  by_model: TokenUsageByModel[];
+}
+
+function buildQueryString(params: TokenUsageQueryParams): string {
+  const searchParams = new URLSearchParams();
+  if (params.start_time) searchParams.append("start_time", params.start_time);
+  if (params.end_time) searchParams.append("end_time", params.end_time);
+  if (params.agent_type) searchParams.append("agent_type", params.agent_type);
+  if (params.user_id !== undefined) searchParams.append("user_id", String(params.user_id));
+  if (params.model) searchParams.append("model", params.model);
+  if (params.granularity) searchParams.append("granularity", params.granularity);
+  const qs = searchParams.toString();
+  return qs ? `?${qs}` : "";
+}
+
+// Token Usage API — single dashboard endpoint.
+export const tokenUsageApi = {
+  getDashboard: (params: TokenUsageQueryParams = {}, signal?: AbortSignal) =>
+    request<TokenUsageDashboard>(
+      orgPath(`/token-usage/dashboard${buildQueryString(params)}`),
+      { signal }
+    ),
+};

--- a/web/src/messages/de/settings.json
+++ b/web/src/messages/de/settings.json
@@ -355,6 +355,37 @@
         }
       }
     },
+    "usagePage": {
+      "title": "Token-Verbrauch",
+      "description": "Token-Verbrauch in Ihrer Organisation überwachen",
+      "inputTokens": "Eingabe-Token",
+      "outputTokens": "Ausgabe-Token",
+      "cacheReadTokens": "Cache-Lese-Token",
+      "cacheCreationTokens": "Cache-Erstellungs-Token",
+      "totalTokens": "Token gesamt",
+      "timeSeriesTitle": "Token-Verbrauch im Zeitverlauf",
+      "byAgentTitle": "Verbrauch nach Agent",
+      "byUserTitle": "Verbrauch nach Benutzer",
+      "byModelTitle": "Verbrauch nach Modell",
+      "columnUser": "Benutzer",
+      "columnModel": "Modell",
+      "unknown": "Unbekannt",
+      "noData": "Keine Token-Verbrauchsdaten verfügbar",
+      "loadFailed": "Token-Verbrauchsdaten konnten nicht geladen werden",
+      "retry": "Erneut versuchen",
+      "filters": {
+        "timeRange": "Zeitraum",
+        "agentType": "Agent-Typ",
+        "granularity": "Granularität",
+        "allAgents": "Alle Agents",
+        "last7Days": "Letzte 7 Tage",
+        "last30Days": "Letzte 30 Tage",
+        "last90Days": "Letzte 90 Tage",
+        "day": "Tag",
+        "week": "Woche",
+        "month": "Monat"
+      }
+    },
     "notifications": {
       "title": "Push Notifications",
       "description": "Configure push notifications for important events like pod status changes, ticket assignments, and runner alerts.",

--- a/web/src/messages/en/ide.json
+++ b/web/src/messages/en/ide.json
@@ -112,7 +112,9 @@
           "extensions": "Extensions",
           "extensionsDesc": "Skills and MCP server marketplace",
           "billing": "Billing",
-          "billingDesc": "Subscription and payments"
+          "billingDesc": "Subscription and payments",
+          "usage": "Token Usage",
+          "usageDesc": "Monitor token consumption"
         }
       },
       "mesh": {

--- a/web/src/messages/en/settings.json
+++ b/web/src/messages/en/settings.json
@@ -495,6 +495,37 @@
         }
       }
     },
+    "usagePage": {
+      "title": "Token Usage",
+      "description": "Monitor token consumption across your organization",
+      "inputTokens": "Input Tokens",
+      "outputTokens": "Output Tokens",
+      "cacheReadTokens": "Cache Read Tokens",
+      "cacheCreationTokens": "Cache Creation Tokens",
+      "totalTokens": "Total Tokens",
+      "timeSeriesTitle": "Token Usage Over Time",
+      "byAgentTitle": "Usage by Agent",
+      "byUserTitle": "Usage by User",
+      "byModelTitle": "Usage by Model",
+      "columnUser": "User",
+      "columnModel": "Model",
+      "unknown": "Unknown",
+      "noData": "No token usage data available",
+      "loadFailed": "Failed to load token usage data",
+      "retry": "Retry",
+      "filters": {
+        "timeRange": "Time Range",
+        "agentType": "Agent Type",
+        "granularity": "Granularity",
+        "allAgents": "All Agents",
+        "last7Days": "Last 7 Days",
+        "last30Days": "Last 30 Days",
+        "last90Days": "Last 90 Days",
+        "day": "Day",
+        "week": "Week",
+        "month": "Month"
+      }
+    },
     "notifications": {
       "title": "Push Notifications",
       "description": "Configure push notifications for important events like pod status changes, ticket assignments, and runner alerts.",

--- a/web/src/messages/es/settings.json
+++ b/web/src/messages/es/settings.json
@@ -355,6 +355,37 @@
         }
       }
     },
+    "usagePage": {
+      "title": "Uso de Tokens",
+      "description": "Monitorear el consumo de tokens en su organización",
+      "inputTokens": "Tokens de entrada",
+      "outputTokens": "Tokens de salida",
+      "cacheReadTokens": "Tokens de lectura de caché",
+      "cacheCreationTokens": "Tokens de creación de caché",
+      "totalTokens": "Tokens totales",
+      "timeSeriesTitle": "Uso de tokens en el tiempo",
+      "byAgentTitle": "Uso por agente",
+      "byUserTitle": "Uso por usuario",
+      "byModelTitle": "Uso por modelo",
+      "columnUser": "Usuario",
+      "columnModel": "Modelo",
+      "unknown": "Desconocido",
+      "noData": "No hay datos de uso de tokens disponibles",
+      "loadFailed": "Error al cargar los datos de uso de tokens",
+      "retry": "Reintentar",
+      "filters": {
+        "timeRange": "Período",
+        "agentType": "Tipo de agente",
+        "granularity": "Granularidad",
+        "allAgents": "Todos los agentes",
+        "last7Days": "Últimos 7 días",
+        "last30Days": "Últimos 30 días",
+        "last90Days": "Últimos 90 días",
+        "day": "Día",
+        "week": "Semana",
+        "month": "Mes"
+      }
+    },
     "notifications": {
       "title": "Push Notifications",
       "description": "Configure push notifications for important events like pod status changes, ticket assignments, and runner alerts.",

--- a/web/src/messages/fr/settings.json
+++ b/web/src/messages/fr/settings.json
@@ -355,6 +355,37 @@
         }
       }
     },
+    "usagePage": {
+      "title": "Utilisation des tokens",
+      "description": "Surveiller la consommation de tokens dans votre organisation",
+      "inputTokens": "Tokens d'entrée",
+      "outputTokens": "Tokens de sortie",
+      "cacheReadTokens": "Tokens de lecture cache",
+      "cacheCreationTokens": "Tokens de création cache",
+      "totalTokens": "Total des tokens",
+      "timeSeriesTitle": "Utilisation des tokens dans le temps",
+      "byAgentTitle": "Utilisation par agent",
+      "byUserTitle": "Utilisation par utilisateur",
+      "byModelTitle": "Utilisation par modèle",
+      "columnUser": "Utilisateur",
+      "columnModel": "Modèle",
+      "unknown": "Inconnu",
+      "noData": "Aucune donnée d'utilisation de tokens disponible",
+      "loadFailed": "Échec du chargement des données d'utilisation des tokens",
+      "retry": "Réessayer",
+      "filters": {
+        "timeRange": "Période",
+        "agentType": "Type d'agent",
+        "granularity": "Granularité",
+        "allAgents": "Tous les agents",
+        "last7Days": "7 derniers jours",
+        "last30Days": "30 derniers jours",
+        "last90Days": "90 derniers jours",
+        "day": "Jour",
+        "week": "Semaine",
+        "month": "Mois"
+      }
+    },
     "notifications": {
       "title": "Push Notifications",
       "description": "Configure push notifications for important events like pod status changes, ticket assignments, and runner alerts.",

--- a/web/src/messages/ja/settings.json
+++ b/web/src/messages/ja/settings.json
@@ -355,6 +355,37 @@
         }
       }
     },
+    "usagePage": {
+      "title": "トークン使用量",
+      "description": "組織全体のトークン消費を監視",
+      "inputTokens": "入力トークン",
+      "outputTokens": "出力トークン",
+      "cacheReadTokens": "キャッシュ読取トークン",
+      "cacheCreationTokens": "キャッシュ作成トークン",
+      "totalTokens": "合計トークン",
+      "timeSeriesTitle": "トークン使用量の推移",
+      "byAgentTitle": "エージェント別使用量",
+      "byUserTitle": "ユーザー別使用量",
+      "byModelTitle": "モデル別使用量",
+      "columnUser": "ユーザー",
+      "columnModel": "モデル",
+      "unknown": "不明",
+      "noData": "トークン使用データがありません",
+      "loadFailed": "トークン使用データの読み込みに失敗しました",
+      "retry": "再試行",
+      "filters": {
+        "timeRange": "期間",
+        "agentType": "エージェントタイプ",
+        "granularity": "粒度",
+        "allAgents": "すべてのエージェント",
+        "last7Days": "過去7日間",
+        "last30Days": "過去30日間",
+        "last90Days": "過去90日間",
+        "day": "日",
+        "week": "週",
+        "month": "月"
+      }
+    },
     "notifications": {
       "title": "Push Notifications",
       "description": "Configure push notifications for important events like pod status changes, ticket assignments, and runner alerts.",

--- a/web/src/messages/ko/settings.json
+++ b/web/src/messages/ko/settings.json
@@ -355,6 +355,37 @@
         }
       }
     },
+    "usagePage": {
+      "title": "토큰 사용량",
+      "description": "조직 전체의 토큰 소비를 모니터링합니다",
+      "inputTokens": "입력 토큰",
+      "outputTokens": "출력 토큰",
+      "cacheReadTokens": "캐시 읽기 토큰",
+      "cacheCreationTokens": "캐시 생성 토큰",
+      "totalTokens": "총 토큰",
+      "timeSeriesTitle": "시간별 토큰 사용량",
+      "byAgentTitle": "에이전트별 사용량",
+      "byUserTitle": "사용자별 사용량",
+      "byModelTitle": "모델별 사용량",
+      "columnUser": "사용자",
+      "columnModel": "모델",
+      "unknown": "알 수 없음",
+      "noData": "토큰 사용 데이터가 없습니다",
+      "loadFailed": "토큰 사용 데이터를 불러오지 못했습니다",
+      "retry": "다시 시도",
+      "filters": {
+        "timeRange": "기간",
+        "agentType": "에이전트 유형",
+        "granularity": "세분화",
+        "allAgents": "모든 에이전트",
+        "last7Days": "최근 7일",
+        "last30Days": "최근 30일",
+        "last90Days": "최근 90일",
+        "day": "일",
+        "week": "주",
+        "month": "월"
+      }
+    },
     "notifications": {
       "title": "Push Notifications",
       "description": "Configure push notifications for important events like pod status changes, ticket assignments, and runner alerts.",

--- a/web/src/messages/pt/settings.json
+++ b/web/src/messages/pt/settings.json
@@ -355,6 +355,37 @@
         }
       }
     },
+    "usagePage": {
+      "title": "Uso de Tokens",
+      "description": "Monitorar o consumo de tokens na sua organização",
+      "inputTokens": "Tokens de entrada",
+      "outputTokens": "Tokens de saída",
+      "cacheReadTokens": "Tokens de leitura de cache",
+      "cacheCreationTokens": "Tokens de criação de cache",
+      "totalTokens": "Total de tokens",
+      "timeSeriesTitle": "Uso de tokens ao longo do tempo",
+      "byAgentTitle": "Uso por agente",
+      "byUserTitle": "Uso por usuário",
+      "byModelTitle": "Uso por modelo",
+      "columnUser": "Usuário",
+      "columnModel": "Modelo",
+      "unknown": "Desconhecido",
+      "noData": "Nenhum dado de uso de tokens disponível",
+      "loadFailed": "Falha ao carregar dados de uso de tokens",
+      "retry": "Tentar novamente",
+      "filters": {
+        "timeRange": "Período",
+        "agentType": "Tipo de agente",
+        "granularity": "Granularidade",
+        "allAgents": "Todos os agentes",
+        "last7Days": "Últimos 7 dias",
+        "last30Days": "Últimos 30 dias",
+        "last90Days": "Últimos 90 dias",
+        "day": "Dia",
+        "week": "Semana",
+        "month": "Mês"
+      }
+    },
     "notifications": {
       "title": "Push Notifications",
       "description": "Configure push notifications for important events like pod status changes, ticket assignments, and runner alerts.",

--- a/web/src/messages/zh/ide.json
+++ b/web/src/messages/zh/ide.json
@@ -112,7 +112,9 @@
           "extensions": "扩展",
           "extensionsDesc": "Skill 和 MCP 服务器市场",
           "billing": "账单",
-          "billingDesc": "订阅和付款"
+          "billingDesc": "订阅和付款",
+          "usage": "Token 用量",
+          "usageDesc": "监控 Token 消耗"
         }
       },
       "mesh": {

--- a/web/src/messages/zh/settings.json
+++ b/web/src/messages/zh/settings.json
@@ -495,6 +495,37 @@
         }
       }
     },
+    "usagePage": {
+      "title": "Token 用量",
+      "description": "监控组织内的 Token 消耗情况",
+      "inputTokens": "输入 Token",
+      "outputTokens": "输出 Token",
+      "cacheReadTokens": "缓存读取 Token",
+      "cacheCreationTokens": "缓存创建 Token",
+      "totalTokens": "总计 Token",
+      "timeSeriesTitle": "Token 用量趋势",
+      "byAgentTitle": "按智能体统计",
+      "byUserTitle": "按用户统计",
+      "byModelTitle": "按模型统计",
+      "columnUser": "用户",
+      "columnModel": "模型",
+      "unknown": "未知",
+      "noData": "暂无 Token 用量数据",
+      "loadFailed": "加载 Token 用量数据失败",
+      "retry": "重试",
+      "filters": {
+        "timeRange": "时间范围",
+        "agentType": "智能体类型",
+        "granularity": "粒度",
+        "allAgents": "全部智能体",
+        "last7Days": "最近 7 天",
+        "last30Days": "最近 30 天",
+        "last90Days": "最近 90 天",
+        "day": "日",
+        "week": "周",
+        "month": "月"
+      }
+    },
     "notifications": {
       "title": "推送通知",
       "description": "配置重要事件的推送通知，如 Pod 状态变化、Ticket 分配和 Runner 警报。",


### PR DESCRIPTION
## Summary

Full-stack implementation of token usage monitoring across AI agents (Claude Code, Codex CLI, OpenCode, Aider):

- **Database**: `token_usages` table with org/user/agent/model dimensions and time-series indexes
- **Runner**: Plugin-based token parsers for 4 agent types, collect on pod exit, report via gRPC
- **Backend**: Domain model, GORM repository with `date_trunc()` aggregation, REST API (`GET /token-usage/dashboard`) with Owner/Admin-only access
- **Frontend**: Usage settings page with overview cards, time-series chart, by-agent/user/model breakdowns, date/granularity/agent filters
- **Bugfix**: Org role field missing from `/api/v1/orgs` response (changed `gorm:"-"` to `gorm:"->"` read-only tag)
- **i18n**: Translations for en, zh, de, es, fr, ja, ko, pt

## Test plan

- [x] Backend unit tests pass (`go test ./...`)
- [x] Runner unit tests pass (`go test ./...`)
- [x] Frontend tests pass (1238 tests, `pnpm test:run`)
- [x] E2E verified: login → settings → Usage tab visible (Owner/Admin only) → dashboard renders with test data
- [x] Proto field number 25 (no conflict with #88 log upload at field 24)