### PR TITLE
fix(web): exclude orphaned pods from Mine/Org sidebar filters

### DIFF
--- a/web/src/stores/__tests__/pod-guards.test.ts
+++ b/web/src/stores/__tests__/pod-guards.test.ts
@@ -93,7 +93,7 @@ describe("Pod Store — fetchSidebarPods", () => {
     });
 
     expect(podApi.list).toHaveBeenCalledWith({
-      status: "running,initializing,orphaned",
+      status: "running,initializing",
       limit: 20,
       offset: 0,
     });
@@ -123,7 +123,7 @@ describe("Pod Store — fetchSidebarPods", () => {
     });
 
     expect(podApi.list).toHaveBeenCalledWith({
-      status: "running,initializing,orphaned",
+      status: "running,initializing",
       createdById: 42,
       limit: 20,
       offset: 0,
@@ -140,7 +140,7 @@ describe("Pod Store — fetchSidebarPods", () => {
     });
 
     expect(podApi.list).toHaveBeenCalledWith({
-      status: "running,initializing,orphaned",
+      status: "running,initializing",
       limit: 20,
       offset: 0,
     });
@@ -200,7 +200,7 @@ describe("Pod Store — loadMorePods", () => {
     });
 
     expect(podApi.list).toHaveBeenCalledWith({
-      status: "running,initializing,orphaned",
+      status: "running,initializing",
       limit: 20,
       offset: 1,
     });
@@ -258,7 +258,7 @@ describe("Pod Store — loadMorePods", () => {
     });
 
     expect(podApi.list).toHaveBeenCalledWith({
-      status: "running,initializing,orphaned",
+      status: "running,initializing",
       createdById: 42,
       limit: 20,
       offset: 1,

--- a/web/src/stores/pod.ts
+++ b/web/src/stores/pod.ts
@@ -8,8 +8,8 @@ export type Pod = PodData;
 
 // Sidebar status filter → API status query parameter mapping
 export const SIDEBAR_STATUS_MAP: Record<string, string> = {
-  mine: "running,initializing,orphaned",
-  org: "running,initializing,orphaned",
+  mine: "running,initializing",
+  org: "running,initializing",
   completed: "terminated,failed,paused,completed,error",
 };
 const SIDEBAR_PAGE_SIZE = 20;


### PR DESCRIPTION
## Summary
- Remove `orphaned` status from `SIDEBAR_STATUS_MAP` for `mine` and `org` filters
- Orphaned pods (runner reconnecting) are a transient state and should not appear in active pod lists
- Updated tests to match new filter behavior

## Test plan
- [x] All 24 pod-guards tests pass
- [ ] Verify Mine filter no longer shows orphaned pods in sidebar
- [ ] Verify Org filter no longer shows orphaned pods in sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)