### PR TITLE
fix(deploy) minio expose api port in docker-compose.yml (selfhost mode)

### DIFF
--- a/deploy/selfhost/docker-compose.yml
+++ b/deploy/selfhost/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       - minio_data:/data
     ports:
       - "${MINIO_CONSOLE_PORT:-9001}:9001"
+      - "${MINIO_API_PORT:-9000}:9000"
     healthcheck:
       test: ["CMD", "mc", "ready", "local"]
       interval: 10s


### PR DESCRIPTION
## Summary

- What changed?
  - Exposed MinIO API port (9000) in the selfhost Docker Compose configuration
  
- Why was this change needed?
  - The MinIO API port was not accessible from the host machine in selfhost mode, preventing external applications and services from connecting to MinIO's S3-compatible API. Only the console port (9001) was exposed, which is insufficient for programmatic access to object storage.

## Changes

- Added port mapping for MinIO API port in `deploy/selfhost/docker-compose.yml`
  - Exposed port `${MINIO_API_PORT:-9000}:9000` with configurable environment variable
  - Maintains consistency with existing MinIO console port configuration pattern
  - Uses default port 9000 if `MINIO_API_PORT` is not specified in environment

## Validation

- [ ] Backend tests (`cd backend && go test ./...`)
- [ ] Web checks (`cd web && pnpm run lint && pnpm run type-check && pnpm run test:coverage`)
- [ ] Runner checks (`cd runner && go test ./...`)
- [x] Manual validation performed (if applicable)
  - Verified MinIO API port is accessible from host machine
  - Confirmed S3 client connections work properly
  - Tested environment variable override functionality

## Documentation

- [ ] Docs updated (README/docs/inline comments)
- [x] No docs changes needed
  - This is an infrastructure configuration fix following existing patterns
  - Environment variable naming is self-explanatory and consistent with `MINIO_CONSOLE_PORT`

## Risk and Rollback

- Risk level: Low
- Rollback plan:
  - Remove the added port mapping line from `deploy/selfhost/docker-compose.yml`
  - Restart the MinIO service with `docker compose restart minio`
  - No data loss or migration required as this is purely a network configuration change