### PR TITLE
fix(runner): enable RunAtLoad for macOS launchd service

### DIFF
--- a/runner/internal/service/service.go
+++ b/runner/internal/service/service.go
@@ -149,8 +149,9 @@ func ServiceConfig() *service.Config {
 		Description: ServiceDescription,
 		Option: service.KeyValue{
 			"UserService": true,
-			// macOS launchd: auto-restart on crash
+			// macOS launchd: auto-restart on crash, auto-start on session create
 			"KeepAlive":        true,
+			"RunAtLoad":        true,
 			"ThrottleInterval": 10,
 			// Linux systemd: auto-restart (always, not just on-failure)
 			"Restart":               "always",


### PR DESCRIPTION
## Summary

- Enable `RunAtLoad=true` in macOS launchd service configuration so the runner auto-starts when a new GUI session is created
- Fixes issue where macOS session recreation (e.g., Screen Sharing reconnection) tears down `gui/501` domain and permanently kills the runner because `RunAtLoad=false` prevents re-registration

## Root Cause

When macOS destroys and recreates the GUI session (`gui/501`), launchd sends SIGTERM to all LaunchAgent services and removes them from the domain. With `RunAtLoad=false`, the service is **not** re-registered when the new session starts, leaving the runner permanently dead until manual intervention.

## Test plan

- [ ] `go build ./...` passes in runner directory
- [ ] Verify generated plist contains `<key>RunAtLoad</key><true/>` after `agentsmesh-runner service install`