### PR TITLE
fix(backend+runner): prevent heartbeat miskillings and resume sandbox escape

### DIFF
--- a/backend/internal/service/runner/pod_heartbeat_handler.go
+++ b/backend/internal/service/runner/pod_heartbeat_handler.go
@@ -2,10 +2,12 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/anthropics/agentsmesh/backend/internal/domain/agentpod"
 	runnerv1 "github.com/anthropics/agentsmesh/proto/gen/go/runner/v1"
+	"gorm.io/gorm"
 )
 
 // handleHeartbeat handles heartbeat from a runner (Proto type)
@@ -65,7 +67,24 @@ func (pc *PodCoordinator) reconcilePods(ctx context.Context, runnerID int64, rep
 	for podKey := range reportedPods {
 		pod, err := pc.podRepo.GetByKeyAndRunner(ctx, podKey, runnerID)
 		if err != nil {
-			// Pod not found in database, tell runner to terminate it
+			if !errors.Is(err, gorm.ErrRecordNotFound) {
+				// Transient DB error: skip this round, retry on next heartbeat
+				pc.logger.Warn("failed to lookup reported pod, will retry",
+					"pod_key", podKey, "runner_id", runnerID, "error", err)
+				continue
+			}
+
+			// Pod confirmed not in database — use evidence accumulation
+			// to tolerate races (e.g., pod just created but DB insert not yet visible)
+			missCount := pc.incrementMissCount(podKey, runnerID)
+			if missCount < orphanMissThreshold {
+				pc.logger.Debug("unknown pod, waiting for more evidence",
+					"pod_key", podKey, "miss_count", missCount, "threshold", orphanMissThreshold)
+				continue
+			}
+			pc.clearMissCount(podKey)
+
+			// Evidence threshold reached — terminate
 			if pc.isTerminateCooldown(podKey) {
 				continue
 			}

--- a/backend/internal/service/runner/pod_reconcile_resilience_test.go
+++ b/backend/internal/service/runner/pod_reconcile_resilience_test.go
@@ -1,0 +1,147 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/anthropics/agentsmesh/backend/internal/domain/agentpod"
+	"github.com/anthropics/agentsmesh/backend/internal/domain/runner"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+)
+
+// errorInjectingPodRepo wraps a real PodRepository and allows injecting errors
+// into GetByKeyAndRunner to simulate transient DB failures.
+type errorInjectingPodRepo struct {
+	agentpod.PodRepository
+	// getByKeyAndRunnerFn, when non-nil, is called instead of the real repo.
+	// This allows dynamic error injection (e.g., alternating error types).
+	getByKeyAndRunnerFn func(ctx context.Context, podKey string, runnerID int64) (*agentpod.Pod, error)
+}
+
+func (r *errorInjectingPodRepo) GetByKeyAndRunner(ctx context.Context, podKey string, runnerID int64) (*agentpod.Pod, error) {
+	if r.getByKeyAndRunnerFn != nil {
+		return r.getByKeyAndRunnerFn(ctx, podKey, runnerID)
+	}
+	return r.PodRepository.GetByKeyAndRunner(ctx, podKey, runnerID)
+}
+
+func TestReconcilePods_TransientDBError_NoTerminate(t *testing.T) {
+	db, cm, tr, hb, podRepo, runnerRepo := setupPodCoordinatorDeps(t)
+	defer cm.Close()
+
+	// Wrap podRepo: always return transient error
+	errRepo := &errorInjectingPodRepo{
+		PodRepository: podRepo,
+		getByKeyAndRunnerFn: func(_ context.Context, _ string, _ int64) (*agentpod.Pod, error) {
+			return nil, fmt.Errorf("connection refused")
+		},
+	}
+
+	logger := newTestLogger()
+	pc := NewPodCoordinator(errRepo, runnerRepo, cm, tr, hb, logger)
+
+	mockSender := &MockCommandSender{}
+	pc.SetCommandSender(mockSender)
+
+	// Create a runner
+	r := &runner.Runner{OrganizationID: 1, NodeID: "transient-err-node", Status: "online"}
+	if err := db.Create(r).Error; err != nil {
+		t.Fatalf("failed to create runner: %v", err)
+	}
+
+	ctx := context.Background()
+	reportedPods := map[string]bool{"transient-pod-1": true}
+
+	// Send many heartbeats — transient error should never trigger terminate
+	for i := 0; i < orphanMissThreshold*2; i++ {
+		pc.reconcilePods(ctx, r.ID, reportedPods)
+	}
+
+	assert.Equal(t, 0, mockSender.TerminatePodCalls,
+		"transient DB error must not trigger terminate")
+}
+
+func TestReconcilePods_NotFound_WithEvidence(t *testing.T) {
+	pc, _, _, db := setupPodEventHandlerDeps(t)
+
+	mockSender := &MockCommandSender{}
+	pc.SetCommandSender(mockSender)
+
+	// Create a runner
+	r := &runner.Runner{OrganizationID: 1, NodeID: "evidence-node", Status: "online"}
+	if err := db.Create(r).Error; err != nil {
+		t.Fatalf("failed to create runner: %v", err)
+	}
+
+	ctx := context.Background()
+	// Report a pod that does NOT exist in DB
+	reportedPods := map[string]bool{"ghost-pod-1": true}
+
+	// Before threshold: no terminate should be sent
+	for i := 0; i < orphanMissThreshold-1; i++ {
+		pc.reconcilePods(ctx, r.ID, reportedPods)
+	}
+	assert.Equal(t, 0, mockSender.TerminatePodCalls,
+		"should not terminate before evidence threshold")
+
+	// At threshold: terminate should be sent
+	pc.reconcilePods(ctx, r.ID, reportedPods)
+	assert.Equal(t, 1, mockSender.TerminatePodCalls,
+		"should terminate after evidence threshold")
+}
+
+// TestReconcilePods_MixedTransientAndNotFound verifies that transient DB errors
+// do NOT contribute to the miss count, and only consecutive NotFound errors
+// accumulate toward the terminate threshold.
+func TestReconcilePods_MixedTransientAndNotFound(t *testing.T) {
+	db, cm, tr, hb, podRepo, runnerRepo := setupPodCoordinatorDeps(t)
+	defer cm.Close()
+
+	callCount := 0
+	errRepo := &errorInjectingPodRepo{
+		PodRepository: podRepo,
+		getByKeyAndRunnerFn: func(_ context.Context, _ string, _ int64) (*agentpod.Pod, error) {
+			callCount++
+			// Alternate: NotFound, transient, NotFound, transient, ...
+			if callCount%2 == 1 {
+				return nil, gorm.ErrRecordNotFound
+			}
+			return nil, fmt.Errorf("connection timeout")
+		},
+	}
+
+	logger := newTestLogger()
+	pc := NewPodCoordinator(errRepo, runnerRepo, cm, tr, hb, logger)
+
+	mockSender := &MockCommandSender{}
+	pc.SetCommandSender(mockSender)
+
+	r := &runner.Runner{OrganizationID: 1, NodeID: "mixed-err-node", Status: "online"}
+	if err := db.Create(r).Error; err != nil {
+		t.Fatalf("failed to create runner: %v", err)
+	}
+
+	ctx := context.Background()
+	reportedPods := map[string]bool{"mixed-pod-1": true}
+
+	// With alternating errors and threshold=3, only odd-numbered heartbeats
+	// (NotFound) increment the miss count. We need 2*threshold - 1 heartbeats
+	// for the miss count to reach threshold:
+	// HB1: NotFound → miss=1, HB2: transient → skip
+	// HB3: NotFound → miss=2, HB4: transient → skip
+	// HB5: NotFound → miss=3 → terminate!
+
+	// After 4 heartbeats (miss count = 2, below threshold): no terminate
+	for i := 0; i < 4; i++ {
+		pc.reconcilePods(ctx, r.ID, reportedPods)
+	}
+	assert.Equal(t, 0, mockSender.TerminatePodCalls,
+		"transient errors should not contribute to miss count")
+
+	// 5th heartbeat (NotFound): miss count reaches threshold → terminate
+	pc.reconcilePods(ctx, r.ID, reportedPods)
+	assert.Equal(t, 1, mockSender.TerminatePodCalls,
+		"should terminate after enough NotFound evidence despite interleaved transient errors")
+}

--- a/runner/internal/runner/pod_builder_setup.go
+++ b/runner/internal/runner/pod_builder_setup.go
@@ -47,21 +47,39 @@ func (b *PodBuilder) setup(ctx context.Context) (string, string, string, error) 
 		return "", "", "", err
 	}
 
+	// LocalPathStrategy reuses the source pod's sandbox as sandboxRoot,
+	// so path templates (e.g., {{.sandbox.root_path}}/.mcp.json) resolve
+	// within the correct directory instead of escaping into a new empty sandbox.
+	//
+	// sandboxOwned tracks whether we created the sandbox and are responsible for
+	// cleaning it up on error. When overridden, the source sandbox must NOT be
+	// deleted — it belongs to the source pod.
+	sandboxOwned := true
+	if result.SandboxRoot != "" && result.SandboxRoot != sandboxRoot {
+		_ = fsutil.RemoveAll(sandboxRoot) // Clean up unused new sandbox
+		sandboxRoot = result.SandboxRoot
+		sandboxOwned = false
+	}
+
 	// 3. Create files from FilesToCreate
 	if len(b.cmd.FilesToCreate) > 0 {
 		b.sendProgress("preparing", 70, "Creating files...")
 	}
 	if err := b.createFiles(sandboxRoot, result.WorkingDir); err != nil {
-		if rmErr := fsutil.RemoveAll(sandboxRoot); rmErr != nil {
-			slog.Warn("Failed to clean up sandbox after file creation error", "path", sandboxRoot, "error", rmErr)
+		if sandboxOwned {
+			if rmErr := fsutil.RemoveAll(sandboxRoot); rmErr != nil {
+				slog.Warn("Failed to clean up sandbox after file creation error", "path", sandboxRoot, "error", rmErr)
+			}
 		}
 		return "", "", "", err
 	}
 
 	// Download skill packages
 	if err := b.downloadResources(ctx, sandboxRoot, result.WorkingDir); err != nil {
-		if rmErr := fsutil.RemoveAll(sandboxRoot); rmErr != nil {
-			slog.Warn("Failed to clean up sandbox after download error", "path", sandboxRoot, "error", rmErr)
+		if sandboxOwned {
+			if rmErr := fsutil.RemoveAll(sandboxRoot); rmErr != nil {
+				slog.Warn("Failed to clean up sandbox after download error", "path", sandboxRoot, "error", rmErr)
+			}
 		}
 		return "", "", "", fmt.Errorf("failed to download resources: %w", err)
 	}

--- a/runner/internal/runner/pod_builder_setup_test.go
+++ b/runner/internal/runner/pod_builder_setup_test.go
@@ -1,0 +1,198 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	runnerv1 "github.com/anthropics/agentsmesh/proto/gen/go/runner/v1"
+	"github.com/anthropics/agentsmesh/runner/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetup_LocalPath_UsesSandboxRootOverride verifies that setup() replaces
+// the newly created sandbox root with the source pod's sandbox (LocalPath)
+// when using LocalPathStrategy.
+func TestSetup_LocalPath_UsesSandboxRootOverride(t *testing.T) {
+	workspaceRoot := t.TempDir()
+
+	// Simulate the source pod's sandbox (what LocalPath points to)
+	sourceSandbox := filepath.Join(workspaceRoot, "sandboxes", "source-pod-key")
+	sourceWorkspace := filepath.Join(sourceSandbox, "workspace")
+	require.NoError(t, os.MkdirAll(sourceWorkspace, 0755))
+
+	runner := &Runner{
+		cfg: &config.Config{
+			WorkspaceRoot: workspaceRoot,
+		},
+	}
+
+	cmd := &runnerv1.CreatePodCommand{
+		PodKey:        "resume-pod-key",
+		LaunchCommand: "echo",
+		LaunchArgs:    []string{"test"},
+		SandboxConfig: &runnerv1.SandboxConfig{
+			LocalPath: sourceSandbox,
+		},
+	}
+
+	builder := NewPodBuilderFromRunner(runner).WithCommand(cmd)
+	sandboxRoot, workingDir, _, err := builder.setup(context.Background())
+	require.NoError(t, err)
+
+	// sandboxRoot should be overridden to the source sandbox
+	assert.Equal(t, sourceSandbox, sandboxRoot,
+		"sandboxRoot should be overridden to source pod's sandbox")
+	assert.Equal(t, sourceWorkspace, workingDir,
+		"workingDir should point to workspace inside source sandbox")
+
+	// The new sandbox directory (for resume-pod-key) should have been cleaned up
+	newSandbox := filepath.Join(workspaceRoot, "sandboxes", "resume-pod-key")
+	_, err = os.Stat(newSandbox)
+	assert.True(t, os.IsNotExist(err),
+		"newly created sandbox should be cleaned up after override")
+}
+
+// TestCreateFiles_ResumeMode_McpJsonInWorkDir verifies that .mcp.json is
+// correctly created inside the working directory when resuming a pod.
+// This was the production bug: path template {{.sandbox.work_dir}}/.mcp.json
+// resolved to the old sandbox which escaped the new sandbox's validation.
+func TestCreateFiles_ResumeMode_McpJsonInWorkDir(t *testing.T) {
+	workspaceRoot := t.TempDir()
+
+	// Simulate the source pod's sandbox
+	sourceSandbox := filepath.Join(workspaceRoot, "sandboxes", "source-pod")
+	sourceWorkspace := filepath.Join(sourceSandbox, "workspace")
+	require.NoError(t, os.MkdirAll(sourceWorkspace, 0755))
+
+	runner := &Runner{
+		cfg: &config.Config{
+			WorkspaceRoot: workspaceRoot,
+		},
+	}
+
+	mcpContent := `{"mcpServers": {"test": {}}}`
+	cmd := &runnerv1.CreatePodCommand{
+		PodKey:        "resume-mcp-pod",
+		LaunchCommand: "echo",
+		LaunchArgs:    []string{"test"},
+		SandboxConfig: &runnerv1.SandboxConfig{
+			LocalPath: sourceSandbox,
+		},
+		FilesToCreate: []*runnerv1.FileToCreate{
+			{
+				Path:    "{{.sandbox.work_dir}}/.mcp.json",
+				Content: mcpContent,
+				Mode:    0644,
+			},
+		},
+	}
+
+	builder := NewPodBuilderFromRunner(runner).WithCommand(cmd)
+	sandboxRoot, workingDir, _, err := builder.setup(context.Background())
+	require.NoError(t, err)
+
+	// Verify sandbox root was overridden
+	assert.Equal(t, sourceSandbox, sandboxRoot)
+
+	// Verify .mcp.json was created in the correct location
+	mcpPath := filepath.Join(workingDir, ".mcp.json")
+	data, err := os.ReadFile(mcpPath)
+	require.NoError(t, err, ".mcp.json should exist in working directory")
+	assert.Equal(t, mcpContent, string(data))
+}
+
+// TestCreateFiles_ResumeMode_RootPathTemplate verifies that {{.sandbox.root_path}}
+// also resolves correctly in resume mode (points to source sandbox, not new empty one).
+func TestCreateFiles_ResumeMode_RootPathTemplate(t *testing.T) {
+	workspaceRoot := t.TempDir()
+
+	sourceSandbox := filepath.Join(workspaceRoot, "sandboxes", "source-pod-root")
+	sourceWorkspace := filepath.Join(sourceSandbox, "workspace")
+	require.NoError(t, os.MkdirAll(sourceWorkspace, 0755))
+
+	runner := &Runner{
+		cfg: &config.Config{
+			WorkspaceRoot: workspaceRoot,
+		},
+	}
+
+	cmd := &runnerv1.CreatePodCommand{
+		PodKey:        "resume-root-tpl-pod",
+		LaunchCommand: "echo",
+		LaunchArgs:    []string{"test"},
+		SandboxConfig: &runnerv1.SandboxConfig{
+			LocalPath: sourceSandbox,
+		},
+		FilesToCreate: []*runnerv1.FileToCreate{
+			{
+				Path:    "{{.sandbox.root_path}}/config.yaml",
+				Content: "key: value",
+				Mode:    0644,
+			},
+		},
+	}
+
+	builder := NewPodBuilderFromRunner(runner).WithCommand(cmd)
+	sandboxRoot, _, _, err := builder.setup(context.Background())
+	require.NoError(t, err)
+
+	// {{.sandbox.root_path}} should resolve to source sandbox
+	configPath := filepath.Join(sandboxRoot, "config.yaml")
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err, "config.yaml should exist in source sandbox root")
+	assert.Equal(t, "key: value", string(data))
+}
+
+// TestSetup_LocalPath_ErrorDoesNotDeleteSourceSandbox verifies that if file
+// creation fails in resume mode, the source pod's sandbox is NOT deleted.
+// This is critical: the error cleanup path must not destroy the source data.
+func TestSetup_LocalPath_ErrorDoesNotDeleteSourceSandbox(t *testing.T) {
+	workspaceRoot := t.TempDir()
+
+	sourceSandbox := filepath.Join(workspaceRoot, "sandboxes", "source-pod-err")
+	sourceWorkspace := filepath.Join(sourceSandbox, "workspace")
+	require.NoError(t, os.MkdirAll(sourceWorkspace, 0755))
+
+	// Place a sentinel file in source sandbox to verify it's preserved
+	sentinelPath := filepath.Join(sourceWorkspace, "important-data.txt")
+	require.NoError(t, os.WriteFile(sentinelPath, []byte("do not delete"), 0644))
+
+	runner := &Runner{
+		cfg: &config.Config{
+			WorkspaceRoot: workspaceRoot,
+		},
+	}
+
+	cmd := &runnerv1.CreatePodCommand{
+		PodKey:        "resume-error-pod",
+		LaunchCommand: "echo",
+		LaunchArgs:    []string{"test"},
+		SandboxConfig: &runnerv1.SandboxConfig{
+			LocalPath: sourceSandbox,
+		},
+		FilesToCreate: []*runnerv1.FileToCreate{
+			{
+				// This path escapes even the overridden sandbox → triggers error
+				Path:    "/tmp/outside-sandbox/evil.txt",
+				Content: "should fail",
+				Mode:    0644,
+			},
+		},
+	}
+
+	builder := NewPodBuilderFromRunner(runner).WithCommand(cmd)
+	_, _, _, err := builder.setup(context.Background())
+	require.Error(t, err, "setup should fail due to path escape")
+
+	// Critical: source sandbox must NOT be deleted
+	_, statErr := os.Stat(sourceSandbox)
+	assert.NoError(t, statErr, "source sandbox directory must still exist after error")
+
+	// Sentinel file must be preserved
+	data, readErr := os.ReadFile(sentinelPath)
+	assert.NoError(t, readErr, "sentinel file must still exist after error")
+	assert.Equal(t, "do not delete", string(data))
+}

--- a/runner/internal/runner/setup_strategy.go
+++ b/runner/internal/runner/setup_strategy.go
@@ -15,6 +15,10 @@ import (
 type SetupResult struct {
 	WorkingDir string
 	BranchName string
+	// SandboxRoot overrides the default sandbox root when non-empty.
+	// Used by LocalPathStrategy to reuse the source pod's sandbox directory,
+	// preventing path template escapes during resume mode.
+	SandboxRoot string
 }
 
 // SetupStrategy defines the interface for working directory setup strategies.
@@ -110,7 +114,11 @@ func (s *LocalPathStrategy) Setup(ctx context.Context, sandboxRoot string, cfg *
 			"local_path", cfg.LocalPath)
 	}
 
-	return &SetupResult{WorkingDir: workingDir, BranchName: ""}, nil
+	return &SetupResult{
+		WorkingDir:  workingDir,
+		BranchName:  "",
+		SandboxRoot: cfg.LocalPath, // Reuse source pod's sandbox to prevent path template escapes
+	}, nil
 }
 
 // =============================================================================

--- a/runner/internal/runner/setup_strategy_test.go
+++ b/runner/internal/runner/setup_strategy_test.go
@@ -1,0 +1,57 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	runnerv1 "github.com/anthropics/agentsmesh/proto/gen/go/runner/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalPathStrategy_ReturnsSandboxRoot(t *testing.T) {
+	localPath := t.TempDir()
+
+	strategy := NewLocalPathStrategy()
+	result, err := strategy.Setup(context.Background(), "/unused/sandbox", &runnerv1.SandboxConfig{
+		LocalPath: localPath,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, localPath, result.SandboxRoot,
+		"LocalPathStrategy should return source sandbox path as SandboxRoot")
+	assert.Equal(t, localPath, result.WorkingDir,
+		"without workspace subdir, WorkingDir should be localPath itself")
+}
+
+func TestLocalPathStrategy_WithWorkspace_ReturnsSandboxRoot(t *testing.T) {
+	localPath := t.TempDir()
+	workspaceDir := filepath.Join(localPath, "workspace")
+	require.NoError(t, os.MkdirAll(workspaceDir, 0755))
+
+	strategy := NewLocalPathStrategy()
+	result, err := strategy.Setup(context.Background(), "/unused/sandbox", &runnerv1.SandboxConfig{
+		LocalPath: localPath,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, localPath, result.SandboxRoot,
+		"SandboxRoot should always be the localPath (source sandbox)")
+	assert.Equal(t, workspaceDir, result.WorkingDir,
+		"WorkingDir should be workspace subdir when it exists")
+}
+
+func TestGitWorktreeStrategy_DoesNotSetSandboxRoot(t *testing.T) {
+	// GitWorktreeStrategy should NOT set SandboxRoot (it creates its own workspace)
+	// This verifies only LocalPathStrategy triggers the override path.
+	strategy := NewEmptySandboxStrategy()
+	sandboxRoot := t.TempDir()
+
+	result, err := strategy.Setup(context.Background(), sandboxRoot, &runnerv1.SandboxConfig{})
+
+	require.NoError(t, err)
+	assert.Empty(t, result.SandboxRoot,
+		"EmptySandboxStrategy should not set SandboxRoot override")
+}


### PR DESCRIPTION
## Summary

- **Bug 1 (Backend)**: Heartbeat reconciliation killed active pods on transient DB errors. Now distinguishes `gorm.ErrRecordNotFound` from transient errors and applies evidence accumulation (miss count threshold) before terminating unknown pods.
- **Bug 2 (Runner)**: Resume pod failed because `.mcp.json` path template escaped the new sandbox. `LocalPathStrategy` now returns `SandboxRoot` override to reuse the source pod's sandbox, with `sandboxOwned` guard to prevent error cleanup from deleting source data.

## Test plan

- [x] `TestReconcilePods_TransientDBError_NoTerminate` — transient DB error never triggers terminate
- [x] `TestReconcilePods_NotFound_WithEvidence` — NotFound requires threshold heartbeats to terminate
- [x] `TestReconcilePods_MixedTransientAndNotFound` — transient errors don't contribute to miss count
- [x] `TestLocalPathStrategy_ReturnsSandboxRoot` — strategy returns SandboxRoot field
- [x] `TestLocalPathStrategy_WithWorkspace_ReturnsSandboxRoot` — with workspace subdir
- [x] `TestGitWorktreeStrategy_DoesNotSetSandboxRoot` — non-LocalPath strategies unaffected
- [x] `TestSetup_LocalPath_UsesSandboxRootOverride` — setup() applies override correctly
- [x] `TestCreateFiles_ResumeMode_McpJsonInWorkDir` — exact production bug scenario
- [x] `TestCreateFiles_ResumeMode_RootPathTemplate` — `{{.sandbox.root_path}}` template
- [x] `TestSetup_LocalPath_ErrorDoesNotDeleteSourceSandbox` — error cleanup preserves source data
- [x] Full regression: `backend/internal/service/runner` and `runner/internal/runner` pass