### PR TITLE
feat(web+backend): replace All pod filter with Mine (created by me)

### DIFF
--- a/backend/internal/api/grpc/runner_adapter_mcp_discovery.go
+++ b/backend/internal/api/grpc/runner_adapter_mcp_discovery.go
@@ -12,7 +12,7 @@ import (
 
 // mcpListAvailablePods handles the "list_available_pods" MCP method.
 func (a *GRPCRunnerAdapter) mcpListAvailablePods(ctx context.Context, tc *middleware.TenantContext) (interface{}, *mcpError) {
-	pods, _, err := a.mcpPodService.ListPods(ctx, tc.OrganizationID, agentpod.ActiveStatuses(), 100, 0)
+	pods, _, err := a.mcpPodService.ListPods(ctx, tc.OrganizationID, agentpod.ActiveStatuses(), 0, 100, 0)
 	if err != nil {
 		return nil, newMcpError(500, "failed to list pods")
 	}

--- a/backend/internal/api/rest/v1/pod_interfaces.go
+++ b/backend/internal/api/rest/v1/pod_interfaces.go
@@ -23,7 +23,7 @@ var (
 // PodServiceForHandler defines the pod service methods needed by PodHandler
 // This interface enables dependency inversion and easier testing
 type PodServiceForHandler interface {
-	ListPods(ctx context.Context, orgID int64, statuses []string, limit, offset int) ([]*agentpod.Pod, int64, error)
+	ListPods(ctx context.Context, orgID int64, statuses []string, createdByID int64, limit, offset int) ([]*agentpod.Pod, int64, error)
 	CreatePod(ctx context.Context, req *agentpodService.CreatePodRequest) (*agentpod.Pod, error)
 	GetPod(ctx context.Context, podKey string) (*agentpod.Pod, error)
 	TerminatePod(ctx context.Context, podKey string) error

--- a/backend/internal/api/rest/v1/pod_query.go
+++ b/backend/internal/api/rest/v1/pod_query.go
@@ -12,9 +12,10 @@ import (
 
 // ListPodsRequest represents pod list request
 type ListPodsRequest struct {
-	Status string `form:"status"`
-	Limit  int    `form:"limit"`
-	Offset int    `form:"offset"`
+	Status      string `form:"status"`
+	CreatedByID int64  `form:"created_by_id"`
+	Limit       int    `form:"limit"`
+	Offset      int    `form:"offset"`
 }
 
 // ListPods lists pods
@@ -42,6 +43,7 @@ func (h *PodHandler) ListPods(c *gin.Context) {
 		c.Request.Context(),
 		tenant.OrganizationID,
 		statuses,
+		req.CreatedByID,
 		limit,
 		req.Offset,
 	)

--- a/backend/internal/domain/agentpod/repository.go
+++ b/backend/internal/domain/agentpod/repository.go
@@ -23,8 +23,8 @@ type PodRepository interface {
 	GetOrgAndCreator(ctx context.Context, podKey string) (orgID, creatorID int64, err error)
 	// GetTicketByID returns a ticket's slug and title by ID (cross-domain read for pod creation).
 	GetTicketByID(ctx context.Context, ticketID int64) (slug, title string, err error)
-	// ListByOrg returns pods for an organization with optional status filter and pagination.
-	ListByOrg(ctx context.Context, orgID int64, statuses []string, limit, offset int) ([]*Pod, int64, error)
+	// ListByOrg returns pods for an organization with optional status and creator filter and pagination.
+	ListByOrg(ctx context.Context, orgID int64, statuses []string, createdByID int64, limit, offset int) ([]*Pod, int64, error)
 	// ListByTicket returns pods for a ticket with associations preloaded.
 	ListByTicket(ctx context.Context, ticketID int64) ([]*Pod, error)
 	// ListByRunner returns pods for a runner with optional status filter.

--- a/backend/internal/infra/agentpod_repo.go
+++ b/backend/internal/infra/agentpod_repo.go
@@ -68,7 +68,7 @@ func (r *podRepo) GetTicketByID(ctx context.Context, ticketID int64) (string, st
 	return t.Slug, t.Title, nil
 }
 
-func (r *podRepo) ListByOrg(ctx context.Context, orgID int64, statuses []string, limit, offset int) ([]*agentpod.Pod, int64, error) {
+func (r *podRepo) ListByOrg(ctx context.Context, orgID int64, statuses []string, createdByID int64, limit, offset int) ([]*agentpod.Pod, int64, error) {
 	query := r.db.WithContext(ctx).Model(&agentpod.Pod{}).Where("organization_id = ?", orgID)
 	switch len(statuses) {
 	case 0:
@@ -76,6 +76,9 @@ func (r *podRepo) ListByOrg(ctx context.Context, orgID int64, statuses []string,
 		query = query.Where("status = ?", statuses[0])
 	default:
 		query = query.Where("status IN ?", statuses)
+	}
+	if createdByID > 0 {
+		query = query.Where("created_by_id = ?", createdByID)
 	}
 
 	var total int64

--- a/backend/internal/service/agentpod/pod_query.go
+++ b/backend/internal/service/agentpod/pod_query.go
@@ -61,8 +61,8 @@ func (s *PodService) GetPodsByTicket(ctx context.Context, ticketID int64) ([]*ag
 }
 
 // ListPods returns pods for an organization
-func (s *PodService) ListPods(ctx context.Context, orgID int64, statuses []string, limit, offset int) ([]*agentpod.Pod, int64, error) {
-	pods, total, err := s.repo.ListByOrg(ctx, orgID, statuses, limit, offset)
+func (s *PodService) ListPods(ctx context.Context, orgID int64, statuses []string, createdByID int64, limit, offset int) ([]*agentpod.Pod, int64, error) {
+	pods, total, err := s.repo.ListByOrg(ctx, orgID, statuses, createdByID, limit, offset)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/backend/internal/service/agentpod/pod_service_list_test.go
+++ b/backend/internal/service/agentpod/pod_service_list_test.go
@@ -23,7 +23,7 @@ func TestListPods(t *testing.T) {
 	}
 
 	t.Run("list all", func(t *testing.T) {
-		pods, total, err := svc.ListPods(ctx, 1, nil, 10, 0)
+		pods, total, err := svc.ListPods(ctx, 1, nil, 0, 10, 0)
 		if err != nil {
 			t.Fatalf("ListPods failed: %v", err)
 		}
@@ -36,7 +36,7 @@ func TestListPods(t *testing.T) {
 	})
 
 	t.Run("list with pagination", func(t *testing.T) {
-		pods, total, err := svc.ListPods(ctx, 1, nil, 2, 0)
+		pods, total, err := svc.ListPods(ctx, 1, nil, 0, 2, 0)
 		if err != nil {
 			t.Fatalf("ListPods failed: %v", err)
 		}
@@ -49,7 +49,7 @@ func TestListPods(t *testing.T) {
 	})
 
 	t.Run("list with single status filter", func(t *testing.T) {
-		pods, _, err := svc.ListPods(ctx, 1, []string{agentpod.StatusInitializing}, 10, 0)
+		pods, _, err := svc.ListPods(ctx, 1, []string{agentpod.StatusInitializing}, 0, 10, 0)
 		if err != nil {
 			t.Fatalf("ListPods failed: %v", err)
 		}
@@ -59,14 +59,14 @@ func TestListPods(t *testing.T) {
 	})
 
 	// Update some pods to different statuses for multi-status test
-	allPods, _, _ := svc.ListPods(ctx, 1, nil, 10, 0)
+	allPods, _, _ := svc.ListPods(ctx, 1, nil, 0, 10, 0)
 	if len(allPods) >= 3 {
 		svc.UpdatePodStatus(ctx, allPods[0].PodKey, agentpod.StatusRunning)
 		svc.UpdatePodStatus(ctx, allPods[1].PodKey, agentpod.StatusTerminated)
 	}
 
 	t.Run("list with multiple status filter", func(t *testing.T) {
-		pods, total, err := svc.ListPods(ctx, 1, []string{agentpod.StatusRunning, agentpod.StatusInitializing}, 10, 0)
+		pods, total, err := svc.ListPods(ctx, 1, []string{agentpod.StatusRunning, agentpod.StatusInitializing}, 0, 10, 0)
 		if err != nil {
 			t.Fatalf("ListPods failed: %v", err)
 		}
@@ -80,7 +80,62 @@ func TestListPods(t *testing.T) {
 	})
 
 	t.Run("list with non-matching status filter", func(t *testing.T) {
-		pods, total, err := svc.ListPods(ctx, 1, []string{agentpod.StatusPaused}, 10, 0)
+		pods, total, err := svc.ListPods(ctx, 1, []string{agentpod.StatusPaused}, 0, 10, 0)
+		if err != nil {
+			t.Fatalf("ListPods failed: %v", err)
+		}
+		if total != 0 {
+			t.Errorf("Total = %d, want 0", total)
+		}
+		if len(pods) != 0 {
+			t.Errorf("Pods count = %d, want 0", len(pods))
+		}
+	})
+
+	t.Run("list filtered by creator", func(t *testing.T) {
+		// CreatedByID 1 should match exactly 1 pod
+		pods, total, err := svc.ListPods(ctx, 1, nil, 1, 10, 0)
+		if err != nil {
+			t.Fatalf("ListPods failed: %v", err)
+		}
+		if total != 1 {
+			t.Errorf("Total = %d, want 1", total)
+		}
+		if len(pods) != 1 {
+			t.Errorf("Pods count = %d, want 1", len(pods))
+		}
+	})
+
+	t.Run("list filtered by creator with status", func(t *testing.T) {
+		// CreatedByID 1 pod was updated to running status above
+		pods, total, err := svc.ListPods(ctx, 1, []string{agentpod.StatusRunning}, 1, 10, 0)
+		if err != nil {
+			t.Fatalf("ListPods failed: %v", err)
+		}
+		if total != 1 {
+			t.Errorf("Total = %d, want 1", total)
+		}
+		if len(pods) != 1 {
+			t.Errorf("Pods count = %d, want 1", len(pods))
+		}
+	})
+
+	t.Run("list filtered by creator with non-matching status", func(t *testing.T) {
+		// CreatedByID 1 pod is running, not initializing
+		pods, total, err := svc.ListPods(ctx, 1, []string{agentpod.StatusInitializing}, 1, 10, 0)
+		if err != nil {
+			t.Fatalf("ListPods failed: %v", err)
+		}
+		if total != 0 {
+			t.Errorf("Total = %d, want 0", total)
+		}
+		if len(pods) != 0 {
+			t.Errorf("Pods count = %d, want 0", len(pods))
+		}
+	})
+
+	t.Run("list filtered by non-existent creator", func(t *testing.T) {
+		pods, total, err := svc.ListPods(ctx, 1, nil, 999, 10, 0)
 		if err != nil {
 			t.Fatalf("ListPods failed: %v", err)
 		}

--- a/backend/internal/service/mesh/service.go
+++ b/backend/internal/service/mesh/service.go
@@ -43,7 +43,7 @@ func NewService(
 // GetTopology returns the complete Mesh topology for an organization
 func (s *Service) GetTopology(ctx context.Context, orgID int64) (*mesh.MeshTopology, error) {
 	// 1. Get active pods
-	pods, _, err := s.podService.ListPods(ctx, orgID, nil, 100, 0)
+	pods, _, err := s.podService.ListPods(ctx, orgID, nil, 0, 100, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/web/src/components/ide/sidebar/WorkspaceFilters.tsx
+++ b/web/src/components/ide/sidebar/WorkspaceFilters.tsx
@@ -2,7 +2,7 @@
 
 import { cn } from "@/lib/utils";
 
-export type FilterType = "all" | "running" | "completed";
+export type FilterType = "mine" | "running" | "completed";
 
 interface WorkspaceFiltersProps {
   filter: FilterType;
@@ -14,7 +14,7 @@ interface WorkspaceFiltersProps {
  * Filter tabs for pod list
  */
 export function WorkspaceFilters({ filter, onFilterChange, t }: WorkspaceFiltersProps) {
-  const filters: FilterType[] = ["running", "completed", "all"];
+  const filters: FilterType[] = ["mine", "running", "completed"];
 
   return (
     <div className="flex items-center gap-1 px-2 py-1 border-y border-border">

--- a/web/src/components/ide/sidebar/WorkspaceSidebarContent.tsx
+++ b/web/src/components/ide/sidebar/WorkspaceSidebarContent.tsx
@@ -44,7 +44,9 @@ export function WorkspaceSidebarContent({ className, onCreatePod, onTerminatePod
   const addPane = useWorkspaceStore((s) => s.addPane);
   const panes = useWorkspaceStore((s) => s.panes);
 
-  const [filter, setFilter] = useState<FilterType>("running");
+  const user = useAuthStore((s) => s.user);
+
+  const [filter, setFilter] = useState<FilterType>("mine");
   const [searchQuery, setSearchQuery] = useState("");
   const [runnersExpanded, setRunnersExpanded] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -84,11 +86,14 @@ export function WorkspaceSidebarContent({ className, onCreatePod, onTerminatePod
     const allowedStatuses = SIDEBAR_STATUS_MAP[filter];
     const statusSet = allowedStatuses
       ? new Set(allowedStatuses.split(","))
-      : null; // "all" → show everything
+      : null; // "mine" → no status filter, but filter by creator below
 
     return pods.filter((pod) => {
       // Status guard
       if (statusSet && !statusSet.has(pod.status)) return false;
+
+      // Creator guard for "mine" filter
+      if (filter === "mine" && user?.id && pod.created_by?.id !== user.id) return false;
 
       // Search filter
       if (searchQuery) {
@@ -102,7 +107,7 @@ export function WorkspaceSidebarContent({ className, onCreatePod, onTerminatePod
 
       return true;
     });
-  }, [pods, searchQuery, filter]);
+  }, [pods, searchQuery, filter, user?.id]);
 
   // Sort pods: running/initializing first, then by creation time (newest first)
   const sortedPods = useMemo(() => {
@@ -206,11 +211,11 @@ export function WorkspaceSidebarContent({ className, onCreatePod, onTerminatePod
             <p className="text-sm text-muted-foreground">
               {searchQuery
                 ? t("workspace.emptyState.noMatch")
-                : filter === "all"
+                : filter === "mine"
                   ? t("workspace.emptyState.title")
                   : t("workspace.emptyState.noFiltered", { filter: t(`workspace.filters.${filter}`) })}
             </p>
-            {!searchQuery && filter === "all" && (
+            {!searchQuery && filter === "mine" && (
               <Button
                 size="sm"
                 variant="outline"

--- a/web/src/lib/api/pod.ts
+++ b/web/src/lib/api/pod.ts
@@ -51,10 +51,11 @@ export interface PodData {
 
 // Pods API
 export const podApi = {
-  list: (filters?: { status?: string; runnerId?: number; limit?: number; offset?: number }) => {
+  list: (filters?: { status?: string; runnerId?: number; createdById?: number; limit?: number; offset?: number }) => {
     const params = new URLSearchParams();
     if (filters?.status) params.append("status", filters.status);
     if (filters?.runnerId) params.append("runner_id", String(filters.runnerId));
+    if (filters?.createdById) params.append("created_by_id", String(filters.createdById));
     if (filters?.limit) params.append("limit", String(filters.limit));
     if (filters?.offset) params.append("offset", String(filters.offset));
     const query = params.toString() ? `?${params.toString()}` : "";

--- a/web/src/messages/de/app.json
+++ b/web/src/messages/de/app.json
@@ -227,7 +227,7 @@
     "podCreated": "Pod created! Waiting for it to start...",
     "podOpened": "Pod opened",
     "filters": {
-      "all": "Alle",
+      "mine": "Meine",
       "running": "Laufend",
       "completed": "Abgeschlossen",
       "error": "Fehler"

--- a/web/src/messages/en/app.json
+++ b/web/src/messages/en/app.json
@@ -244,7 +244,7 @@
     "podCreated": "Pod created! Waiting for it to start...",
     "podOpened": "Pod opened",
     "filters": {
-      "all": "All",
+      "mine": "Mine",
       "running": "Running",
       "completed": "Completed",
       "error": "Error"

--- a/web/src/messages/es/app.json
+++ b/web/src/messages/es/app.json
@@ -227,7 +227,7 @@
     "podCreated": "Pod created! Waiting for it to start...",
     "podOpened": "Pod opened",
     "filters": {
-      "all": "Todos",
+      "mine": "Míos",
       "running": "En Ejecución",
       "completed": "Completados",
       "error": "Error"

--- a/web/src/messages/fr/app.json
+++ b/web/src/messages/fr/app.json
@@ -227,7 +227,7 @@
     "podCreated": "Pod created! Waiting for it to start...",
     "podOpened": "Pod opened",
     "filters": {
-      "all": "Tous",
+      "mine": "Les miens",
       "running": "En cours",
       "completed": "Terminés",
       "error": "Erreur"

--- a/web/src/messages/ja/app.json
+++ b/web/src/messages/ja/app.json
@@ -227,7 +227,7 @@
     "podCreated": "Pod created! Waiting for it to start...",
     "podOpened": "Pod opened",
     "filters": {
-      "all": "すべて",
+      "mine": "自分の",
       "running": "実行中",
       "completed": "完了",
       "error": "エラー"

--- a/web/src/messages/ko/app.json
+++ b/web/src/messages/ko/app.json
@@ -227,7 +227,7 @@
     "podCreated": "Pod created! Waiting for it to start...",
     "podOpened": "Pod opened",
     "filters": {
-      "all": "전체",
+      "mine": "내 Pod",
       "running": "실행 중",
       "completed": "완료",
       "error": "오류"

--- a/web/src/messages/pt/app.json
+++ b/web/src/messages/pt/app.json
@@ -227,7 +227,7 @@
     "podCreated": "Pod created! Waiting for it to start...",
     "podOpened": "Pod opened",
     "filters": {
-      "all": "Todos",
+      "mine": "Meus",
       "running": "Em Execução",
       "completed": "Concluídos",
       "error": "Erro"

--- a/web/src/messages/zh/app.json
+++ b/web/src/messages/zh/app.json
@@ -244,7 +244,7 @@
     "podCreated": "Pod 已创建！等待启动中...",
     "podOpened": "Pod 已打开",
     "filters": {
-      "all": "全部",
+      "mine": "我创建的",
       "running": "运行中",
       "completed": "已完成",
       "error": "错误"

--- a/web/src/stores/__tests__/pod-guards.test.ts
+++ b/web/src/stores/__tests__/pod-guards.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { act } from "@testing-library/react";
-import { usePodStore } from "../pod";
+import { usePodStore, SIDEBAR_STATUS_MAP, Pod } from "../pod";
+import { useAuthStore } from "../auth";
 import { mockPod, mockPod2, resetPodStore } from "./pod-test-utils";
 
 vi.mock("@/lib/api", () => ({
@@ -13,6 +14,73 @@ vi.mock("@/lib/api", () => ({
 }));
 
 import { podApi } from "@/lib/api";
+
+describe("Pod Store — defaults", () => {
+  it("should default currentSidebarFilter to mine", () => {
+    // Fresh store import — check the initial value before any setState
+    // resetPodStore also sets "mine", so we verify via SIDEBAR_STATUS_MAP keys
+    expect(SIDEBAR_STATUS_MAP).toHaveProperty("mine");
+    expect(SIDEBAR_STATUS_MAP).not.toHaveProperty("all");
+  });
+
+  it("should have mine as default currentSidebarFilter after reset", () => {
+    resetPodStore();
+    expect(usePodStore.getState().currentSidebarFilter).toBe("mine");
+  });
+});
+
+describe("Pod Store — SIDEBAR_STATUS_MAP client-side guard", () => {
+  // Simulates the client-side filtering logic from WorkspaceSidebarContent
+  function applyClientFilter(pods: Pod[], filter: string, userId?: number): Pod[] {
+    const allowedStatuses = SIDEBAR_STATUS_MAP[filter];
+    const statusSet = allowedStatuses
+      ? new Set(allowedStatuses.split(","))
+      : null;
+
+    return pods.filter((pod) => {
+      if (statusSet && !statusSet.has(pod.status)) return false;
+      if (filter === "mine" && userId && pod.created_by?.id !== userId) return false;
+      return true;
+    });
+  }
+
+  const myPod: Pod = { ...mockPod, created_by: { id: 42, username: "me" } };
+  const otherPod: Pod = { ...mockPod2, created_by: { id: 99, username: "other" } };
+  const noPod: Pod = { ...mockPod, pod_key: "pod-no-creator" };
+
+  it("mine filter should only show pods created by the current user", () => {
+    const result = applyClientFilter([myPod, otherPod], "mine", 42);
+    expect(result).toHaveLength(1);
+    expect(result[0].pod_key).toBe(myPod.pod_key);
+  });
+
+  it("mine filter should exclude pods without created_by", () => {
+    const result = applyClientFilter([myPod, noPod], "mine", 42);
+    expect(result).toHaveLength(1);
+    expect(result[0].pod_key).toBe(myPod.pod_key);
+  });
+
+  it("mine filter should show all pods when userId is undefined (not logged in)", () => {
+    const result = applyClientFilter([myPod, otherPod], "mine", undefined);
+    expect(result).toHaveLength(2);
+  });
+
+  it("running filter should only show running/initializing pods regardless of creator", () => {
+    const runningPod: Pod = { ...otherPod, status: "running" };
+    const terminatedPod: Pod = { ...myPod, status: "terminated" };
+    const result = applyClientFilter([runningPod, terminatedPod], "running", 42);
+    expect(result).toHaveLength(1);
+    expect(result[0].pod_key).toBe(runningPod.pod_key);
+  });
+
+  it("completed filter should only show terminal status pods", () => {
+    const runningPod: Pod = { ...myPod, status: "running" };
+    const terminatedPod: Pod = { ...otherPod, status: "terminated" };
+    const failedPod: Pod = { ...mockPod, pod_key: "pod-failed", status: "failed", agent_status: "idle", created_at: "2024-01-03T00:00:00Z" };
+    const result = applyClientFilter([runningPod, terminatedPod, failedPod], "completed", 42);
+    expect(result).toHaveLength(2);
+  });
+});
 
 describe("Pod Store — fetchSidebarPods", () => {
   beforeEach(resetPodStore);
@@ -41,6 +109,36 @@ describe("Pod Store — fetchSidebarPods", () => {
 
     expect(podApi.list).toHaveBeenCalledWith({
       status: "terminated,failed,paused,completed,error,orphaned",
+      limit: 20,
+      offset: 0,
+    });
+  });
+
+  it("should fetch with createdById for mine filter", async () => {
+    useAuthStore.setState({ user: { id: 42, email: "test@test.com", username: "test" } });
+    vi.mocked(podApi.list).mockResolvedValue({ pods: [mockPod], total: 1, limit: 20, offset: 0 });
+
+    await act(async () => {
+      await usePodStore.getState().fetchSidebarPods("mine");
+    });
+
+    expect(podApi.list).toHaveBeenCalledWith({
+      createdById: 42,
+      limit: 20,
+      offset: 0,
+    });
+    expect(usePodStore.getState().currentSidebarFilter).toBe("mine");
+  });
+
+  it("should fetch mine without createdById when user is not set", async () => {
+    useAuthStore.setState({ user: null });
+    vi.mocked(podApi.list).mockResolvedValue({ pods: [], total: 0, limit: 20, offset: 0 });
+
+    await act(async () => {
+      await usePodStore.getState().fetchSidebarPods("mine");
+    });
+
+    expect(podApi.list).toHaveBeenCalledWith({
       limit: 20,
       offset: 0,
     });
@@ -141,6 +239,27 @@ describe("Pod Store — loadMorePods", () => {
     });
 
     // Should not duplicate mockPod2
+    expect(usePodStore.getState().pods).toHaveLength(2);
+  });
+
+  it("should load more with createdById for mine filter", async () => {
+    useAuthStore.setState({ user: { id: 42, email: "test@test.com", username: "test" } });
+    usePodStore.setState({
+      pods: [mockPod],
+      podHasMore: true,
+      currentSidebarFilter: "mine",
+    });
+    vi.mocked(podApi.list).mockResolvedValue({ pods: [mockPod2], total: 2, limit: 20, offset: 1 });
+
+    await act(async () => {
+      await usePodStore.getState().loadMorePods();
+    });
+
+    expect(podApi.list).toHaveBeenCalledWith({
+      createdById: 42,
+      limit: 20,
+      offset: 1,
+    });
     expect(usePodStore.getState().pods).toHaveLength(2);
   });
 });

--- a/web/src/stores/__tests__/pod-test-utils.ts
+++ b/web/src/stores/__tests__/pod-test-utils.ts
@@ -39,6 +39,6 @@ export function resetPodStore() {
     podTotal: 0,
     podHasMore: false,
     loadingMore: false,
-    currentSidebarFilter: "running",
+    currentSidebarFilter: "mine",
   });
 }

--- a/web/src/stores/pod.ts
+++ b/web/src/stores/pod.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { podApi, PodData, ApiError } from "@/lib/api";
+import { useAuthStore } from "@/stores/auth";
 import { getErrorMessage } from "@/lib/utils";
 
 // Re-export PodData as Pod for cleaner component API
@@ -7,9 +8,9 @@ export type Pod = PodData;
 
 // Sidebar status filter → API status query parameter mapping
 export const SIDEBAR_STATUS_MAP: Record<string, string> = {
+  mine: "",
   running: "running,initializing",
   completed: "terminated,failed,paused,completed,error,orphaned",
-  all: "",
 };
 const SIDEBAR_PAGE_SIZE = 20;
 
@@ -151,7 +152,7 @@ export const usePodStore = create<PodState>((set, get) => ({
   podTotal: 0,
   podHasMore: false,
   loadingMore: false,
-  currentSidebarFilter: "running",
+  currentSidebarFilter: "mine",
 
   fetchPods: async (filters) => {
     const fetchStartTs = Date.now();
@@ -226,8 +227,10 @@ export const usePodStore = create<PodState>((set, get) => ({
     set({ loading: true, error: null, currentSidebarFilter: statusFilter });
     try {
       const statusParam = SIDEBAR_STATUS_MAP[statusFilter] ?? "";
+      const createdById = statusFilter === "mine" ? useAuthStore.getState().user?.id : undefined;
       const response = await podApi.list({
         status: statusParam || undefined,
+        createdById,
         limit: SIDEBAR_PAGE_SIZE,
         offset: 0,
       });
@@ -264,8 +267,10 @@ export const usePodStore = create<PodState>((set, get) => ({
     set({ loadingMore: true });
     try {
       const statusParam = SIDEBAR_STATUS_MAP[currentSidebarFilter] ?? "";
+      const createdById = currentSidebarFilter === "mine" ? useAuthStore.getState().user?.id : undefined;
       const response = await podApi.list({
         status: statusParam || undefined,
+        createdById,
         limit: SIDEBAR_PAGE_SIZE,
         offset: pods.length,
       });


### PR DESCRIPTION
## Summary
- Replace "All" filter tab in workspace sidebar with "Mine" (shows only pods created by current user)
- Default filter selection changed from "Running" to "Mine"
- Backend: added `created_by_id` query parameter to `GET /api/v1/organizations/:slug/pods`
- Frontend: new "mine" filter with server-side filtering + client-side WebSocket guard
- i18n: added translations for all 8 languages (en/zh/de/es/fr/ja/ko/pt)

## Test plan
- [x] Backend `TestListPods` — 4 new subtests for `createdByID` filtering (by creator, creator+status, creator+non-matching status, non-existent creator)
- [x] Frontend `pod-guards.test.ts` — 7 new tests (mine API calls, loadMore with mine, store defaults, client-side guard logic)
- [x] All 1248 frontend tests pass
- [x] All backend tests pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)