### PR TITLE
fix(runner): fix VirtualTerminal RWMutex deadlock in serialization code

### DIFF
--- a/runner/internal/terminal/vt/serialize_handler.go
+++ b/runner/internal/terminal/vt/serialize_handler.go
@@ -60,7 +60,7 @@ func (h *StringSerializeHandler) serialize(startRow, endRow int, excludeFinalCur
 		h.currentRow.Reset()
 		h.nullCellCount = 0
 
-		cells := h.vt.GetCellsRow(row)
+		cells := h.vt.getCellsRowNoLock(row)
 		if cells != nil {
 			for col := 0; col < len(cells); col++ {
 				cell := cells[col]
@@ -157,7 +157,7 @@ func (h *StringSerializeHandler) rowEnd(row int, isLastRow bool) {
 
 	rowSeparator := ""
 	if !isLastRow {
-		if !h.vt.IsLineWrapped(row + 1) {
+		if !h.vt.isLineWrappedNoLock(row + 1) {
 			rowSeparator = "\r\n"
 			h.lastCursorRow = row + 1
 			h.lastCursorCol = 0
@@ -182,7 +182,7 @@ func (h *StringSerializeHandler) serializeString(startRow, endRow int, excludeFi
 
 	rowEnd := len(h.allRows)
 	bufferLength := endRow - startRow + 1
-	if bufferLength <= h.vt.Rows() {
+	if bufferLength <= h.vt.rows {
 		rowEnd = h.lastContentCursorRow + 1 - h.firstRow
 		if rowEnd < 0 {
 			rowEnd = 0
@@ -202,11 +202,12 @@ func (h *StringSerializeHandler) serializeString(startRow, endRow int, excludeFi
 	}
 
 	if !excludeFinalCursorPosition {
-		cursorRow, cursorCol := h.vt.CursorPosition()
+		cursorRow := h.vt.cursorY
+		cursorCol := h.vt.cursorX
 		fmt.Fprintf(&content, "\x1b[%d;%dH", cursorRow+1, cursorCol+1)
 	}
 
-	curFg, curBg, curAttrs, curUlStyle, curUlColor := h.vt.GetCurrentStyle()
+	curFg, curBg, curAttrs, curUlStyle, curUlColor := h.vt.getCurrentStyleNoLock()
 	curCell := NewFullStyledCell(' ', curFg, curBg, curAttrs, 1, curUlStyle, curUlColor)
 	sgrSeq := h.diffStyle(curCell, h.cursorStyle)
 	if len(sgrSeq) > 0 {

--- a/runner/internal/terminal/vt/serialize_history.go
+++ b/runner/internal/terminal/vt/serialize_history.go
@@ -95,7 +95,7 @@ func (h *StringSerializeHandler) serializeStringForHistory(startRow, endRow, his
 
 	rowEnd := len(h.allRows)
 	bufferLength := endRow - startRow + 1
-	if bufferLength <= h.vt.Rows() {
+	if bufferLength <= h.vt.rows {
 		rowEnd = h.lastContentCursorRow + 1 - h.firstRow
 		if rowEnd < 0 {
 			rowEnd = 0

--- a/runner/internal/terminal/vt/vt_api.go
+++ b/runner/internal/terminal/vt/vt_api.go
@@ -183,7 +183,11 @@ func StripANSIBytes(data []byte) []byte {
 func (vt *VirtualTerminal) GetCellsRow(row int) []Cell {
 	vt.mu.RLock()
 	defer vt.mu.RUnlock()
+	return vt.getCellsRowNoLock(row)
+}
 
+// getCellsRowNoLock returns a copy of the cells for a given row without locking (caller must hold lock)
+func (vt *VirtualTerminal) getCellsRowNoLock(row int) []Cell {
 	if row < 0 || row >= len(vt.cells) {
 		return nil
 	}
@@ -196,7 +200,11 @@ func (vt *VirtualTerminal) GetCellsRow(row int) []Cell {
 func (vt *VirtualTerminal) IsLineWrapped(row int) bool {
 	vt.mu.RLock()
 	defer vt.mu.RUnlock()
+	return vt.isLineWrappedNoLock(row)
+}
 
+// isLineWrappedNoLock returns true if the given line is wrapped without locking (caller must hold lock)
+func (vt *VirtualTerminal) isLineWrappedNoLock(row int) bool {
 	if row < 0 || row >= len(vt.isWrapped) {
 		return false
 	}


### PR DESCRIPTION
Serialization methods called Rows(), CursorPosition(), GetCurrentStyle(), GetCellsRow(), and IsLineWrapped() which acquire vt.mu.RLock(), but they are called from TryGetSnapshot() which already holds vt.mu.RLock(). When a concurrent writer (Resize or Feed) is pending, Go's RWMutex blocks new readers, causing a 3-way deadlock:

  - goroutine A (TryGetSnapshot): holds RLock, Rows() wants RLock → blocked
  - goroutine B (Resize from relay): wants Lock → blocked by A's RLock
  - goroutine C (Feed from PTY): wants Lock → blocked behind B

Fix: use direct field access (h.vt.rows) and NoLock method variants in all serialization code, since the caller already holds the lock.

## Summary

- What changed?
- Why was this change needed?

## Changes

- 

## Validation

- [ ] Backend tests (`cd backend && go test ./...`)
- [ ] Web checks (`cd web && pnpm run lint && pnpm run type-check && pnpm run test:coverage`)
- [ ] Runner checks (`cd runner && go test ./...`)
- [ ] Manual validation performed (if applicable)

## Documentation

- [ ] Docs updated (README/docs/inline comments)
- [ ] No docs changes needed

## Risk and Rollback

- Risk level: Low / Medium / High
- Rollback plan:
