### PR TITLE
fix(loop): add idle timeout to auto-terminate REPL-style loop pods

### DIFF
--- a/backend/internal/api/rest/v1/loop_handler.go
+++ b/backend/internal/api/rest/v1/loop_handler.go
@@ -76,6 +76,7 @@ type createLoopRequest struct {
 	MaxConcurrentRuns *int                   `json:"max_concurrent_runs"`
 	MaxRetainedRuns   *int                   `json:"max_retained_runs"`
 	TimeoutMinutes    *int                   `json:"timeout_minutes"`
+	IdleTimeoutSec    *int                   `json:"idle_timeout_sec"`
 }
 
 type updateLoopRequest struct {
@@ -106,6 +107,7 @@ type updateLoopRequest struct {
 	MaxConcurrentRuns *int                   `json:"max_concurrent_runs"`
 	MaxRetainedRuns   *int                   `json:"max_retained_runs"`
 	TimeoutMinutes    *int                   `json:"timeout_minutes"`
+	IdleTimeoutSec    *int                   `json:"idle_timeout_sec"`
 }
 
 type listLoopsQuery struct {
@@ -233,6 +235,15 @@ func (h *LoopHandler) CreateLoop(c *gin.Context) {
 		sessionPersistence = *req.SessionPersistence
 	}
 
+	idleTimeoutSec := 30
+	if req.IdleTimeoutSec != nil {
+		idleTimeoutSec = *req.IdleTimeoutSec
+	}
+	if idleTimeoutSec < 0 || idleTimeoutSec > 3600 {
+		apierr.ValidationError(c, "idle_timeout_sec must be between 0 and 3600 (0 = disabled)")
+		return
+	}
+
 	loop, err := h.loopService.Create(c.Request.Context(), &loopService.CreateLoopRequest{
 		OrganizationID:      tenant.OrganizationID,
 		CreatedByID:         tenant.UserID,
@@ -260,6 +271,7 @@ func (h *LoopHandler) CreateLoop(c *gin.Context) {
 		MaxConcurrentRuns:   maxConcurrentRuns,
 		MaxRetainedRuns:     maxRetainedRuns,
 		TimeoutMinutes:      timeoutMinutes,
+		IdleTimeoutSec:      idleTimeoutSec,
 	})
 	if err != nil {
 		slog.Warn("loop create: service error", "error", err, "name", req.Name, "slug", req.Slug)
@@ -341,6 +353,10 @@ func (h *LoopHandler) UpdateLoop(c *gin.Context) {
 		apierr.ValidationError(c, "max_retained_runs must be between 0 and 10000 (0 = unlimited)")
 		return
 	}
+	if req.IdleTimeoutSec != nil && (*req.IdleTimeoutSec < 0 || *req.IdleTimeoutSec > 3600) {
+		apierr.ValidationError(c, "idle_timeout_sec must be between 0 and 3600 (0 = disabled)")
+		return
+	}
 
 	svcReq := &loopService.UpdateLoopRequest{
 		Name:                req.Name,
@@ -363,6 +379,7 @@ func (h *LoopHandler) UpdateLoop(c *gin.Context) {
 		MaxConcurrentRuns:   req.MaxConcurrentRuns,
 		MaxRetainedRuns:     req.MaxRetainedRuns,
 		TimeoutMinutes:      req.TimeoutMinutes,
+		IdleTimeoutSec:      req.IdleTimeoutSec,
 	}
 
 	if req.ConfigOverrides != nil {

--- a/backend/internal/api/rest/v1/webhooks/integration_setup_test.go
+++ b/backend/internal/api/rest/v1/webhooks/integration_setup_test.go
@@ -137,7 +137,11 @@ func setupIntegrationDB(t *testing.T) *gorm.DB {
 		id INTEGER PRIMARY KEY,
 		organization_id INTEGER,
 		name TEXT,
-		status TEXT
+		status TEXT,
+		agent_status TEXT NOT NULL DEFAULT 'idle',
+		last_activity DATETIME,
+		agent_waiting_since DATETIME,
+		finished_at DATETIME
 	)`)
 
 	// Seed test data

--- a/backend/internal/domain/agentpod/pod.go
+++ b/backend/internal/domain/agentpod/pod.go
@@ -56,9 +56,10 @@ type Pod struct {
 	AgentStatus string `gorm:"size:50;not null;default:'idle'" json:"agent_status"`
 	AgentPID    *int   `gorm:"column:agent_pid" json:"agent_pid,omitempty"` // Claude/Agent process PID
 
-	StartedAt    *time.Time `json:"started_at,omitempty"`
-	FinishedAt   *time.Time `json:"finished_at,omitempty"`
-	LastActivity *time.Time `json:"last_activity,omitempty"`
+	StartedAt         *time.Time `json:"started_at,omitempty"`
+	FinishedAt        *time.Time `json:"finished_at,omitempty"`
+	LastActivity      *time.Time `json:"last_activity,omitempty"`
+	AgentWaitingSince *time.Time `json:"-"`
 
 	// Initial prompt and configuration
 	InitialPrompt string  `gorm:"type:text" json:"initial_prompt,omitempty"`

--- a/backend/internal/domain/loop/loop.go
+++ b/backend/internal/domain/loop/loop.go
@@ -95,6 +95,7 @@ type Loop struct {
 	MaxConcurrentRuns  int    `gorm:"not null;default:1" json:"max_concurrent_runs"`
 	MaxRetainedRuns    int    `gorm:"not null;default:0" json:"max_retained_runs"` // 0 = unlimited
 	TimeoutMinutes     int    `gorm:"not null;default:60" json:"timeout_minutes"`
+	IdleTimeoutSec     int    `gorm:"not null;default:30" json:"idle_timeout_sec"`
 
 	// Runtime state (updated after runs)
 	//

--- a/backend/internal/domain/loop/loop_run.go
+++ b/backend/internal/domain/loop/loop_run.go
@@ -274,4 +274,8 @@ type LoopRunRepository interface {
 	// Keeps the most recent `keep` finished runs, deletes the rest.
 	// Returns the number of rows deleted.
 	DeleteOldFinishedRuns(ctx context.Context, loopID int64, keep int) (int64, error)
+
+	// GetIdleLoopPods returns active loop runs whose Pods have been idle (agent waiting)
+	// longer than the loop's idle_timeout_sec. Used by the scheduler to auto-terminate.
+	GetIdleLoopPods(ctx context.Context, orgIDs []int64) ([]*LoopRun, error)
 }

--- a/backend/internal/infra/loop_run_repo.go
+++ b/backend/internal/infra/loop_run_repo.go
@@ -501,5 +501,25 @@ func (r *loopRunRepo) handleConcurrencyPolicy(tx *gorm.DB, l *loop.Loop, params 
 	return nil
 }
 
+// GetIdleLoopPods returns active loop runs whose Pods have been idle longer than idle_timeout_sec.
+func (r *loopRunRepo) GetIdleLoopPods(ctx context.Context, orgIDs []int64) ([]*loop.LoopRun, error) {
+	var runs []*loop.LoopRun
+	query := r.db.WithContext(ctx).
+		Table("loop_runs").
+		Joins("JOIN loops ON loops.id = loop_runs.loop_id").
+		Joins("JOIN pods ON pods.pod_key = loop_runs.pod_key").
+		Where("loop_runs.finished_at IS NULL").
+		Where("pods.status = ?", agentpod.StatusRunning).
+		Where("pods.agent_status = ?", agentpod.AgentStatusWaiting).
+		Where("pods.agent_waiting_since IS NOT NULL").
+		Where("loops.idle_timeout_sec > 0").
+		Where("pods.agent_waiting_since < NOW() - (loops.idle_timeout_sec || ' seconds')::INTERVAL")
+	if len(orgIDs) > 0 {
+		query = query.Where("loop_runs.organization_id IN ?", orgIDs)
+	}
+	err := query.Find(&runs).Error
+	return runs, err
+}
+
 // Compile-time interface compliance check
 var _ loop.LoopRunRepository = (*loopRunRepo)(nil)

--- a/backend/internal/infra/loop_test_setup_test.go
+++ b/backend/internal/infra/loop_test_setup_test.go
@@ -49,6 +49,7 @@ func setupLoopTestDB(t *testing.T) *gorm.DB {
 			max_concurrent_runs INTEGER NOT NULL DEFAULT 1,
 			max_retained_runs INTEGER NOT NULL DEFAULT 0,
 			timeout_minutes INTEGER NOT NULL DEFAULT 60,
+			idle_timeout_sec INTEGER NOT NULL DEFAULT 30,
 			sandbox_path TEXT,
 			last_pod_key TEXT,
 			created_by_id INTEGER NOT NULL DEFAULT 0,
@@ -99,6 +100,8 @@ func setupLoopTestDB(t *testing.T) *gorm.DB {
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			pod_key TEXT NOT NULL UNIQUE,
 			status TEXT NOT NULL DEFAULT 'initializing',
+			agent_status TEXT NOT NULL DEFAULT 'idle',
+			agent_waiting_since DATETIME,
 			finished_at DATETIME,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)

--- a/backend/internal/service/agentpod/pod_service_setup_test.go
+++ b/backend/internal/service/agentpod/pod_service_setup_test.go
@@ -65,6 +65,7 @@ func setupTestDB(t *testing.T) *gorm.DB {
 		started_at DATETIME,
 		finished_at DATETIME,
 		last_activity DATETIME,
+		agent_waiting_since DATETIME,
 		initial_prompt TEXT,
 		branch_name TEXT,
 		sandbox_path TEXT,

--- a/backend/internal/service/billing/service_setup_tables_test.go
+++ b/backend/internal/service/billing/service_setup_tables_test.go
@@ -95,6 +95,10 @@ func getAuxiliaryTablesSQL() string {
 		organization_id INTEGER NOT NULL,
 		name TEXT NOT NULL,
 		status TEXT NOT NULL DEFAULT 'pending',
+		agent_status TEXT NOT NULL DEFAULT 'idle',
+		last_activity DATETIME,
+		agent_waiting_since DATETIME,
+		finished_at DATETIME,
 		created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 	);
 	CREATE TABLE IF NOT EXISTS invitations (

--- a/backend/internal/service/channel/test_helper_test.go
+++ b/backend/internal/service/channel/test_helper_test.go
@@ -85,6 +85,10 @@ func setupTestDB(t *testing.T) *gorm.DB {
 		pod_key TEXT NOT NULL UNIQUE,
 		organization_id INTEGER NOT NULL,
 		status TEXT NOT NULL DEFAULT 'running',
+		agent_status TEXT NOT NULL DEFAULT 'idle',
+		last_activity DATETIME,
+		agent_waiting_since DATETIME,
+		finished_at DATETIME,
 		created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 	)`)
 

--- a/backend/internal/service/loop/loop_orchestrator_monitoring.go
+++ b/backend/internal/service/loop/loop_orchestrator_monitoring.go
@@ -190,3 +190,53 @@ func (o *LoopOrchestrator) RefreshLoopStats(ctx context.Context, loopID int64) e
 func (o *LoopOrchestrator) GetLastPodKey(ctx context.Context, loopID int64) *string {
 	return o.loopRunService.GetLatestPodKey(ctx, loopID)
 }
+
+// CheckIdleLoopPods detects Loop Pods that have been idle (agent waiting) longer than
+// the loop's idle_timeout_sec and terminates them.
+// This handles REPL-style agents (e.g., Claude Code) that don't exit after completing a prompt.
+// orgIDs filters to specific organizations; nil means all orgs (single-instance mode).
+//
+// The run is marked as "completed" (not "cancelled") because the agent has actually finished
+// its work — the idle state means it's waiting for the next prompt, not that it was interrupted.
+// This is important for persistent sandbox resume: only completed runs update last_pod_key,
+// so future runs can resume from this run's sandbox state.
+func (o *LoopOrchestrator) CheckIdleLoopPods(ctx context.Context, orgIDs []int64) error {
+	runs, err := o.loopRunService.GetIdleLoopPods(ctx, orgIDs)
+	if err != nil {
+		o.logger.Error("failed to get idle loop pods", "error", err)
+		return err
+	}
+
+	if len(runs) == 0 {
+		return nil
+	}
+
+	o.logger.Info("found idle loop pods to terminate", "count", len(runs))
+
+	for _, run := range runs {
+		// Mark the run as completed BEFORE terminating the Pod.
+		// HandleRunCompleted uses FinishRun with optimistic locking (WHERE finished_at IS NULL),
+		// so the subsequent pod_terminated event will be a no-op (already finished).
+		o.HandleRunCompleted(ctx, run, loopDomain.RunStatusCompleted)
+
+		// Terminate the Pod to release resources
+		if run.PodKey != nil && o.podTerminator != nil {
+			if termErr := o.podTerminator.TerminatePod(ctx, *run.PodKey); termErr != nil {
+				o.logger.Error("failed to terminate idle loop pod",
+					"pod_key", *run.PodKey,
+					"run_id", run.ID,
+					"loop_id", run.LoopID,
+					"error", termErr,
+				)
+			}
+		}
+
+		o.logger.Info("terminated idle loop pod",
+			"run_id", run.ID,
+			"loop_id", run.LoopID,
+			"pod_key", run.PodKey,
+		)
+	}
+
+	return nil
+}

--- a/backend/internal/service/loop/loop_run_service.go
+++ b/backend/internal/service/loop/loop_run_service.go
@@ -193,6 +193,11 @@ func (s *LoopRunService) GetOrphanPendingRuns(ctx context.Context, orgIDs []int6
 	return s.repo.GetOrphanPendingRuns(ctx, orgIDs)
 }
 
+// GetIdleLoopPods returns active loop runs whose Pods have been idle longer than idle_timeout_sec.
+func (s *LoopRunService) GetIdleLoopPods(ctx context.Context, orgIDs []int64) ([]*loopDomain.LoopRun, error) {
+	return s.repo.GetIdleLoopPods(ctx, orgIDs)
+}
+
 // ComputeLoopStats computes run statistics from Pod status (SSOT).
 func (s *LoopRunService) ComputeLoopStats(ctx context.Context, loopID int64) (total int, successful int, failed int, err error) {
 	return s.repo.ComputeLoopStats(ctx, loopID)

--- a/backend/internal/service/loop/loop_run_service_test.go
+++ b/backend/internal/service/loop/loop_run_service_test.go
@@ -45,6 +45,7 @@ func setupLoopRunServiceTestDB(t *testing.T) *gorm.DB {
 			max_concurrent_runs INTEGER NOT NULL DEFAULT 1,
 			max_retained_runs INTEGER NOT NULL DEFAULT 0,
 			timeout_minutes INTEGER NOT NULL DEFAULT 60,
+			idle_timeout_sec INTEGER NOT NULL DEFAULT 30,
 			permission_mode TEXT NOT NULL DEFAULT 'bypassPermissions',
 			repository_id INTEGER,
 			runner_id INTEGER,
@@ -94,7 +95,10 @@ func setupLoopRunServiceTestDB(t *testing.T) *gorm.DB {
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			pod_key TEXT NOT NULL UNIQUE,
 			status TEXT NOT NULL DEFAULT 'initializing',
+			agent_status TEXT NOT NULL DEFAULT 'idle',
 			finished_at DATETIME,
+			last_activity DATETIME,
+			agent_waiting_since DATETIME,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)
 	`)

--- a/backend/internal/service/loop/loop_scheduler.go
+++ b/backend/internal/service/loop/loop_scheduler.go
@@ -141,6 +141,9 @@ func (s *LoopScheduler) runTimeoutLoop() {
 			if err := s.orchestrator.CheckApprovalTimeouts(context.Background(), s.getOrgIDs()); err != nil {
 				s.logger.Error("approval timeout check failed", "error", err)
 			}
+			if err := s.orchestrator.CheckIdleLoopPods(context.Background(), s.getOrgIDs()); err != nil {
+				s.logger.Error("idle loop pod check failed", "error", err)
+			}
 			if err := s.orchestrator.CleanupOrphanPendingRuns(context.Background(), s.getOrgIDs()); err != nil {
 				s.logger.Error("orphan cleanup failed", "error", err)
 			}

--- a/backend/internal/service/loop/loop_service.go
+++ b/backend/internal/service/loop/loop_service.go
@@ -133,6 +133,7 @@ type CreateLoopRequest struct {
 	MaxConcurrentRuns  int
 	MaxRetainedRuns    int // 0 = unlimited (keep all runs)
 	TimeoutMinutes     int
+	IdleTimeoutSec     int // 0 = disabled, >0 = auto-terminate after N seconds idle
 }
 
 // UpdateLoopRequest represents a loop update request
@@ -163,6 +164,7 @@ type UpdateLoopRequest struct {
 	MaxConcurrentRuns  *int
 	MaxRetainedRuns    *int
 	TimeoutMinutes     *int
+	IdleTimeoutSec     *int
 }
 
 // ListLoopsFilter represents filters for listing loops (service-level alias)
@@ -277,6 +279,7 @@ func (s *LoopService) Create(ctx context.Context, req *CreateLoopRequest) (*loop
 		MaxConcurrentRuns:   req.MaxConcurrentRuns,
 		MaxRetainedRuns:     req.MaxRetainedRuns,
 		TimeoutMinutes:      req.TimeoutMinutes,
+		IdleTimeoutSec:      req.IdleTimeoutSec,
 		CreatedByID:         req.CreatedByID,
 		NextRunAt:           nextRunAt,
 	}
@@ -416,6 +419,9 @@ func (s *LoopService) Update(ctx context.Context, orgID int64, slug string, req 
 	}
 	if req.TimeoutMinutes != nil {
 		updates["timeout_minutes"] = *req.TimeoutMinutes
+	}
+	if req.IdleTimeoutSec != nil {
+		updates["idle_timeout_sec"] = *req.IdleTimeoutSec
 	}
 
 	// H1: When runner changes on a persistent-sandbox loop, break the resume chain.

--- a/backend/internal/service/loop/loop_service_test.go
+++ b/backend/internal/service/loop/loop_service_test.go
@@ -51,6 +51,7 @@ func setupLoopServiceTestDB(t *testing.T) *gorm.DB {
 			max_concurrent_runs INTEGER NOT NULL DEFAULT 1,
 			max_retained_runs INTEGER NOT NULL DEFAULT 0,
 			timeout_minutes INTEGER NOT NULL DEFAULT 60,
+			idle_timeout_sec INTEGER NOT NULL DEFAULT 30,
 			sandbox_path TEXT,
 			last_pod_key TEXT,
 			created_by_id INTEGER NOT NULL DEFAULT 0,
@@ -95,7 +96,10 @@ func setupLoopServiceTestDB(t *testing.T) *gorm.DB {
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			pod_key TEXT NOT NULL UNIQUE,
 			status TEXT NOT NULL DEFAULT 'initializing',
+			agent_status TEXT NOT NULL DEFAULT 'idle',
 			finished_at DATETIME,
+			last_activity DATETIME,
+			agent_waiting_since DATETIME,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)
 	`)

--- a/backend/internal/service/mesh/service_setup_test.go
+++ b/backend/internal/service/mesh/service_setup_test.go
@@ -35,6 +35,7 @@ func setupTestDB(t *testing.T) *gorm.DB {
 		started_at DATETIME,
 		finished_at DATETIME,
 		last_activity DATETIME,
+		agent_waiting_since DATETIME,
 		initial_prompt TEXT NOT NULL DEFAULT '',
 		branch_name TEXT,
 		sandbox_path TEXT,

--- a/backend/internal/service/runner/pod_coordinator_helper_test.go
+++ b/backend/internal/service/runner/pod_coordinator_helper_test.go
@@ -27,6 +27,7 @@ func setupPodCoordinatorTestDB(t *testing.T) (*gorm.DB, agentpod.PodRepository, 
 			error_code TEXT,
 			error_message TEXT,
 			last_activity DATETIME,
+			agent_waiting_since DATETIME,
 			finished_at DATETIME,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP

--- a/backend/internal/service/runner/pod_event_handler_helper_test.go
+++ b/backend/internal/service/runner/pod_event_handler_helper_test.go
@@ -45,6 +45,7 @@ func setupPodEventHandlerDeps(t *testing.T) (*PodCoordinator, *RunnerConnectionM
 			started_at DATETIME,
 			finished_at DATETIME,
 			last_activity DATETIME,
+			agent_waiting_since DATETIME,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)

--- a/backend/internal/service/runner/pod_status_handler.go
+++ b/backend/internal/service/runner/pod_status_handler.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"time"
 
 	"github.com/anthropics/agentsmesh/backend/internal/domain/agentpod"
 	runnerv1 "github.com/anthropics/agentsmesh/proto/gen/go/runner/v1"
@@ -23,6 +24,14 @@ func (pc *PodCoordinator) handleAgentStatus(runnerID int64, data *runnerv1.Agent
 
 	updates := map[string]interface{}{
 		"agent_status": data.Status,
+	}
+
+	// Track when agent enters/exits waiting state for idle timeout detection
+	if data.Status == agentpod.AgentStatusWaiting {
+		now := time.Now()
+		updates["agent_waiting_since"] = now
+	} else {
+		updates["agent_waiting_since"] = nil
 	}
 
 	if err := pc.podRepo.UpdateAgentStatus(ctx, data.PodKey, updates); err != nil {

--- a/backend/internal/service/ticket/mr_sync_mock_test.go
+++ b/backend/internal/service/ticket/mr_sync_mock_test.go
@@ -231,8 +231,12 @@ func setupMRSyncTestDB(t *testing.T) *gorm.DB {
 			organization_id INTEGER NOT NULL,
 			pod_key TEXT NOT NULL UNIQUE,
 			status TEXT NOT NULL DEFAULT 'initializing',
+			agent_status TEXT NOT NULL DEFAULT 'idle',
 			branch_name TEXT,
 			ticket_id INTEGER,
+			last_activity DATETIME,
+			agent_waiting_since DATETIME,
+			finished_at DATETIME,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)

--- a/backend/migrations/000079_add_idle_timeout.down.sql
+++ b/backend/migrations/000079_add_idle_timeout.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_pods_agent_waiting;
+ALTER TABLE pods DROP COLUMN IF EXISTS agent_waiting_since;
+ALTER TABLE loops DROP COLUMN IF EXISTS idle_timeout_sec;

--- a/backend/migrations/000079_add_idle_timeout.up.sql
+++ b/backend/migrations/000079_add_idle_timeout.up.sql
@@ -1,0 +1,10 @@
+-- Loop execution policy: auto-terminate agent after idle timeout
+ALTER TABLE loops ADD COLUMN IF NOT EXISTS idle_timeout_sec INT NOT NULL DEFAULT 30;
+
+-- Pod runtime state: when the agent entered "waiting" state
+ALTER TABLE pods ADD COLUMN IF NOT EXISTS agent_waiting_since TIMESTAMPTZ;
+
+-- Partial index: accelerate scheduler idle-pod scan
+CREATE INDEX IF NOT EXISTS idx_pods_agent_waiting
+  ON pods (agent_waiting_since)
+  WHERE status = 'running' AND agent_status = 'waiting' AND agent_waiting_since IS NOT NULL;


### PR DESCRIPTION
## Summary

- Add `idle_timeout_sec` field to Loop (default 30s, 0=disabled) to control when idle REPL-style agent pods are auto-terminated
- Add `agent_waiting_since` runtime timestamp on Pod, set/cleared by agent status handler
- Scheduler (60s cycle) detects pods idle beyond threshold via JOIN query and terminates them, marking runs as completed to preserve persistent sandbox resume chain
- Fixes #128 (previously reverted due to immediate termination without timeout)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 66 packages)
- [ ] Manual: Create direct-mode Loop with idle_timeout_sec=30 → trigger → agent completes prompt → Pod auto-terminates within ~90s → run status = completed


🤖 Generated with [Claude Code](https://claude.com/claude-code)