### PR TITLE
docs: remove Homebrew installation guidance for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,6 @@ The Runner is a lightweight daemon that runs on your machine and executes AI age
 curl -fsSL https://agentsmesh.ai/install.sh | sh
 ```
 
-Or via Homebrew:
-
-```bash
-brew install agentsmesh/tap/agentsmesh-runner
-```
-
 > See the [Runner README](runner/) for more installation options (deb, rpm, Windows, etc.)
 
 ### 2. Login

--- a/runner/.goreleaser.yml
+++ b/runner/.goreleaser.yml
@@ -198,12 +198,6 @@ release:
     irm https://agentsmesh.ai/install.ps1 | iex
     ```
 
-    **macOS (Homebrew):**
-    ```bash
-    brew tap agentsmesh/tap https://github.com/AgentsMesh/BrewCask
-    brew install agentsmesh/tap/agentsmesh-runner
-    ```
-
     ### Quick Start
 
     ```bash

--- a/runner/README.md
+++ b/runner/README.md
@@ -28,13 +28,6 @@ curl -fsSL https://agentsmesh.ai/install.sh | sh
 irm https://agentsmesh.ai/install.ps1 | iex
 ```
 
-### macOS (Homebrew)
-
-```bash
-brew tap agentsmesh/tap https://github.com/AgentsMesh/BrewCask
-brew install agentsmesh/tap/agentsmesh-runner
-```
-
 All binaries are available on the [Releases](https://github.com/AgentsMesh/AgentsMesh/releases/latest) page (tar.gz, deb, rpm, zip).
 
 ## Quick Start

--- a/web/public/install.sh
+++ b/web/public/install.sh
@@ -240,32 +240,6 @@ print_next_steps() {
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 }
 
-# Check for Homebrew on macOS (suggest but don't require)
-check_homebrew() {
-    if [ "$OS" = "darwin" ] && command -v brew >/dev/null 2>&1; then
-        echo ""
-        warn "Homebrew detected! You can also install via:"
-        echo "     ${BLUE}brew tap agentsmesh/tap https://github.com/AgentsMesh/BrewCask${NC}"
-        echo "     ${BLUE}brew install agentsmesh/tap/agentsmesh-runner${NC}"
-        echo ""
-
-        # In pipe mode, skip interactive prompt and continue with installation
-        if ! is_tty; then
-            info "Non-interactive mode detected, continuing with direct installation..."
-            return
-        fi
-
-        printf "Continue with direct installation? [Y/n] "
-        read -r response </dev/tty
-        case "$response" in
-            [nN][oO]|[nN])
-                info "Installation cancelled. Use Homebrew to install."
-                exit 0
-                ;;
-        esac
-    fi
-}
-
 # Main
 main() {
     echo ""
@@ -280,7 +254,6 @@ main() {
     echo ""
 
     detect_platform
-    check_homebrew
     detect_install_dir
     get_latest_version
     install

--- a/web/src/app/changelog/page.tsx
+++ b/web/src/app/changelog/page.tsx
@@ -228,7 +228,7 @@ const changelog: ChangelogEntry[] = [
           "Runner migrated from WebSocket to gRPC + mTLS communication",
           "MCP tool: create_pod with agent_type_id parameter",
           "macOS universal binary support in GoReleaser",
-          "Homebrew formula automatic updates on release",
+          "Automated release pipeline for all platforms",
           "Windows ConPTY support for terminal",
         ],
       },

--- a/web/src/app/docs/runners/setup/page.tsx
+++ b/web/src/app/docs/runners/setup/page.tsx
@@ -50,17 +50,6 @@ irm ${serverUrl}/install.ps1 | iex`}</pre>
         </div>
 
         <h3 className="text-lg font-medium mb-2 mt-6">
-          {t("docs.runners.setup.quickInstall.brewTitle")}
-        </h3>
-        <div className="bg-muted rounded-lg p-4 font-mono text-sm overflow-x-auto">
-          <pre className="text-green-500 dark:text-green-400">{`# Add AgentsMesh tap
-brew tap agentsmesh/tap https://github.com/AgentsMesh/BrewCask
-
-# Install runner
-brew install agentsmesh/tap/agentsmesh-runner`}</pre>
-        </div>
-
-        <h3 className="text-lg font-medium mb-2 mt-6">
           {t("docs.runners.setup.quickInstall.linuxTitle")}
         </h3>
         <p className="text-sm text-muted-foreground mb-2">

--- a/web/src/messages/de/docs.json
+++ b/web/src/messages/de/docs.json
@@ -151,7 +151,7 @@
         "description": "Ein Runner ist die Ausführungsumgebung, in der KI-Agenten-Pods laufen. Installieren Sie AgentsMesh Runner auf Ihrer Entwicklungsmaschine oder Ihrem Server.",
         "methodToken": "Mit einem Token registrieren",
         "methodLogin": "Mit Browser-Login registrieren",
-        "seeSetup": "Siehe {link} für Docker-, Homebrew-, Linux-Paket- und Kubernetes-Bereitstellungsoptionen."
+        "seeSetup": "Siehe {link} für Docker-, Linux-Paket- und Kubernetes-Bereitstellungsoptionen."
       },
       "step3": {
         "title": "KI-Agenten-CLIs installieren",
@@ -648,7 +648,6 @@
         "quickInstall": {
           "title": "Quick Installation",
           "oneLineTitle": "One-Line Install (Recommended)",
-          "brewTitle": "macOS (Homebrew)",
           "linuxTitle": "Linux (Package Manager)",
           "afterInstall": "After Installation",
           "tokenHint": "Get your registration token from Settings → Runners → Create Token in the AgentsMesh web interface.",

--- a/web/src/messages/en/docs.json
+++ b/web/src/messages/en/docs.json
@@ -151,7 +151,7 @@
         "description": "A Runner is the execution environment where AI agent Pods run. Install the AgentsMesh Runner on your development machine or server.",
         "methodToken": "Register with a token",
         "methodLogin": "Register with browser login",
-        "seeSetup": "See {link} for Docker, Homebrew, Linux packages, and Kubernetes deployment options."
+        "seeSetup": "See {link} for Docker, Linux packages, and Kubernetes deployment options."
       },
       "step3": {
         "title": "Install AI Agent CLIs",
@@ -648,7 +648,6 @@
         "quickInstall": {
           "title": "Quick Installation",
           "oneLineTitle": "One-Line Install (Recommended)",
-          "brewTitle": "macOS (Homebrew)",
           "linuxTitle": "Linux (Package Manager)",
           "afterInstall": "After Installation",
           "methodToken": "Option A: Register with a token",

--- a/web/src/messages/es/docs.json
+++ b/web/src/messages/es/docs.json
@@ -151,7 +151,7 @@
         "description": "Un Runner es el entorno de ejecución donde se ejecutan los Pods de agentes IA. Instala AgentsMesh Runner en tu máquina de desarrollo o servidor.",
         "methodToken": "Registrar con un token",
         "methodLogin": "Registrar con inicio de sesión del navegador",
-        "seeSetup": "Consulta {link} para opciones de despliegue con Docker, Homebrew, paquetes Linux y Kubernetes."
+        "seeSetup": "Consulta {link} para opciones de despliegue con Docker, paquetes Linux y Kubernetes."
       },
       "step3": {
         "title": "Instalar CLIs de agentes IA",
@@ -648,7 +648,6 @@
         "quickInstall": {
           "title": "Quick Installation",
           "oneLineTitle": "One-Line Install (Recommended)",
-          "brewTitle": "macOS (Homebrew)",
           "linuxTitle": "Linux (Package Manager)",
           "afterInstall": "After Installation",
           "tokenHint": "Get your registration token from Settings → Runners → Create Token in the AgentsMesh web interface.",

--- a/web/src/messages/fr/docs.json
+++ b/web/src/messages/fr/docs.json
@@ -151,7 +151,7 @@
         "description": "Un Runner est l'environnement d'exécution où les Pods d'agents IA s'exécutent. Installez AgentsMesh Runner sur votre machine de développement ou serveur.",
         "methodToken": "S'inscrire avec un jeton",
         "methodLogin": "S'inscrire avec connexion navigateur",
-        "seeSetup": "Consultez {link} pour les options de déploiement Docker, Homebrew, packages Linux et Kubernetes."
+        "seeSetup": "Consultez {link} pour les options de déploiement Docker, packages Linux et Kubernetes."
       },
       "step3": {
         "title": "Installer les CLIs d'agents IA",
@@ -648,7 +648,6 @@
         "quickInstall": {
           "title": "Quick Installation",
           "oneLineTitle": "One-Line Install (Recommended)",
-          "brewTitle": "macOS (Homebrew)",
           "linuxTitle": "Linux (Package Manager)",
           "afterInstall": "After Installation",
           "tokenHint": "Get your registration token from Settings → Runners → Create Token in the AgentsMesh web interface.",

--- a/web/src/messages/ja/docs.json
+++ b/web/src/messages/ja/docs.json
@@ -151,7 +151,7 @@
         "description": "RunnerはAIエージェントPodの実行環境です。開発マシンまたはサーバーにAgentsMesh Runnerをインストールします。",
         "methodToken": "トークンで登録",
         "methodLogin": "ブラウザログインで登録",
-        "seeSetup": "Docker、Homebrew、Linuxパッケージ、Kubernetesデプロイオプションについては {link} をご覧ください。"
+        "seeSetup": "Docker、Linuxパッケージ、Kubernetesデプロイオプションについては {link} をご覧ください。"
       },
       "step3": {
         "title": "AIエージェントCLIをインストール",
@@ -648,7 +648,6 @@
         "quickInstall": {
           "title": "Quick Installation",
           "oneLineTitle": "One-Line Install (Recommended)",
-          "brewTitle": "macOS (Homebrew)",
           "linuxTitle": "Linux (Package Manager)",
           "afterInstall": "After Installation",
           "tokenHint": "Get your registration token from Settings → Runners → Create Token in the AgentsMesh web interface.",

--- a/web/src/messages/ko/docs.json
+++ b/web/src/messages/ko/docs.json
@@ -151,7 +151,7 @@
         "description": "Runner는 AI 에이전트 Pod의 실행 환경입니다. 개발 머신이나 서버에 AgentsMesh Runner를 설치하세요.",
         "methodToken": "토큰으로 등록",
         "methodLogin": "브라우저 로그인으로 등록",
-        "seeSetup": "Docker, Homebrew, Linux 패키지 및 Kubernetes 배포 옵션에 대해서는 {link}을 참조하세요."
+        "seeSetup": "Docker, Linux 패키지 및 Kubernetes 배포 옵션에 대해서는 {link}을 참조하세요."
       },
       "step3": {
         "title": "AI 에이전트 CLI 설치",
@@ -648,7 +648,6 @@
         "quickInstall": {
           "title": "Quick Installation",
           "oneLineTitle": "One-Line Install (Recommended)",
-          "brewTitle": "macOS (Homebrew)",
           "linuxTitle": "Linux (Package Manager)",
           "afterInstall": "After Installation",
           "tokenHint": "Get your registration token from Settings → Runners → Create Token in the AgentsMesh web interface.",

--- a/web/src/messages/pt/docs.json
+++ b/web/src/messages/pt/docs.json
@@ -151,7 +151,7 @@
         "description": "Um Runner é o ambiente de execução onde os Pods de agentes IA são executados. Instale o AgentsMesh Runner na sua máquina de desenvolvimento ou servidor.",
         "methodToken": "Registrar com um token",
         "methodLogin": "Registrar com login pelo navegador",
-        "seeSetup": "Consulte {link} para opções de implantação com Docker, Homebrew, pacotes Linux e Kubernetes."
+        "seeSetup": "Consulte {link} para opções de implantação com Docker, pacotes Linux e Kubernetes."
       },
       "step3": {
         "title": "Instalar CLIs de agentes IA",
@@ -648,7 +648,6 @@
         "quickInstall": {
           "title": "Quick Installation",
           "oneLineTitle": "One-Line Install (Recommended)",
-          "brewTitle": "macOS (Homebrew)",
           "linuxTitle": "Linux (Package Manager)",
           "afterInstall": "After Installation",
           "tokenHint": "Get your registration token from Settings → Runners → Create Token in the AgentsMesh web interface.",

--- a/web/src/messages/zh/docs.json
+++ b/web/src/messages/zh/docs.json
@@ -151,7 +151,7 @@
         "description": "Runner 是 AI 智能体 Pod 的执行环境。在你的开发机器或服务器上安装 AgentsMesh Runner。",
         "methodToken": "使用令牌注册",
         "methodLogin": "使用浏览器登录注册",
-        "seeSetup": "查看 {link} 了解 Docker、Homebrew、Linux 包和 Kubernetes 部署选项。"
+        "seeSetup": "查看 {link} 了解 Docker、Linux 包和 Kubernetes 部署选项。"
       },
       "step3": {
         "title": "安装 AI 智能体 CLI",
@@ -648,7 +648,6 @@
         "quickInstall": {
           "title": "快速安装",
           "oneLineTitle": "一行命令安装（推荐）",
-          "brewTitle": "macOS (Homebrew)",
           "linuxTitle": "Linux（包管理器）",
           "afterInstall": "安装后",
           "tokenHint": "在 AgentsMesh Web 界面的 设置 → Runner → 创建令牌 中获取注册令牌。",


### PR DESCRIPTION
## Summary
- Remove Homebrew tap/install instructions from all user-facing documentation and website
- Remove `check_homebrew` function from install.sh (no longer suggests brew on macOS)
- Remove Homebrew section from release notes template in goreleaser
- Update i18n strings across all 8 languages (en, zh, ja, ko, fr, es, de, pt)
- Homebrew publishing pipeline is **retained** — only the user-facing promotion is removed

## Test plan
- [ ] Verify docs pages render correctly without Homebrew section
- [ ] Verify install.sh runs without errors on macOS (no Homebrew prompt)
- [ ] Verify all i18n keys resolve correctly (no missing `brewTitle` errors)