### PR TITLE
fix(runner): search Claude JSONL files in HOME-based project path

### DIFF
--- a/runner/internal/tokenusage/parser_claude.go
+++ b/runner/internal/tokenusage/parser_claude.go
@@ -91,10 +91,28 @@ func (p *ClaudeParser) Parse(sandboxPath string, podStartedAt time.Time) (*Token
 	return usage, nil
 }
 
-// claudePathHash computes the project directory hash used by Claude Code.
-// It replaces all "/" with "-" in the resolved absolute path.
+// claudePathHash reproduces the project directory naming convention used by
+// Claude Code: the resolved absolute path with OS path separators replaced by "-".
+//
+// Claude Code (Node.js on macOS/Linux) simply does path.replaceAll("/", "-").
+// We also handle "\" and strip ":" so the hash is valid on Windows.
+//
+// This is intentionally NOT using filepath helpers — it must match the external
+// convention, not the local OS path semantics.
 func claudePathHash(resolvedPath string) string {
-	return strings.ReplaceAll(resolvedPath, string(filepath.Separator), "-")
+	var b strings.Builder
+	b.Grow(len(resolvedPath))
+	for _, c := range resolvedPath {
+		switch c {
+		case '/', '\\':
+			b.WriteByte('-')
+		case ':':
+			// skip (Windows drive prefix, e.g. "C:")
+		default:
+			b.WriteRune(c)
+		}
+	}
+	return b.String()
 }
 
 func parseClaudeJSONLFile(path string, usage *TokenUsage) error {

--- a/runner/internal/tokenusage/parser_test.go
+++ b/runner/internal/tokenusage/parser_test.go
@@ -3,6 +3,7 @@ package tokenusage
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -12,6 +13,16 @@ import (
 
 // epoch is a zero time used as podStartedAt when we want all files to pass the mtime filter.
 var epoch = time.Time{}
+
+// setHome overrides the home directory for os.UserHomeDir() on all platforms.
+// On Unix it sets HOME; on Windows it sets USERPROFILE.
+func setHome(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("HOME", dir)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", dir)
+	}
+}
 
 // --- TokenUsage tests ---
 
@@ -92,7 +103,7 @@ invalid json line
 func setupClaudeHomeProject(t *testing.T, sandboxPath string) string {
 	t.Helper()
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 
 	// Resolve symlinks to match what claudePathHash does
 	resolved, err := filepath.EvalSymlinks(sandboxPath)
@@ -167,7 +178,7 @@ func TestClaudeParser_Parse_SubagentFiles(t *testing.T) {
 
 func TestClaudeParser_NoFiles(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("HOME", dir) // Override HOME to avoid scanning real files
+	setHome(t, dir) // Override HOME to avoid scanning real files
 	parser := &ClaudeParser{}
 	usage, err := parser.Parse(t.TempDir(), epoch)
 	assert.NoError(t, err)
@@ -194,6 +205,7 @@ func TestClaudeParser_SkipsOldFiles(t *testing.T) {
 }
 
 func TestClaudePathHash(t *testing.T) {
+	// Unix-style paths (cross-platform: filepath.ToSlash is a no-op on these)
 	tests := []struct {
 		input string
 		want  string
@@ -206,6 +218,10 @@ func TestClaudePathHash(t *testing.T) {
 		got := claudePathHash(tt.input)
 		assert.Equal(t, tt.want, got, "claudePathHash(%q)", tt.input)
 	}
+
+	// Windows-style paths (filepath.ToSlash converts \ to / on all platforms)
+	assert.Equal(t, "C-Users-test", claudePathHash(`C:\Users\test`))
+	assert.Equal(t, "D-workspace", claudePathHash(`D:\workspace`))
 }
 
 // --- Codex parser tests ---
@@ -425,7 +441,7 @@ func TestCollect_UnknownAgent(t *testing.T) {
 }
 
 func TestCollect_NoData(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setHome(t, t.TempDir())
 	usage := Collect("claude", t.TempDir(), epoch)
 	assert.Nil(t, usage)
 }


### PR DESCRIPTION
## Summary

- Fix `ClaudeParser` to search JSONL files in `$HOME/.claude/projects/{path-hash}/` instead of the incorrect `{sandboxPath}/.claude/projects/` path
- Resolve symlinks via `EvalSymlinks` before computing path hash (handles worktree symlinks)
- Try both `sandboxPath` and `sandboxPath/workspace` as working directory candidates
- Use `WalkDir` for recursive file discovery (covers `subagents/` subdirectories)

**Root cause**: Claude Code stores session data under `$HOME/.claude/projects/` keyed by a hash of the resolved working directory path. The parser was looking inside the sandbox directory itself, which never contains `.claude/projects/`.

## Test plan

- [x] `TestClaudeParser_Parse_HomeBasedPath` — verifies HOME-based path lookup
- [x] `TestClaudeParser_Parse_WorkspaceSubdir` — verifies workspace/ subdirectory candidate
- [x] `TestClaudeParser_Parse_SubagentFiles` — verifies recursive JSONL discovery
- [x] `TestClaudeParser_SkipsOldFiles` — verifies mtime filter still works
- [x] `TestClaudePathHash` — unit tests for path hash computation
- [x] All 23 tokenusage tests pass, full `go test ./...` passes