### PR TITLE
fix(web): restore repository binding in ticket creation and hide priority

### DIFF
--- a/web/src/components/tickets/TicketCreateDialog.tsx
+++ b/web/src/components/tickets/TicketCreateDialog.tsx
@@ -13,17 +13,11 @@ import {
   ResponsiveDialogBody,
   ResponsiveDialogFooter,
 } from "@/components/ui/responsive-dialog";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { TicketPriority } from "@/lib/api/ticket";
 import { ticketApi } from "@/lib/api";
 import { organizationApi, OrganizationMember } from "@/lib/api/organization";
 import { useAuthStore } from "@/stores/auth";
+import { RepositorySelect } from "@/components/common/RepositorySelect";
 import { useBreakpoint } from "@/components/layout/useBreakpoint";
 import { cn } from "@/lib/utils";
 import { ChevronDown, Users, Check } from "lucide-react";
@@ -37,18 +31,11 @@ export interface TicketCreateDialogProps {
   parentTicketSlug?: string;
 }
 
-const priorityOptions: { value: TicketPriority }[] = [
-  { value: "urgent" },
-  { value: "high" },
-  { value: "medium" },
-  { value: "low" },
-  { value: "none" },
-];
-
 interface FormData {
   title: string;
   content: string;
   priority: TicketPriority;
+  repositoryId: number | null;
   assigneeIds: number[];
 }
 
@@ -70,6 +57,7 @@ export function TicketCreateDialog({
     title: "",
     content: "",
     priority: "medium",
+    repositoryId: null,
     assigneeIds: [],
   });
 
@@ -97,6 +85,7 @@ export function TicketCreateDialog({
       title: "",
       content: "",
       priority: "medium",
+      repositoryId: null,
       assigneeIds: [],
     });
     setError(null);
