### PR TITLE
fix(backend): move .mcp.json to plugin directory to avoid overwriting repo config

### DIFF
--- a/backend/internal/service/agent/builder_claude_code.go
+++ b/backend/internal/service/agent/builder_claude_code.go
@@ -120,13 +120,16 @@ func (b *ClaudeCodeBuilder) BuildFilesToCreate(ctx *BuildContext) ([]*runnerv1.F
 	}
 
 	// .mcp.json — merged MCP server configuration
+	// Placed in the plugin directory (not work_dir) to avoid overwriting
+	// any existing .mcp.json in the repository. Claude Code's --plugin-dir
+	// mechanism automatically loads .mcp.json from the plugin root.
 	mcpConfig := b.buildMcpConfig(ctx)
 	mcpJSON, err := json.MarshalIndent(mcpConfig, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal MCP config: %w", err)
 	}
 	files = append(files, &runnerv1.FileToCreate{
-		Path:    "{{.sandbox.work_dir}}/.mcp.json",
+		Path:    pluginDir + "/.mcp.json",
 		Content: string(mcpJSON),
 		Mode:    0644,
 	})

--- a/backend/internal/service/agent/config_builder_extension_test.go
+++ b/backend/internal/service/agent/config_builder_extension_test.go
@@ -374,6 +374,11 @@ func TestClaudeCodeBuilder_BuildFilesToCreate(t *testing.T) {
 				foundPluginJSON = true
 			case strings.HasSuffix(f.Path, ".mcp.json"):
 				foundMcpJSON = true
+				// .mcp.json must be inside the plugin directory, not in work_dir,
+				// to avoid overwriting existing .mcp.json in the repository.
+				if !strings.Contains(f.Path, "agentsmesh-plugin/") {
+					t.Errorf(".mcp.json should be inside agentsmesh-plugin/, got path: %s", f.Path)
+				}
 			case f.IsDirectory && strings.HasSuffix(f.Path, "/skills"):
 				foundSkillsDir = true
 			}


### PR DESCRIPTION
## Summary

- Move platform's `.mcp.json` from `{{.sandbox.work_dir}}/.mcp.json` (worktree root) to `agentsmesh-plugin/.mcp.json` (plugin directory)
- Prevents overwriting existing `.mcp.json` in user repositories when creating pods
- Claude Code's `--plugin-dir` mechanism automatically loads `.mcp.json` from the plugin root

## Root Cause

`builder_claude_code.go` was writing the platform MCP config directly to the worktree root, overwriting any repo-level `.mcp.json` (e.g., project-specific MCP server configurations).

## Test plan

- [x] Existing `TestClaudeCodeBuilder_BuildFilesToCreate` passes with added assertion that `.mcp.json` is inside `agentsmesh-plugin/`
- [x] Full `./internal/service/agent/...` test suite passes