### PR TITLE
fix(runner): fix log collector not matching rotated log filenames

### DIFF
--- a/runner/internal/config/config_paths.go
+++ b/runner/internal/config/config_paths.go
@@ -70,10 +70,16 @@ func (c *Config) GetPluginsDir() string {
 	return filepath.Join(home, ".agentsmesh", "plugins")
 }
 
+// DefaultLogFileName returns the base log file name (e.g., "runner.log").
+// Used by both the logger (for rotation naming) and the log collector (for pattern matching).
+func DefaultLogFileName() string {
+	return "runner.log"
+}
+
 // GetLogPath returns the log file path.
 // Always uses TempBaseDir for predictable, easy-to-find log location.
 func (c *Config) GetLogPath() string {
-	return filepath.Join(TempBaseDir(), "runner.log")
+	return filepath.Join(TempBaseDir(), DefaultLogFileName())
 }
 
 // GetLogConfig returns the logger configuration.

--- a/runner/internal/logger/logger.go
+++ b/runner/internal/logger/logger.go
@@ -196,6 +196,21 @@ func Close() error {
 	return nil
 }
 
+// IsOwnLogFile reports whether filename matches the default logger's rotated log
+// file naming pattern (e.g., "runner-2024-01-15.log", "runner-2024-01-15.log.0").
+// Returns false if the logger was not initialized with a file path.
+func IsOwnLogFile(filename string) bool {
+	mu.RLock()
+	w := defaultLogger
+	mu.RUnlock()
+
+	if w == nil || w.writer == nil {
+		return false
+	}
+	prefix := w.writer.baseName + "-"
+	return IsLogFile(filename, prefix, w.writer.ext)
+}
+
 // Default returns the default logger.
 func Default() *slog.Logger {
 	mu.RLock()

--- a/runner/internal/logger/logger_rotating_writer.go
+++ b/runner/internal/logger/logger_rotating_writer.go
@@ -220,7 +220,7 @@ func (rw *rotatingWriter) cleanupOldLogs() {
 
 		name := entry.Name()
 		// Check if file matches our log pattern
-		if !isLogFile(name, prefix, rw.ext) {
+		if !IsLogFile(name, prefix, rw.ext) {
 			continue
 		}
 
@@ -262,8 +262,10 @@ func (rw *rotatingWriter) cleanupOldLogs() {
 	}
 }
 
-// isLogFile checks if a filename matches the log file pattern.
-func isLogFile(name, prefix, ext string) bool {
+// IsLogFile checks if a filename matches the rotated log file pattern.
+// Pattern: prefix + YYYY-MM-DD + ext (e.g., runner-2024-01-15.log)
+// Or: prefix + YYYY-MM-DD + ext + .N (e.g., runner-2024-01-15.log.0)
+func IsLogFile(name, prefix, ext string) bool {
 	// Match: prefix + date + ext (e.g., runner-2024-01-15.log)
 	// Or: prefix + date + ext + .N (e.g., runner-2024-01-15.log.0)
 	if len(name) < len(prefix)+len(ext)+10 { // 10 = len("YYYY-MM-DD")

--- a/runner/internal/logger/logger_test.go
+++ b/runner/internal/logger/logger_test.go
@@ -75,9 +75,9 @@ func TestIsLogFile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := isLogFile(tt.filename, tt.prefix, tt.ext)
+			got := IsLogFile(tt.filename, tt.prefix, tt.ext)
 			if got != tt.want {
-				t.Errorf("isLogFile(%q, %q, %q) = %v, want %v",
+				t.Errorf("IsLogFile(%q, %q, %q) = %v, want %v",
 					tt.filename, tt.prefix, tt.ext, got, tt.want)
 			}
 		})
@@ -225,7 +225,7 @@ func TestRotatingWriter_DirectoryCleanup(t *testing.T) {
 		if err != nil {
 			continue
 		}
-		if isLogFile(entry.Name(), "test-", ".log") {
+		if IsLogFile(entry.Name(), "test-", ".log") {
 			totalSize += info.Size()
 			logCount++
 		}

--- a/runner/internal/runner/log_collector.go
+++ b/runner/internal/runner/log_collector.go
@@ -60,7 +60,7 @@ func CollectLogs(ctx context.Context) (tarPath string, sizeBytes int64, err erro
 		totalBytes += written
 	}
 
-	// Collect runner.log* and diagnostic files from logDir
+	// Collect runner log files (runner-YYYY-MM-DD.log*) and diagnostic files from logDir
 	entries, dirErr := os.ReadDir(logDir)
 	if dirErr != nil {
 		log.Warn("Failed to read log directory", "dir", logDir, "error", dirErr)
@@ -73,7 +73,7 @@ func CollectLogs(ctx context.Context) (tarPath string, sizeBytes int64, err erro
 			if entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
 				continue
 			}
-			if strings.HasPrefix(name, "runner.log") ||
+			if logger.IsOwnLogFile(name) ||
 				(strings.HasPrefix(name, "blocked-") && strings.HasSuffix(name, ".stacks")) ||
 				(strings.HasPrefix(name, "diag-") && strings.HasSuffix(name, ".txt")) {
 				addFile(filepath.Join(logDir, name), name)


### PR DESCRIPTION
## Summary
- Log collector used `strings.HasPrefix(name, "runner.log")` to find log files, but the rotating writer names them `runner-YYYY-MM-DD.log` — this mismatch produced empty 32-byte tar.gz archives
- Export `logger.IsLogFile` and add `logger.IsOwnLogFile()` so the collector delegates filename matching to the logger (single source of truth)
- Extract `config.DefaultLogFileName()` to eliminate the magic string in `GetLogPath`

## Test plan
- [ ] Deploy runner and trigger "upload diagnostic logs"
- [ ] Verify the downloaded tar.gz contains actual log files (not 32 bytes)
- [ ] Run `go test ./...` in runner — all pass