### PR TITLE
chore: migrate minio Docker image from minio/minio to pgsty/minio

### DIFF
--- a/ci/build-onpremise.sh
+++ b/ci/build-onpremise.sh
@@ -93,7 +93,7 @@ echo "  Done."
 echo "[5/8] Pulling base images..."
 docker pull postgres:16-alpine
 docker pull redis:7-alpine
-docker pull minio/minio:latest
+docker pull pgsty/minio:latest
 docker pull traefik:v3.2
 echo "  Done."
 
@@ -111,7 +111,7 @@ echo "  Done."
 echo "[7/8] Exporting base images..."
 docker save postgres:16-alpine -o "${IMAGES_DIR}/postgres.tar"
 docker save redis:7-alpine -o "${IMAGES_DIR}/redis.tar"
-docker save minio/minio:latest -o "${IMAGES_DIR}/minio.tar"
+docker save pgsty/minio:latest -o "${IMAGES_DIR}/minio.tar"
 docker save traefik:v3.2 -o "${IMAGES_DIR}/traefik.tar"
 echo "  Done."
 

--- a/deploy/dev/docker-compose.yml
+++ b/deploy/dev/docker-compose.yml
@@ -49,7 +49,7 @@ services:
 
   # MinIO object storage (S3 compatible)
   minio:
-    image: minio/minio:latest
+    image: pgsty/minio:latest
     restart: unless-stopped
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}

--- a/deploy/onpremise/docker-compose.yml
+++ b/deploy/onpremise/docker-compose.yml
@@ -55,7 +55,7 @@ services:
   # MinIO Object Storage (S3 Compatible)
   # ===========================================================================
   minio:
-    image: minio/minio:latest
+    image: pgsty/minio:latest
     restart: unless-stopped
     environment:
       MINIO_ROOT_USER: minioadmin

--- a/deploy/selfhost/docker-compose.yml
+++ b/deploy/selfhost/docker-compose.yml
@@ -51,7 +51,7 @@ services:
   # MinIO Object Storage (S3 Compatible)
   # ===========================================================================
   minio:
-    image: minio/minio:latest
+    image: pgsty/minio:latest
     restart: unless-stopped
     environment:
       MINIO_ROOT_USER: minioadmin


### PR DESCRIPTION
## Summary

Migrate the MinIO Docker image from `minio/minio:latest` to `pgsty/minio:latest` ([Docker Hub](https://hub.docker.com/r/pgsty/minio)).

## Changes

- `deploy/dev/docker-compose.yml` - updated minio service image
- `deploy/onpremise/docker-compose.yml` - updated minio service image
- `deploy/selfhost/docker-compose.yml` - updated minio service image
- `ci/build-onpremise.sh` - updated docker pull and docker save commands