### PR TITLE
fix(web): close terminal pane on pod terminate and remove redundant tab bar

### DIFF
--- a/web/src/components/ide/sidebar/WorkspaceSidebarContent.tsx
+++ b/web/src/components/ide/sidebar/WorkspaceSidebarContent.tsx
@@ -42,6 +42,7 @@ export function WorkspaceSidebarContent({ className, onCreatePod, onTerminatePod
   const runnersLoading = useRunnerStore((s) => s.loading);
   const fetchRunners = useRunnerStore((s) => s.fetchRunners);
   const addPane = useWorkspaceStore((s) => s.addPane);
+  const removePaneByPodKey = useWorkspaceStore((s) => s.removePaneByPodKey);
   const panes = useWorkspaceStore((s) => s.panes);
 
   const user = useAuthStore((s) => s.user);
@@ -153,10 +154,11 @@ export function WorkspaceSidebarContent({ className, onCreatePod, onTerminatePod
       });
       if (confirmed) {
         await terminatePod(podKey);
+        removePaneByPodKey(podKey);
         onTerminatePod?.();
       }
     },
-    [confirm, t, terminatePod, onTerminatePod]
+    [confirm, t, terminatePod, removePaneByPodKey, onTerminatePod]
   );
 
   return (

--- a/web/src/components/mesh/PodContextMenu.tsx
+++ b/web/src/components/mesh/PodContextMenu.tsx
@@ -18,6 +18,7 @@ import {
 import { podApi } from "@/lib/api";
 import type { MeshNode } from "@/stores/mesh";
 import { useMeshStore } from "@/stores/mesh";
+import { useWorkspaceStore } from "@/stores/workspace";
 
 interface PodContextMenuProps {
   node: MeshNode;
@@ -30,6 +31,7 @@ export default function PodContextMenu({ node, children }: PodContextMenuProps) 
   const router = useRouter();
   const orgSlug = params.org as string;
   const { fetchTopology } = useMeshStore();
+  const removePaneByPodKey = useWorkspaceStore((s) => s.removePaneByPodKey);
   const { dialogProps, confirm } = useConfirmDialog();
 
   const isActive = node.status === "running" || node.status === "initializing";
@@ -53,9 +55,10 @@ export default function PodContextMenu({ node, children }: PodContextMenuProps) 
     });
     if (confirmed) {
       await podApi.terminate(node.pod_key);
+      removePaneByPodKey(node.pod_key);
       fetchTopology();
     }
-  }, [confirm, t, node.pod_key, fetchTopology]);
+  }, [confirm, t, node.pod_key, removePaneByPodKey, fetchTopology]);
 
   return (
     <>

--- a/web/src/components/workspace/TerminalPane.tsx
+++ b/web/src/components/workspace/TerminalPane.tsx
@@ -44,6 +44,7 @@ export function TerminalPane({
   const terminalFontSize = useWorkspaceStore((s) => s.terminalFontSize);
   const setActivePane = useWorkspaceStore((s) => s.setActivePane);
   const splitPane = useWorkspaceStore((s) => s.splitPane);
+  const removePaneByPodKey = useWorkspaceStore((s) => s.removePaneByPodKey);
   const panes = useWorkspaceStore((s) => s.panes);
   const initProgress = usePodStore((state) => state.initProgress[podKey]);
   const terminatePod = usePodStore((state) => state.terminatePod);
@@ -95,13 +96,13 @@ export function TerminalPane({
     setIsTerminating(true);
     try {
       await terminatePod(podKey);
-      onClose?.();
+      removePaneByPodKey(podKey);
     } catch (error) {
       console.error("Failed to terminate pod:", error);
     } finally {
       setIsTerminating(false);
     }
-  }, [podKey, terminatePod, onClose]);
+  }, [podKey, terminatePod, removePaneByPodKey]);
 
   // Cancel pending maximize RAF on unmount
   useEffect(() => {

--- a/web/src/components/workspace/WorkspaceManager.tsx
+++ b/web/src/components/workspace/WorkspaceManager.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useMemo } from "react";
 import { cn } from "@/lib/utils";
 import { CenteredSpinner } from "@/components/ui/spinner";
 import { useBreakpoint } from "@/components/layout/useBreakpoint";
 import { useWorkspaceStore } from "@/stores/workspace";
-import { TerminalTabs } from "./TerminalTabs";
 import { TerminalGrid } from "./TerminalGrid";
 import { TerminalSwiper } from "./TerminalSwiper";
 import { TerminalToolbar } from "./TerminalToolbar";
@@ -21,7 +20,6 @@ export function WorkspaceManager({ className }: WorkspaceManagerProps) {
   const addPane = useWorkspaceStore((s) => s.addPane);
   const _hasHydrated = useWorkspaceStore((s) => s._hasHydrated);
   const [showPodSelector, setShowPodSelector] = useState(false);
-  const [isFullscreen, setIsFullscreen] = useState(false);
 
   // Memoize to avoid creating a new array reference on every render
   const openPodKeys = useMemo(() => panes.map((p) => p.podKey), [panes]);
@@ -56,28 +54,6 @@ export function WorkspaceManager({ className }: WorkspaceManagerProps) {
     }
   };
 
-  // Toggle fullscreen
-  const toggleFullscreen = () => {
-    if (!document.fullscreenElement) {
-      document.documentElement.requestFullscreen();
-      setIsFullscreen(true);
-    } else {
-      document.exitFullscreen();
-      setIsFullscreen(false);
-    }
-  };
-
-  // Listen for fullscreen changes
-  useEffect(() => {
-    const handleFullscreenChange = () => {
-      setIsFullscreen(!!document.fullscreenElement);
-    };
-    document.addEventListener("fullscreenchange", handleFullscreenChange);
-    return () => {
-      document.removeEventListener("fullscreenchange", handleFullscreenChange);
-    };
-  }, []);
-
   if (!_hasHydrated) {
     return (
       <div className="h-full bg-terminal-bg">
@@ -90,21 +66,11 @@ export function WorkspaceManager({ className }: WorkspaceManagerProps) {
     <div className={cn("flex flex-col h-full bg-terminal-bg", className)}>
       {/* Desktop layout */}
       {!isMobile && (
-        <>
-          {/* Tab bar */}
-          <TerminalTabs
-            onAddNew={handleAddNew}
-            isFullscreen={isFullscreen}
-            onToggleFullscreen={toggleFullscreen}
-          />
-
-          {/* Grid */}
-          <TerminalGrid
-            onPopout={handlePopout}
-            onAddNew={handleAddNew}
-            className="flex-1"
-          />
-        </>
+        <TerminalGrid
+          onPopout={handlePopout}
+          onAddNew={handleAddNew}
+          className="flex-1"
+        />
       )}
 
       {/* Mobile layout */}

--- a/web/src/providers/RealtimeProvider.tsx
+++ b/web/src/providers/RealtimeProvider.tsx
@@ -3,6 +3,7 @@
 import React, { createContext, useContext, useEffect, useCallback, useRef, useMemo } from "react";
 import { useRealtimeConnection, useAllEventsSubscription } from "@/hooks/useRealtimeEvents";
 import { usePodStore } from "@/stores/pod";
+import { useWorkspaceStore } from "@/stores/workspace";
 import { useRunnerStore } from "@/stores/runner";
 import { useTicketStore } from "@/stores/ticket";
 import { useMeshStore } from "@/stores/mesh";
@@ -101,6 +102,10 @@ export function RealtimeProvider({
               data.error_message
             );
           }
+          // Close terminal pane when pod reaches a terminal state
+          if (data.status === "terminated" || data.status === "failed" || data.status === "error") {
+            useWorkspaceStore.getState().removePaneByPodKey(data.pod_key);
+          }
           // Also refresh Mesh topology since pod status affects the mesh
           useMeshStore.getState().fetchTopology?.();
           console.log("[Realtime] Pod status changed:", data.pod_key, data.status);
@@ -120,6 +125,8 @@ export function RealtimeProvider({
           const data = event.data as PodStatusChangedData;
           // Update pod status to terminated
           usePodStore.getState().updatePodStatus?.(data.pod_key, "terminated");
+          // Close terminal pane for the terminated pod
+          useWorkspaceStore.getState().removePaneByPodKey(data.pod_key);
           // Also refresh Mesh topology since termination removes the pod from mesh
           useMeshStore.getState().fetchTopology?.();
           console.log("[Realtime] Pod terminated:", data.pod_key);

--- a/web/src/stores/workspace.ts
+++ b/web/src/stores/workspace.ts
@@ -91,6 +91,7 @@ interface WorkspaceState {
   updateSplitSizes: (splitId: string, sizes: [number, number]) => void;
   setMobileActiveIndex: (index: number) => void;
   setTerminalFontSize: (size: number) => void;
+  removePaneByPodKey: (podKey: string) => void;
   clearAllPanes: () => void;
   getPaneByPodKey: (podKey: string) => TerminalPane | undefined;
 
@@ -288,6 +289,13 @@ export const useWorkspaceStore = create<WorkspaceState>()(
       closePaneFromTree: (paneId) => {
         // Alias for removePane — removes from both panes array and tree
         get().removePane(paneId);
+      },
+
+      removePaneByPodKey: (podKey) => {
+        const pane = get().panes.find((p) => p.podKey === podKey);
+        if (pane) {
+          get().removePane(pane.id);
+        }
       },
 
       updateSplitSizes: (splitId, sizes) => {


### PR DESCRIPTION
## Summary
- When a pod is terminated (sidebar, terminal pane, mesh context menu, or WebSocket event), automatically close the corresponding terminal pane
- Remove the redundant `TerminalTabs` bar — each pane already has its own header with title, status dot, and action buttons
- Add `removePaneByPodKey()` to workspace store for centralized pane cleanup

## Test plan
- [ ] Terminate a pod from sidebar → terminal pane closes
- [ ] Terminate a pod from terminal pane header → pane closes
- [ ] Terminate a pod from mesh context menu → pane closes (if open)
- [ ] External termination (WebSocket) → pane auto-closes
- [ ] Click a pod in sidebar that already has a pane open → focuses existing pane
- [ ] Click a new pod in sidebar → opens new pane with horizontal split
- [ ] Empty state "Open Terminal" button still works
- [ ] Mobile layout unaffected (TerminalSwiper still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)