### PR TITLE
fix(runner): macOS launchd restart after upgrade

### DIFF
--- a/runner/internal/service/service.go
+++ b/runner/internal/service/service.go
@@ -147,8 +147,8 @@ func ServiceConfig() *service.Config {
 			// macOS launchd: auto-restart on crash
 			"KeepAlive":        true,
 			"ThrottleInterval": 10,
-			// Linux systemd: auto-restart on failure
-			"Restart":               "on-failure",
+			// Linux systemd: auto-restart (always, not just on-failure)
+			"Restart":               "always",
 			"RestartSec":            "10",
 			"StartLimitBurst":       "5",
 			"StartLimitIntervalSec": "60",

--- a/runner/internal/service/service_management.go
+++ b/runner/internal/service/service_management.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/kardianos/service"
 
@@ -171,15 +172,23 @@ func GetDefaultConfigPath() string {
 // RestartForUpdate restarts the service after an update.
 // This should be called after the binary has been replaced.
 func RestartForUpdate() error {
-	prg := &Program{}
-	s, err := service.New(prg, ServiceConfig())
-	if err != nil {
-		return fmt.Errorf("failed to create service: %w", err)
-	}
-
-	// Check if running as a service
 	if !service.Interactive() {
-		// Restart the service
+		if runtime.GOOS == "darwin" {
+			// macOS launchd: kardianos/service.Restart() uses launchctl unload/load.
+			// When called from within the service process, unload kills the process
+			// before load can execute, leaving the service unregistered in launchd.
+			// Instead, exit and let KeepAlive=true restart us with the new binary.
+			log.Info("Update applied, exiting for launchd KeepAlive restart")
+			os.Exit(0)
+		}
+
+		// Linux/Windows: s.Restart() uses atomic service manager commands
+		// (systemctl restart / sc.exe) that work correctly from within the process.
+		prg := &Program{}
+		s, err := service.New(prg, ServiceConfig())
+		if err != nil {
+			return fmt.Errorf("failed to create service: %w", err)
+		}
 		err = s.Restart()
 		if err != nil {
 			return fmt.Errorf("failed to restart service: %w", err)


### PR DESCRIPTION
## Summary

- Fix macOS service unable to restart after remote upgrade. `kardianos/service.Restart()` calls `launchctl unload` then `load`; when invoked from within the service process, `unload` kills the process before `load` executes, leaving the service unregistered in launchd.
- On macOS, exit with code 0 and let `KeepAlive=true` auto-restart with the new binary. Linux/Windows paths unchanged (`systemctl restart` / `sc.exe` are atomic).
- Change systemd `Restart` policy from `on-failure` to `always` so clean exits also trigger restart.

## Test plan

- [ ] `go build ./...` — compiles on macOS
- [ ] Deploy to macmini-02-16, trigger remote upgrade, verify `launchctl list agentsmesh-runner` shows PID
- [ ] Linux: confirm `systemctl restart` path unchanged