### PR TITLE
fix(runnerlog): use public presigned URL for runner log uploads

### DIFF
--- a/backend/internal/service/runnerlog/service.go
+++ b/backend/internal/service/runnerlog/service.go
@@ -59,8 +59,8 @@ func (s *Service) RequestUpload(ctx context.Context, orgID, runnerID, userID int
 	}
 
 	// Generate presigned PUT URL
-	// Use internal presigned URL because Runner connects within Docker network
-	presignedURL, err := s.storage.InternalPresignPutURL(ctx, storageKey, "application/gzip", presignPutExpiry)
+	// Use public presigned URL because Runner is self-hosted and connects from external networks
+	presignedURL, err := s.storage.PresignPutURL(ctx, storageKey, "application/gzip", presignPutExpiry)
 	if err != nil {
 		// Mark the record as failed since we can't proceed
 		_ = s.repo.MarkFailed(ctx, requestID, "failed to generate upload URL")


### PR DESCRIPTION
## Summary
- Runner diagnostic log upload was failing because the backend generated an **internal OSS presigned URL** (`oss-us-west-1-internal.aliyuncs.com`) which is only accessible within the Alibaba Cloud VPC
- Runner is self-hosted on user machines (e.g., Mac Mini), so it cannot reach the internal endpoint (`connection refused`)
- Switched `InternalPresignPutURL` → `PresignPutURL` in `runnerlog.Service.RequestUpload` so the presigned URL uses the public endpoint

## Test plan
- [ ] Deploy backend and trigger "upload diagnostic logs" from a self-hosted Runner
- [ ] Verify the presigned URL uses the public OSS endpoint
- [ ] Confirm log file appears in OSS after upload