### PR TITLE
fix(backend): allow re-import of soft-deleted GitHub repositories

### DIFF
--- a/backend/internal/service/repository/service_setup_test.go
+++ b/backend/internal/service/repository/service_setup_test.go
@@ -66,6 +66,17 @@ func setupTestDB(t *testing.T) *gorm.DB {
 		t.Fatalf("failed to create repositories table: %v", err)
 	}
 
+	// Partial unique index: only active (non-deleted) rows are constrained.
+	// Mirrors production schema (migration 000081).
+	err = db.Exec(`
+		CREATE UNIQUE INDEX IF NOT EXISTS repositories_org_provider_path_unique
+		ON repositories (organization_id, provider_type, provider_base_url, full_path)
+		WHERE deleted_at IS NULL
+	`).Error
+	if err != nil {
+		t.Fatalf("failed to create unique index: %v", err)
+	}
+
 	// Create loops table (referenced by Delete/HardDelete for application-level RESTRICT check)
 	err = db.Exec(`
 		CREATE TABLE IF NOT EXISTS loops (

--- a/backend/migrations/000081_fix_repository_unique_constraint_soft_delete.down.sql
+++ b/backend/migrations/000081_fix_repository_unique_constraint_soft_delete.down.sql
@@ -1,0 +1,7 @@
+-- Revert to plain unique constraint (loses soft-delete awareness).
+
+DROP INDEX IF EXISTS repositories_org_provider_path_unique;
+
+ALTER TABLE repositories
+    ADD CONSTRAINT repositories_org_provider_path_unique
+    UNIQUE(organization_id, provider_type, provider_base_url, full_path);

--- a/backend/migrations/000081_fix_repository_unique_constraint_soft_delete.up.sql
+++ b/backend/migrations/000081_fix_repository_unique_constraint_soft_delete.up.sql
@@ -1,0 +1,10 @@
+-- Fix: unique constraint must exclude soft-deleted rows so that
+-- re-importing a previously deleted repository succeeds.
+-- Replace the plain UNIQUE constraint with a partial unique index.
+
+ALTER TABLE repositories
+    DROP CONSTRAINT IF EXISTS repositories_org_provider_path_unique;
+
+CREATE UNIQUE INDEX repositories_org_provider_path_unique
+    ON repositories (organization_id, provider_type, provider_base_url, full_path)
+    WHERE deleted_at IS NULL;


### PR DESCRIPTION
The unique constraint on repositories(org_id, provider_type, provider_base_url, full_path) did not exclude soft-deleted rows, causing a constraint violation when re-importing a previously deleted repository. Replace the plain UNIQUE constraint with a partial unique index filtered by WHERE deleted_at IS NULL.

Also add the partial unique index to test setup so SQLite tests mirror production behavior.

## Summary

- What changed?
- Why was this change needed?

## Changes

- 

## Validation

- [ ] Backend tests (`cd backend && go test ./...`)
- [ ] Web checks (`cd web && pnpm run lint && pnpm run type-check && pnpm run test:coverage`)
- [ ] Runner checks (`cd runner && go test ./...`)
- [ ] Manual validation performed (if applicable)

## Documentation

- [ ] Docs updated (README/docs/inline comments)
- [ ] No docs changes needed

## Risk and Rollback

- Risk level: Low / Medium / High
- Rollback plan:
