### PR TITLE
fix(backend): make repository import idempotent (upsert on duplicate)

### DIFF
--- a/backend/internal/api/rest/v1/repositories_crud.go
+++ b/backend/internal/api/rest/v1/repositories_crud.go
@@ -43,19 +43,26 @@ func (h *RepositoryHandler) CreateRepository(c *gin.Context) {
 		return
 	}
 
-	// Check repository quota before creation
+	// Check repository quota before creation (skip for re-imports of existing repos)
 	if h.billingService != nil {
-		if err := h.billingService.CheckQuota(c.Request.Context(), tenant.OrganizationID, "repositories", 1); err != nil {
-			if err == billing.ErrQuotaExceeded {
-				apierr.PaymentRequired(c, apierr.REPOSITORY_QUOTA_EXCEEDED, "Repository quota exceeded. Please upgrade your plan to add more repositories.")
+		_, existsErr := h.repositoryService.GetByFullPath(
+			c.Request.Context(), tenant.OrganizationID,
+			req.ProviderType, req.ProviderBaseURL, req.FullPath,
+		)
+		isNewRepo := existsErr == repository.ErrRepositoryNotFound
+		if isNewRepo {
+			if err := h.billingService.CheckQuota(c.Request.Context(), tenant.OrganizationID, "repositories", 1); err != nil {
+				if err == billing.ErrQuotaExceeded {
+					apierr.PaymentRequired(c, apierr.REPOSITORY_QUOTA_EXCEEDED, "Repository quota exceeded. Please upgrade your plan to add more repositories.")
+					return
+				}
+				if err == billing.ErrSubscriptionFrozen {
+					apierr.PaymentRequired(c, apierr.SUBSCRIPTION_FROZEN, "Your subscription has expired. Please renew to continue.")
+					return
+				}
+				apierr.InternalError(c, "Failed to check quota")
 				return
 			}
-			if err == billing.ErrSubscriptionFrozen {
-				apierr.PaymentRequired(c, apierr.SUBSCRIPTION_FROZEN, "Your subscription has expired. Please renew to continue.")
-				return
-			}
-			apierr.InternalError(c, "Failed to check quota")
-			return
 		}
 	}
 
@@ -90,15 +97,11 @@ func (h *RepositoryHandler) CreateRepository(c *gin.Context) {
 		ImportedByUserID: &userID,
 	})
 	if err != nil {
-		if err == repository.ErrRepositoryExists {
-			apierr.Conflict(c, apierr.ALREADY_EXISTS, "Repository already configured")
-			return
-		}
 		apierr.InternalError(c, "Failed to create repository")
 		return
 	}
 
-	c.JSON(http.StatusCreated, gin.H{"repository": repo})
+	c.JSON(http.StatusOK, gin.H{"repository": repo})
 }
 
 // GetRepository returns repository by ID

--- a/backend/internal/api/rest/v1/repositories_webhook_mock_test.go
+++ b/backend/internal/api/rest/v1/repositories_webhook_mock_test.go
@@ -78,6 +78,15 @@ func (m *mockRepositoryService) SyncFromProvider(ctx context.Context, repoID int
 	return nil, nil
 }
 
+func (m *mockRepositoryService) GetByFullPath(ctx context.Context, orgID int64, providerType, providerBaseURL, fullPath string) (*gitprovider.Repository, error) {
+	for _, repo := range m.repos {
+		if repo.OrganizationID == orgID && repo.ProviderType == providerType && repo.ProviderBaseURL == providerBaseURL && repo.FullPath == fullPath {
+			return repo, nil
+		}
+	}
+	return nil, repository.ErrRepositoryNotFound
+}
+
 func (m *mockRepositoryService) ListMergeRequests(ctx context.Context, repoID int64, branch, state string) ([]*repository.MergeRequestInfo, error) {
 	return nil, nil
 }

--- a/backend/internal/service/repository/interfaces.go
+++ b/backend/internal/service/repository/interfaces.go
@@ -31,6 +31,8 @@ type RepositoryServiceInterface interface {
 	ListBranches(ctx context.Context, repoID int64, accessToken string) ([]string, error)
 	// SyncFromProvider syncs repository info from git provider
 	SyncFromProvider(ctx context.Context, repoID int64, accessToken string) (*gitprovider.Repository, error)
+	// GetByFullPath returns a repository by org, provider, and full path
+	GetByFullPath(ctx context.Context, orgID int64, providerType, providerBaseURL, fullPath string) (*gitprovider.Repository, error)
 	// ListMergeRequests lists merge requests for a repository
 	ListMergeRequests(ctx context.Context, repoID int64, branch, state string) ([]*MergeRequestInfo, error)
 }

--- a/backend/internal/service/repository/service.go
+++ b/backend/internal/service/repository/service.go
@@ -60,15 +60,40 @@ type CreateRequest struct {
 	ImportedByUserID *int64 // User who imported this repo
 }
 
-// Create creates a new repository configuration
+// Create creates a new repository configuration.
+// If the same repository already exists, it updates provider metadata
+// (idempotent import) so that re-importing after a provider reconnect
+// does not fail.
 func (s *Service) Create(ctx context.Context, req *CreateRequest) (*gitprovider.Repository, error) {
 	// Check if repository already exists (unique: org + provider_type + provider_base_url + full_path)
 	existing, err := s.repo.FindByOrgAndPath(ctx, req.OrganizationID, req.ProviderType, req.ProviderBaseURL, req.FullPath)
 	if err != nil {
 		return nil, err
 	}
+
+	// Idempotent import: update provider-sourced metadata, preserve user-configured fields
 	if existing != nil {
-		return nil, ErrRepositoryExists
+		updates := map[string]interface{}{
+			"name":        req.Name,
+			"external_id": req.ExternalID,
+			"is_active":   true,
+		}
+		if req.DefaultBranch != "" {
+			updates["default_branch"] = req.DefaultBranch
+		}
+		if req.ImportedByUserID != nil {
+			updates["imported_by_user_id"] = *req.ImportedByUserID
+		}
+		if req.CloneURL != "" {
+			updates["clone_url"] = req.CloneURL
+		}
+		if req.HttpCloneURL != "" {
+			updates["http_clone_url"] = req.HttpCloneURL
+		}
+		if req.SshCloneURL != "" {
+			updates["ssh_clone_url"] = req.SshCloneURL
+		}
+		return s.Update(ctx, existing.ID, updates)
 	}
 
 	repo := &gitprovider.Repository{

--- a/backend/internal/service/repository/service_crud_test.go
+++ b/backend/internal/service/repository/service_crud_test.go
@@ -37,7 +37,7 @@ func TestCreate(t *testing.T) {
 	}
 }
 
-func TestCreateDuplicate(t *testing.T) {
+func TestCreateDuplicateIsIdempotent(t *testing.T) {
 	db := setupTestDB(t)
 	service := NewService(infra.NewGitProviderRepository(db))
 	ctx := context.Background()
@@ -52,12 +52,22 @@ func TestCreateDuplicate(t *testing.T) {
 		FullPath:        "org/test-repo",
 		Visibility:      "organization",
 	}
-	service.Create(ctx, req)
+	original, err := service.Create(ctx, req)
+	if err != nil {
+		t.Fatalf("failed to create repository: %v", err)
+	}
 
-	// Try to create duplicate
-	_, err := service.Create(ctx, req)
-	if err != ErrRepositoryExists {
-		t.Errorf("expected ErrRepositoryExists, got %v", err)
+	// Re-import with updated name should upsert, not error
+	req.Name = "renamed-repo"
+	updated, err := service.Create(ctx, req)
+	if err != nil {
+		t.Fatalf("expected idempotent import to succeed, got: %v", err)
+	}
+	if updated.ID != original.ID {
+		t.Errorf("expected same ID %d, got %d", original.ID, updated.ID)
+	}
+	if updated.Name != "renamed-repo" {
+		t.Errorf("expected name 'renamed-repo', got %s", updated.Name)
 	}
 }
 


### PR DESCRIPTION
Previously, re-importing an existing active repository returned ErrRepositoryExists (409 Conflict). This broke the disconnect → reconnect → re-import flow, since deleting a GitHub connection does not soft-delete repos.

Change Create() to upsert: when a repo already exists, update provider-sourced metadata (name, external_id, default_branch, clone URLs, imported_by_user_id) while preserving user-configured fields (ticket_prefix, visibility, webhook_config).

Also fix a quota bug: skip billing quota check for re-imports since no new row is created.

## Summary

- What changed?
- Why was this change needed?

## Changes

- 

## Validation

- [ ] Backend tests (`cd backend && go test ./...`)
- [ ] Web checks (`cd web && pnpm run lint && pnpm run type-check && pnpm run test:coverage`)
- [ ] Runner checks (`cd runner && go test ./...`)
- [ ] Manual validation performed (if applicable)

## Documentation

- [ ] Docs updated (README/docs/inline comments)
- [ ] No docs changes needed

## Risk and Rollback

- Risk level: Low / Medium / High
- Rollback plan:
