### PR TITLE
fix(backend): exclude soft-deleted repos in duplicate check on import

### DIFF
--- a/backend/internal/infra/gitprovider_repo.go
+++ b/backend/internal/infra/gitprovider_repo.go
@@ -24,7 +24,7 @@ func NewGitProviderRepository(db *gorm.DB) gitprovider.RepositoryRepo {
 func (r *gitProviderRepo) FindByOrgAndPath(ctx context.Context, orgID int64, providerType, providerBaseURL, fullPath string) (*gitprovider.Repository, error) {
 	var repo gitprovider.Repository
 	err := r.db.WithContext(ctx).
-		Where("organization_id = ? AND provider_type = ? AND provider_base_url = ? AND full_path = ?",
+		Where("organization_id = ? AND provider_type = ? AND provider_base_url = ? AND full_path = ? AND deleted_at IS NULL",
 			orgID, providerType, providerBaseURL, fullPath).
 		First(&repo).Error
 	if err != nil {

--- a/backend/internal/service/repository/service_crud_test.go
+++ b/backend/internal/service/repository/service_crud_test.go
@@ -61,6 +61,45 @@ func TestCreateDuplicate(t *testing.T) {
 	}
 }
 
+func TestCreateAfterSoftDelete(t *testing.T) {
+	db := setupTestDB(t)
+	service := NewService(infra.NewGitProviderRepository(db))
+	ctx := context.Background()
+
+	req := &CreateRequest{
+		OrganizationID:  1,
+		ProviderType:    "gitlab",
+		ProviderBaseURL: "https://gitlab.com",
+		CloneURL:        "https://gitlab.com/org/test-repo.git",
+		ExternalID:      "12345",
+		Name:            "test-repo",
+		FullPath:        "org/test-repo",
+		Visibility:      "organization",
+	}
+
+	created, err := service.Create(ctx, req)
+	if err != nil {
+		t.Fatalf("failed to create repository: %v", err)
+	}
+
+	// Soft delete the repository
+	if err := service.Delete(ctx, created.ID); err != nil {
+		t.Fatalf("failed to delete repository: %v", err)
+	}
+
+	// Re-import the same repository should succeed
+	repo, err := service.Create(ctx, req)
+	if err != nil {
+		t.Fatalf("expected re-import after soft delete to succeed, got: %v", err)
+	}
+	if repo.Name != "test-repo" {
+		t.Errorf("expected name 'test-repo', got %s", repo.Name)
+	}
+	if repo.ID == created.ID {
+		t.Error("expected new repository to have a different ID from the deleted one")
+	}
+}
+
 func TestCreateWithDefaultBranch(t *testing.T) {
 	db := setupTestDB(t)
 	service := NewService(infra.NewGitProviderRepository(db))


### PR DESCRIPTION
## Summary

- Fix 409 Conflict when re-importing a previously soft-deleted repository
- `FindByOrgAndPath` was missing `deleted_at IS NULL` condition, causing it to match deleted records during the uniqueness check
- Add `TestCreateAfterSoftDelete` test to cover the create → soft-delete → re-import scenario

## Test plan

- [x] `TestCreateAfterSoftDelete` passes: create → delete → re-import succeeds
- [x] `TestCreateDuplicate` still passes: active duplicate still returns 409
- [x] Full `repository` test suite passes (63 tests)