### PR TITLE
feat(runner): use exec-replace for post-upgrade restart

### DIFF
--- a/runner/cmd/runner/cmd_run.go
+++ b/runner/cmd/runner/cmd_run.go
@@ -18,7 +18,6 @@ import (
 	"github.com/anthropics/agentsmesh/runner/internal/logger"
 	"github.com/anthropics/agentsmesh/runner/internal/pidfile"
 	"github.com/anthropics/agentsmesh/runner/internal/runner"
-	"github.com/anthropics/agentsmesh/runner/internal/service"
 	"github.com/anthropics/agentsmesh/runner/internal/updater"
 )
 
@@ -178,7 +177,7 @@ func startRunner(cfg *config.Config) (ok bool) {
 
 	// Inject updater and restart function for remote upgrade support
 	r.SetUpdater(updater.New(version))
-	r.SetRestartFunc(service.RestartFunc())
+	r.SetRestartFunc(execRestartFunc())
 
 	// Create web console (lifecycle managed by Supervisor)
 	consoleServer := console.New(cfg, DefaultConsolePort, version)

--- a/runner/cmd/runner/exec_restart.go
+++ b/runner/cmd/runner/exec_restart.go
@@ -1,0 +1,35 @@
+//go:build !windows
+
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// execRestartFunc returns a restart function that exec-replaces the current
+// process with the (updated) binary on disk. Because the runner is a single
+// binary, the updater can safely overwrite the file while we are still
+// running — the OS keeps the old inode open. syscall.Exec then loads the
+// new binary in-place, preserving the PID.
+func execRestartFunc() func() (int, error) {
+	return func() (int, error) {
+		execPath, err := os.Executable()
+		if err != nil {
+			return 0, fmt.Errorf("get executable path: %w", err)
+		}
+		execPath, err = filepath.EvalSymlinks(execPath)
+		if err != nil {
+			return 0, fmt.Errorf("resolve symlinks: %w", err)
+		}
+
+		slog.Info("Exec-replacing process with updated binary", "path", execPath)
+
+		err = syscall.Exec(execPath, os.Args, os.Environ())
+		// If Exec succeeds, this line is never reached.
+		return 0, fmt.Errorf("exec failed: %w", err)
+	}
+}

--- a/runner/cmd/runner/exec_restart_windows.go
+++ b/runner/cmd/runner/exec_restart_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package main
+
+import (
+	"github.com/anthropics/agentsmesh/runner/internal/service"
+)
+
+// execRestartFunc returns the platform restart function for Windows.
+// Windows does not support Unix syscall.Exec (exec-replace), so we
+// fall back to the service manager: in service mode it asks the SCM
+// to restart; in interactive mode it logs a manual-restart hint.
+func execRestartFunc() func() (int, error) {
+	return service.RestartFunc()
+}

--- a/runner/internal/pidfile/pidfile_unix.go
+++ b/runner/internal/pidfile/pidfile_unix.go
@@ -31,6 +31,12 @@ func CleanupStaleProcess() error {
 		return nil // No PID file or corrupt file (already cleaned up)
 	}
 
+	// After exec-replace the PID stays the same, so the new process
+	// would see its own PID in the file and try to kill itself.
+	if pid == os.Getpid() {
+		return nil
+	}
+
 	// Check if process is alive (signal 0 = existence check)
 	if err := syscall.Kill(pid, 0); err != nil {
 		if errors.Is(err, syscall.EPERM) {

--- a/runner/internal/pidfile/pidfile_windows.go
+++ b/runner/internal/pidfile/pidfile_windows.go
@@ -30,6 +30,14 @@ func CleanupStaleProcess() error {
 		return nil
 	}
 
+	// Defensive: on Unix, exec-replace keeps the same PID, so the new
+	// process would see its own PID and try to kill itself. On Windows
+	// service restart the PID changes, making this check a no-op — but
+	// it's kept for symmetry and safety.
+	if pid == os.Getpid() {
+		return nil
+	}
+
 	inspector := process.DefaultInspector()
 
 	// Check if the process is still alive.

--- a/runner/internal/service/service_management.go
+++ b/runner/internal/service/service_management.go
@@ -202,15 +202,6 @@ func RestartForUpdate() error {
 	return nil
 }
 
-// ScheduleRestartOnExit schedules a restart when the process exits.
-// This is useful for graceful updates where we want to restart after the update is applied.
-func ScheduleRestartOnExit() {
-	// In service mode, the service manager will automatically restart the process
-	// after it exits (if configured to do so).
-	// For interactive mode, we just exit and let the user restart manually.
-	log.Info("Update complete. Process will exit for restart.")
-}
-
 // RestartFunc returns a function that can be used to restart the service.
 // This is designed to be passed to the graceful updater.
 // Returns pid=0 because the service manager spawns the new process and we


### PR DESCRIPTION
## Summary

- Replace service-manager-based restart with `syscall.Exec` on Unix, allowing the runner to reload itself after self-upgrade without relying on an external supervisor (launchd/systemd)
- Add self-PID guard in pidfile cleanup to prevent the new process from killing itself after exec-replace (PID unchanged)
- Windows falls back to existing `service.RestartFunc()` since `syscall.Exec` is not available

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/pidfile/... ./internal/runner/...` passes
- [x] `GOOS=windows go build ./cmd/runner` cross-compiles successfully
- [ ] CI checks pass