### PR TITLE
fix(runner): make HTTP server port binding synchronous to fail fast o…

### DIFF
--- a/runner/internal/console/server.go
+++ b/runner/internal/console/server.go
@@ -6,6 +6,7 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -95,17 +96,24 @@ func (s *Server) Start() error {
 	}
 	mux.Handle("/", http.FileServer(http.FS(staticFS)))
 
+	addr := fmt.Sprintf("127.0.0.1:%d", s.port)
 	s.httpServer = &http.Server{
-		Addr:         fmt.Sprintf("127.0.0.1:%d", s.port),
+		Addr:         addr,
 		Handler:      mux,
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
 	}
 
+	// Bind port synchronously so that callers (Supervisor) see bind errors immediately.
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("console server failed to bind %s: %w", addr, err)
+	}
+
 	log.Info("Starting web console", "url", fmt.Sprintf("http://127.0.0.1:%d", s.port))
 
 	safego.Go("console-http-listen", func() {
-		if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := s.httpServer.Serve(listener); err != nil && err != http.ErrServerClosed {
 			log.Error("Server error", "error", err)
 		}
 	})

--- a/runner/internal/mcp/http_server.go
+++ b/runner/internal/mcp/http_server.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/pprof"
 	"sync"
@@ -108,18 +109,26 @@ func (s *HTTPServer) Start() error {
 	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
+	addr := fmt.Sprintf("127.0.0.1:%d", s.port)
 	s.httpServer = &http.Server{
-		Addr:         fmt.Sprintf("127.0.0.1:%d", s.port),
+		Addr:         addr,
 		Handler:      mux,
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 	}
 
 	log := logger.MCP()
+
+	// Bind port synchronously so that callers (Supervisor) see bind errors immediately.
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("MCP server failed to bind %s: %w", addr, err)
+	}
+
 	log.Info("Starting MCP HTTP server", "port", s.port)
 
 	safego.Go("mcp-http-listen", func() {
-		if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := s.httpServer.Serve(listener); err != nil && err != http.ErrServerClosed {
 			log.Error("Server error", "error", err)
 		}
 	})


### PR DESCRIPTION
…n conflict

Previously, both MCP and Console servers called ListenAndServe inside a goroutine, causing Start() to always return nil even when the port was already in use. This allowed a runner to continue operating without a functional MCP server, making all pod MCP tool calls fail silently.

Split into synchronous net.Listen() + async Serve(listener) so port binding errors propagate to the Supervisor immediately.

## Summary

- What changed?
- Why was this change needed?

## Changes

- 

## Validation

- [ ] Backend tests (`cd backend && go test ./...`)
- [ ] Web checks (`cd web && pnpm run lint && pnpm run type-check && pnpm run test:coverage`)
- [ ] Runner checks (`cd runner && go test ./...`)
- [ ] Manual validation performed (if applicable)

## Documentation

- [ ] Docs updated (README/docs/inline comments)
- [ ] No docs changes needed

## Risk and Rollback

- Risk level: Low / Medium / High
- Rollback plan:
