### PR TITLE
fix(runner): fix Pod Daemon not finding executables in $PATH

### DIFF
--- a/runner/internal/envpath/envpath.go
+++ b/runner/internal/envpath/envpath.go
@@ -13,14 +13,54 @@ import (
 //     use it directly and skip the expensive login shell spawn.
 //  2. Platform-specific resolution (Unix: login shell spawn; Windows: current PATH).
 //  3. Fallback — current process PATH.
+//
+// The resolved PATH is then merged with the current process PATH to ensure
+// directories from the interactive session (e.g., nvm, pyenv, rbenv) are not
+// lost. This is critical for Pod Daemon mode, where the daemon subprocess
+// inherits only the resolved PATH and uses it for exec.LookPath.
 func ResolveLoginShellPATH() string {
 	// Fast path: if the service installer captured PATH at install time,
 	// use it directly — avoids the overhead of spawning a login shell.
 	if envPath := os.Getenv("AGENTSMESH_PATH"); envPath != "" {
 		dirs := strings.Split(envPath, string(os.PathListSeparator))
 		slog.Info("envpath: using AGENTSMESH_PATH from environment", "dirs", len(dirs))
-		return envPath
+		return mergeWithCurrentPATH(envPath)
 	}
 
-	return resolveLoginShellPATH()
+	return mergeWithCurrentPATH(resolveLoginShellPATH())
+}
+
+// mergeWithCurrentPATH merges the resolved PATH with the current process PATH.
+// Resolved dirs take priority (appear first); unique dirs from the current
+// process PATH are appended. This ensures tools installed via version managers
+// (nvm, pyenv, etc.) that initialize in .bashrc (but not login shell profiles)
+// are still available when the runner was started from an interactive session.
+func mergeWithCurrentPATH(resolved string) string {
+	current := os.Getenv("PATH")
+	if current == "" || current == resolved {
+		return resolved
+	}
+
+	sep := string(os.PathListSeparator)
+	resolvedDirs := strings.Split(resolved, sep)
+
+	seen := make(map[string]bool, len(resolvedDirs))
+	for _, d := range resolvedDirs {
+		seen[d] = true
+	}
+
+	var extra int
+	for _, d := range strings.Split(current, sep) {
+		if d != "" && !seen[d] {
+			resolvedDirs = append(resolvedDirs, d)
+			seen[d] = true
+			extra++
+		}
+	}
+
+	if extra > 0 {
+		slog.Info("envpath: merged additional dirs from current process PATH", "extra_dirs", extra)
+	}
+
+	return strings.Join(resolvedDirs, sep)
 }

--- a/runner/internal/envpath/envpath_test.go
+++ b/runner/internal/envpath/envpath_test.go
@@ -62,6 +62,56 @@ func TestResolveLoginShellPATH_FallbackOnInvalidShell(t *testing.T) {
 // profile prints extra output before/after the PATH does not corrupt the result.
 // It creates a small sh wrapper that emits noise and then prints PATH with the
 // sentinel, simulating a .zshrc with nvm or welcome-message output.
+func TestMergeWithCurrentPATH_AppendsUniqueDirs(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin:/opt/nvm/bin:/usr/local/bin")
+
+	result := mergeWithCurrentPATH("/usr/bin:/usr/local/bin")
+
+	// /opt/nvm/bin should be appended (unique to current PATH)
+	if !strings.Contains(result, "/opt/nvm/bin") {
+		t.Errorf("expected merged PATH to include /opt/nvm/bin, got: %s", result)
+	}
+	// Resolved dirs should appear first
+	if strings.Index(result, "/usr/bin") > strings.Index(result, "/opt/nvm/bin") {
+		t.Error("expected resolved dirs to appear before appended dirs")
+	}
+}
+
+func TestMergeWithCurrentPATH_NoDuplicates(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin:/usr/local/bin")
+
+	result := mergeWithCurrentPATH("/usr/bin:/usr/local/bin")
+
+	dirs := strings.Split(result, ":")
+	seen := make(map[string]bool)
+	for _, d := range dirs {
+		if seen[d] {
+			t.Errorf("duplicate dir in merged PATH: %s", d)
+		}
+		seen[d] = true
+	}
+}
+
+func TestMergeWithCurrentPATH_EmptyCurrentPATH(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	resolved := "/usr/bin:/usr/local/bin"
+	result := mergeWithCurrentPATH(resolved)
+	if result != resolved {
+		t.Errorf("expected %q, got %q", resolved, result)
+	}
+}
+
+func TestMergeWithCurrentPATH_IdenticalPATH(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin:/usr/local/bin")
+
+	resolved := "/usr/bin:/usr/local/bin"
+	result := mergeWithCurrentPATH(resolved)
+	if result != resolved {
+		t.Errorf("expected %q when paths are identical, got %q", resolved, result)
+	}
+}
+
 func TestResolveLoginShellPATH_NoisyProfile(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping login shell test on Windows")


### PR DESCRIPTION
## Summary

- Fix Pod Daemon subprocess failing to find executables (gemini, opencode, etc.) installed via version managers (nvm, pyenv, rbenv)
- Root cause: `ResolveLoginShellPATH()` resolves PATH from `bash -l` which may not source `.bashrc` where version managers initialize. The daemon subprocess inherits only this incomplete PATH, causing `exec.LookPath` to fail
- Merge unique directories from the current process PATH into the resolved login shell PATH so no directories are lost

## Test plan

- [x] Unit tests for `mergeWithCurrentPATH` (append unique dirs, no duplicates, empty/identical PATH edge cases)
- [x] All existing `envpath` tests pass
- [x] Full `runner` test suite passes (`go test ./...`)
- [ ] Manual: verify Pod creation works for agents installed via nvm (e.g., opencode, gemini)