@@ -114,12 +103,17 @@ export function TicketCreateDialog({
       setError(t("tickets.createDialog.titleRequired"));
       return;
     }
+    if (!form.repositoryId) {
+      setError(t("tickets.createDialog.repositoryRequired"));
+      return;
+    }
 
     setLoading(true);
     setError(null);
 
     try {
       const response = await ticketApi.create({
+        repositoryId: form.repositoryId,
         title: form.title.trim(),
         content: form.content || undefined,
         priority: form.priority,
@@ -179,23 +173,17 @@ export function TicketCreateDialog({
               />
             </FormField>
 
-            {/* Priority */}
-            <FormField label={t("tickets.filters.priority")} htmlFor="ticket-priority">
-              <Select
-                value={form.priority}
-                onValueChange={(val) => updateField("priority", val as TicketPriority)}
-              >
-                <SelectTrigger id="ticket-priority">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {priorityOptions.map((opt) => (
-                    <SelectItem key={opt.value} value={opt.value}>
-                      {t(`tickets.priority.${opt.value}`)}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+            {/* Repository */}
+            <FormField
+              label={t("tickets.createDialog.repository")}
+              htmlFor="ticket-repo"
+              required
+            >
+              <RepositorySelect
+                value={form.repositoryId}
+                onChange={(value) => updateField("repositoryId", value)}
+                placeholder={t("tickets.createDialog.selectRepository")}
+              />
             </FormField>
 
             {/* Assignees */}

--- a/web/src/components/tickets/TicketDetail.tsx
+++ b/web/src/components/tickets/TicketDetail.tsx
@@ -6,7 +6,7 @@ import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog, useConfirmDialog } from "@/components/ui/confirm-dialog";
 import { useAuthStore } from "@/stores/auth";
-import { useTicketStore, TicketStatus, TicketPriority } from "@/stores/ticket";
+import { useTicketStore, TicketStatus } from "@/stores/ticket";
 import { useTicketExtraData } from "./hooks";
 import { LabelsList, CommentsList, SubTicketsList, RelationsList, CommitsList } from "./shared";
 import { TicketDetailSidebar } from "./TicketDetailSidebar";
@@ -89,11 +89,11 @@ export function TicketDetail({ slug }: TicketDetailProps) {
     }
   };
 
-  const handlePriorityChange = async (newPriority: TicketPriority) => {
+  const handleRepositoryChange = async (repositoryId: number | null) => {
     try {
-      await updateTicket(slug, { priority: newPriority });
+      await updateTicket(slug, { repositoryId });
     } catch (err) {
-      console.error("Failed to update priority:", err);
+      console.error("Failed to update repository:", err);
     }
   };
 
@@ -199,7 +199,7 @@ export function TicketDetail({ slug }: TicketDetailProps) {
         ticket={currentTicket}
         onDelete={handleDelete}
         onStatusChange={handleStatusChange}
-        onPriorityChange={handlePriorityChange}
+        onRepositoryChange={handleRepositoryChange}
         ticketSlug={slug}
         t={t}
         commentsSlot={

--- a/web/src/components/tickets/TicketDetailPane.tsx
+++ b/web/src/components/tickets/TicketDetailPane.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useAuthStore } from "@/stores/auth";
-import { useTicketStore, Ticket, TicketStatus, TicketPriority } from "@/stores/ticket";
+import { useTicketStore, Ticket, TicketStatus } from "@/stores/ticket";
 import { ticketApi } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import {
@@ -18,7 +18,6 @@ import {
 import { cn } from "@/lib/utils";
 import TicketPodPanel from "./TicketPodPanel";
 import { StatusSelect } from "./StatusSelect";
-import { PrioritySelect } from "./PrioritySelect";
 import { InlineEditableText } from "./InlineEditableText";
 import { useTicketExtraData } from "./hooks";
 import { SubTicketsList, RelationsList, CommitsList, LabelsList } from "./shared";
@@ -103,25 +102,6 @@ export function TicketDetailPane({ slug, onClose, className }: TicketDetailPaneP
       }
     },
     [ticket, slug, updateTicketStatus]
-  );
-
-  // Handle priority change with optimistic update
-  const handlePriorityChange = useCallback(
-    async (newPriority: TicketPriority) => {
-      if (!ticket) return;
-
-      const oldPriority = ticket.priority;
-      setTicket({ ...ticket, priority: newPriority });
-
-      try {
-        await updateTicket(slug, { priority: newPriority });
-      } catch (err: unknown) {
-        console.error("Failed to update priority:", err);
-        setTicket({ ...ticket, priority: oldPriority });
-        throw err;
-      }
-    },
-    [ticket, slug, updateTicket]
   );
 
   // Handle title change with optimistic update
@@ -238,16 +218,11 @@ export function TicketDetailPane({ slug, onClose, className }: TicketDetailPaneP
             inputClassName="text-lg font-bold tracking-tight"
           />
 
-          {/* Status & Priority */}
+          {/* Status */}
           <div className="flex items-center gap-2 flex-wrap">
             <StatusSelect
               value={ticket.status}
               onChange={handleStatusChange}
-              size="sm"
-            />
-            <PrioritySelect
-              value={ticket.priority}
-              onChange={handlePriorityChange}
               size="sm"
             />
           </div>

--- a/web/src/components/tickets/TicketDetailSidebar.tsx
+++ b/web/src/components/tickets/TicketDetailSidebar.tsx
@@ -3,11 +3,11 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { Ticket, TicketStatus, TicketPriority } from "@/stores/ticket";
+import { Ticket, TicketStatus } from "@/stores/ticket";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { StatusSelect } from "./StatusSelect";
-import { PrioritySelect } from "./PrioritySelect";
+import { RepositorySelect } from "@/components/common/RepositorySelect";
 import { ticketApi } from "@/lib/api";
 import { useWorkspaceStore } from "@/stores/workspace";
 import { useAuthStore } from "@/stores/auth";
@@ -34,7 +34,7 @@ interface TicketDetailSidebarProps {
   ticket: Ticket;
   onDelete: () => void;
   onStatusChange: (status: TicketStatus) => void;
-  onPriorityChange?: (priority: TicketPriority) => void;
+  onRepositoryChange: (repositoryId: number | null) => void;
   ticketSlug: string;
   t: (key: string, params?: Record<string, string | number>) => string;
   commentsSlot?: React.ReactNode;
@@ -59,17 +59,13 @@ export function TicketDetailSidebar({
   ticket,
   onDelete,
   onStatusChange,
-  onPriorityChange,
+  onRepositoryChange,
   ticketSlug,
   t,
   commentsSlot,
 }: TicketDetailSidebarProps) {
   const handleStatusChange = async (status: TicketStatus) => {
     onStatusChange(status);
-  };
-
-  const handlePriorityChange = async (priority: TicketPriority) => {
-    onPriorityChange?.(priority);
   };
 
   return (
@@ -97,21 +93,15 @@ export function TicketDetailSidebar({
 
         <div className="mx-4 border-t border-border/40" />
 
-        {/* Priority */}
+        {/* Repository */}
         <div className="px-4 py-3 hover:bg-muted/30 transition-colors">
-          <div className="flex items-center justify-between">
-            <span className="text-xs font-medium text-muted-foreground">{t("tickets.filters.priority")}</span>
-            {onPriorityChange ? (
-              <PrioritySelect
-                value={ticket.priority}
-                onChange={handlePriorityChange}
-                showLabel
-                size="sm"
-              />
-            ) : (
-              <span className="text-sm">{t(`tickets.priority.${ticket.priority}`)}</span>
-            )}
-          </div>
+          <span className="text-xs font-medium text-muted-foreground block mb-2">{t("tickets.detail.repository")}</span>
+          <RepositorySelect
+            value={ticket.repository_id ?? null}
+            onChange={(value) => onRepositoryChange(value)}
+            placeholder={t("tickets.detail.noRepository")}
+            className="text-sm"
+          />
         </div>
 
         <div className="mx-4 border-t border-border/40" />

--- a/web/src/components/tickets/__tests__/TicketCreateDialog.test.tsx
+++ b/web/src/components/tickets/__tests__/TicketCreateDialog.test.tsx
@@ -29,6 +29,34 @@ vi.mock("@/components/ui/block-editor", () => ({
   ),
 }));
 
+// Mock RepositorySelect
+const mockRepositorySelectOnChange = vi.fn();
+vi.mock("@/components/common/RepositorySelect", () => ({
+  RepositorySelect: ({
+    value,
+    onChange,
+    placeholder,
+  }: {
+    value: number | null;
+    onChange: (v: number | null) => void;
+    placeholder?: string;
+  }) => {
+    mockRepositorySelectOnChange.mockImplementation(onChange);
+    return (
+      <select
+        data-testid="repository-select"
+        value={value ?? ""}
+        onChange={(e) =>
+          onChange(e.target.value ? Number(e.target.value) : null)
+        }
+      >
+        <option value="">{placeholder || "Select..."}</option>
+        <option value="1">my-repo</option>
+      </select>
+    );
+  },
+}));
+
 import { TicketCreateDialog } from "../TicketCreateDialog";
 
 function setMobile() {
@@ -117,6 +145,25 @@ describe("TicketCreateDialog", () => {
       expect(mockCreate).not.toHaveBeenCalled();
     });
 
+    it("shows error when submitting without repository", async () => {
+      render(<TicketCreateDialog {...defaultProps} />);
+
+      const titleInput = screen.getByPlaceholderText("Enter ticket title");
+      fireEvent.change(titleInput, { target: { value: "Test Ticket" } });
+
+      const submitButton = screen.getByRole("button", {
+        name: "Create Ticket",
+      });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Repository is required")
+        ).toBeInTheDocument();
+      });
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
     it("clears error when user starts typing", async () => {
       render(<TicketCreateDialog {...defaultProps} />);
 
@@ -145,6 +192,9 @@ describe("TicketCreateDialog", () => {
       const titleInput = screen.getByPlaceholderText("Enter ticket title");
       fireEvent.change(titleInput, { target: { value: "Test Ticket" } });
 
+      const repoSelect = screen.getByTestId("repository-select");
+      fireEvent.change(repoSelect, { target: { value: "1" } });
+
       const submitButton = screen.getByRole("button", {
         name: "Create Ticket",
       });
@@ -154,6 +204,7 @@ describe("TicketCreateDialog", () => {
         expect(mockCreate).toHaveBeenCalledWith(
           expect.objectContaining({
             title: "Test Ticket",
+            repositoryId: 1,
             priority: "medium",
           })
         );
@@ -166,6 +217,9 @@ describe("TicketCreateDialog", () => {
 
       const titleInput = screen.getByPlaceholderText("Enter ticket title");
       fireEvent.change(titleInput, { target: { value: "Test Ticket" } });
+
+      const repoSelect = screen.getByTestId("repository-select");
+      fireEvent.change(repoSelect, { target: { value: "1" } });
 
       const submitButton = screen.getByRole("button", {
         name: "Create Ticket",
@@ -182,6 +236,9 @@ describe("TicketCreateDialog", () => {
 
       const titleInput = screen.getByPlaceholderText("Enter ticket title");
       fireEvent.change(titleInput, { target: { value: "Sub-task" } });
+
+      const repoSelect = screen.getByTestId("repository-select");
+      fireEvent.change(repoSelect, { target: { value: "1" } });
 
       const submitButton = screen.getByRole("button", {
         name: "Create Ticket",
@@ -206,6 +263,9 @@ describe("TicketCreateDialog", () => {
       const titleInput = screen.getByPlaceholderText("Enter ticket title");
       fireEvent.change(titleInput, { target: { value: "Test Ticket" } });
 
+      const repoSelect = screen.getByTestId("repository-select");
+      fireEvent.change(repoSelect, { target: { value: "1" } });
+
       const submitButton = screen.getByRole("button", {
         name: "Create Ticket",
       });
@@ -224,6 +284,9 @@ describe("TicketCreateDialog", () => {
 
       const titleInput = screen.getByPlaceholderText("Enter ticket title");
       fireEvent.change(titleInput, { target: { value: "Test Ticket" } });
+
+      const repoSelect = screen.getByTestId("repository-select");
+      fireEvent.change(repoSelect, { target: { value: "1" } });
 
       const submitButton = screen.getByRole("button", {
         name: "Create Ticket",

--- a/web/src/components/tickets/__tests__/TicketDetail.test.tsx
+++ b/web/src/components/tickets/__tests__/TicketDetail.test.tsx
@@ -293,10 +293,10 @@ describe('TicketDetail Component', () => {
   })
 
   describe('metadata sidebar', () => {
-    it('should display ticket priority', async () => {
+    it('should display repository selector', async () => {
       render(<TicketDetail slug="PROJ-42" />)
       await waitFor(() => {
-        expect(screen.getByText('Priority')).toBeInTheDocument()
+        expect(screen.getByText('Repository')).toBeInTheDocument()
       })
     })
 


### PR DESCRIPTION
## Summary
- Restore required `RepositorySelect` in Create Ticket dialog (was removed in 264c6c3f)
- Replace `PrioritySelect` with `RepositorySelect` in ticket detail sidebar and detail pane
- Hide priority field from ticket creation and detail UI (still sends default `medium` to API)
- Update tests to cover repository required validation and mock RepositorySelect

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 1307 tests pass (87 test files)
- [ ] Manual: Create ticket → repository field is required, priority is hidden
- [ ] Manual: Ticket detail page sidebar shows repository selector instead of priority
- [ ] Manual: Ticket detail pane shows only status (no priority)

🤖 Generated with [Claude Code](https://claude.com/claude-code)