### PR TITLE
fix(runner,web): fix pod daemon recovery path and sidebar realtime update

### DIFF
--- a/runner/internal/poddaemon/manager.go
+++ b/runner/internal/poddaemon/manager.go
@@ -11,7 +11,7 @@ import (
 
 // PodDaemonManager manages the lifecycle of pod daemon sessions.
 type PodDaemonManager struct {
-	workspaceRoot string
+	sandboxesDir  string // Base directory containing per-pod sandbox directories
 	socketDir     string // IPC socket directory (short path, provided by config)
 	runnerBinPath string
 }
@@ -35,9 +35,9 @@ type CreateOpts struct {
 }
 
 // NewPodDaemonManager creates a new manager.
-// workspaceRoot is the base directory for sandbox directories.
+// sandboxesDir is the base directory containing per-pod sandbox directories (each with pod_daemon.json).
 // socketDir is the directory for IPC sockets (must be short for Unix socket path limits).
-func NewPodDaemonManager(workspaceRoot, socketDir string) (*PodDaemonManager, error) {
+func NewPodDaemonManager(sandboxesDir, socketDir string) (*PodDaemonManager, error) {
 	binPath, err := os.Executable()
 	if err != nil {
 		return nil, fmt.Errorf("get executable path: %w", err)
@@ -48,7 +48,7 @@ func NewPodDaemonManager(workspaceRoot, socketDir string) (*PodDaemonManager, er
 	}
 
 	return &PodDaemonManager{
-		workspaceRoot: workspaceRoot,
+		sandboxesDir:  sandboxesDir,
 		socketDir:     socketDir,
 		runnerBinPath: binPath,
 	}, nil
@@ -134,14 +134,14 @@ func (m *PodDaemonManager) AttachSession(state *PodDaemonState) (*daemonPTY, err
 	return connectDaemon(state.IPCPath)
 }
 
-// RecoverSessions scans the workspace root for existing daemon state files.
+// RecoverSessions scans the sandboxes directory for existing daemon state files.
 func (m *PodDaemonManager) RecoverSessions() ([]*PodDaemonState, error) {
-	entries, err := os.ReadDir(m.workspaceRoot)
+	entries, err := os.ReadDir(m.sandboxesDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("read workspace root: %w", err)
+		return nil, fmt.Errorf("read sandboxes dir: %w", err)
 	}
 
 	var sessions []*PodDaemonState
@@ -149,7 +149,7 @@ func (m *PodDaemonManager) RecoverSessions() ([]*PodDaemonState, error) {
 		if !entry.IsDir() {
 			continue
 		}
-		sandboxPath := filepath.Join(m.workspaceRoot, entry.Name())
+		sandboxPath := filepath.Join(m.sandboxesDir, entry.Name())
 		state, err := LoadState(sandboxPath)
 		if err != nil {
 			continue // No state file or corrupt

--- a/runner/internal/poddaemon/manager_test.go
+++ b/runner/internal/poddaemon/manager_test.go
@@ -86,7 +86,7 @@ func TestNewPodDaemonManager(t *testing.T) {
 	mgr, err := NewPodDaemonManager(dir, socketDir)
 	require.NoError(t, err)
 	assert.NotNil(t, mgr)
-	assert.Equal(t, dir, mgr.workspaceRoot)
+	assert.Equal(t, dir, mgr.sandboxesDir)
 	assert.Equal(t, socketDir, mgr.socketDir)
 	assert.NotEmpty(t, mgr.runnerBinPath) // should resolve to test binary
 }

--- a/runner/internal/runner/runner.go
+++ b/runner/internal/runner/runner.go
@@ -131,7 +131,7 @@ func New(cfg *config.Config) (*Runner, error) {
 	podStore := NewInMemoryPodStore()
 
 	// Create Pod Daemon manager for session persistence
-	podDaemonMgr, err := poddaemon.NewPodDaemonManager(cfg.WorkspaceRoot, cfg.GetSocketDir())
+	podDaemonMgr, err := poddaemon.NewPodDaemonManager(cfg.GetSandboxesDir(), cfg.GetSocketDir())
 	if err != nil {
 		log.Warn("Pod Daemon manager unavailable, sessions won't persist across restarts", "error", err)
 	}

--- a/web/src/providers/RealtimeProvider.tsx
+++ b/web/src/providers/RealtimeProvider.tsx
@@ -77,6 +77,9 @@ export function RealtimeProvider({
           const data = event.data as PodCreatedData;
           // Fetch the individual pod to avoid resetting pagination state
           usePodStore.getState().fetchPod?.(data.pod_key);
+          // Refresh sidebar to show newly created pod immediately
+          const { currentSidebarFilter, fetchSidebarPods } = usePodStore.getState();
+          fetchSidebarPods?.(currentSidebarFilter);
           // Also refresh Mesh topology since a new pod affects the mesh
           useMeshStore.getState().fetchTopology?.();
           console.log("[Realtime] Pod created:", data.pod_key);


### PR DESCRIPTION
## Summary

- **Pod Daemon Recovery**: `RecoverSessions()` scanned `workspaceRoot` (`/tmp/agentsmesh-workspace/`) instead of the `sandboxes/` subdirectory where `pod_daemon.json` files actually live. Fixes daemon recovery after runner restart.
- **Pod Sidebar Realtime**: `pod:created` WebSocket event only fetched the individual pod but never refreshed the sidebar list. New pods now appear immediately in the "Mine" section.

## Test plan

- [x] `go test ./internal/poddaemon/...` — all 30+ tests pass (including RecoverSessions coverage)
- [x] `tsc --noEmit` — TypeScript type-check passes
- [ ] Manual: create a pod and verify it appears in sidebar immediately
- [ ] Manual: restart runner and verify existing daemon sessions are recovered