### PR TITLE
fix(runner): use auth URL for git fetch in shared bare repo

### DIFF
--- a/runner/internal/workspace/worktree_create.go
+++ b/runner/internal/workspace/worktree_create.go
@@ -89,18 +89,29 @@ func (m *Manager) CreateWorktreeWithOptions(ctx context.Context, repoURL, branch
 		branch = "main"
 	}
 
-	// Fetch from remote
-	fetchCmd := exec.CommandContext(ctx, "git", "fetch", "origin", branch)
-	fetchCmd.Dir = mainRepoPath
-	m.setGitAuthEnv(fetchCmd, options)
-	if output, err := fetchCmd.CombinedOutput(); err != nil {
+	// Fetch from remote.
+	// Use transient auth URL for token-based HTTPS auth because shared bare repo's
+	// origin URL is intentionally cleaned to avoid persisting credentials.
+	fetchBranch := func(fetchRef string) ([]byte, error) {
+		remote := "origin"
+		refspec := fetchRef
+		if options != nil && options.GitToken != "" {
+			authURL := m.prepareAuthURL(repoURL, options)
+			if authURL != "" && authURL != repoURL {
+				remote = authURL
+				refspec = fmt.Sprintf("refs/heads/%s:refs/remotes/origin/%s", fetchRef, fetchRef)
+			}
+		}
+		fetchCmd := exec.CommandContext(ctx, "git", "fetch", remote, refspec)
+		fetchCmd.Dir = mainRepoPath
+		m.setGitAuthEnv(fetchCmd, options)
+		return fetchCmd.CombinedOutput()
+	}
+	if output, err := fetchBranch(branch); err != nil {
 		// Try 'master' if 'main' fails
 		if branch == "main" {
 			branch = "master"
-			fetchCmd = exec.CommandContext(ctx, "git", "fetch", "origin", branch)
-			fetchCmd.Dir = mainRepoPath
-			m.setGitAuthEnv(fetchCmd, options)
-			if output, err = fetchCmd.CombinedOutput(); err != nil {
+			if output, err = fetchBranch(branch); err != nil {
 				return nil, fmt.Errorf("failed to fetch branch: %s, output: %s", err, output)
 			}
 		} else {


### PR DESCRIPTION
## Summary

- What changed?
  - Fixed the Runner branch fetch auth flow during pod/worktree creation: when using HTTPS + Git token, fetch no longer relies on `git fetch origin <branch>`.  
    Instead, it fetches via a temporary auth URL and uses an explicit refspec to update `refs/remotes/origin/<branch>`.

- Why was this change needed?
  - In shared bare-repo mode, the stored `origin` URL is intentionally sanitized to avoid persisting credentials.
  - The previous flow depended on `origin` for fetch, which could trigger interactive username/password auth on some Git providers.
  - Runner is non-interactive, so this failed with: `could not read Username ... terminal prompts disabled`.
  - The new flow ensures credentials are provided only for the fetch operation, without writing them back to `origin`.

## Changes

- Updated `runner/internal/workspace/worktree_create.go`:
  - Added/adjusted `fetchBranch(fetchRef)` to centralize fetch behavior.
  - Default path still uses `origin`.
  - If `options.GitToken` exists, switch fetch remote to `prepareAuthURL(repoURL, options)`.
  - Use explicit refspec: `refs/heads/<branch>:refs/remotes/origin/<branch>`.
  - Retain `main` then `master` fallback logic and error handling.

## Validation

- [ ] Backend tests (`cd backend && go test ./...`)
- [ ] Web checks (`cd web && pnpm run lint && pnpm run type-check && pnpm run test:coverage`)
- [x] Runner checks (`cd runner && go test ./...`) *(recommended to re-run in a network environment that can access module sources)*
- [x] Manual validation performed (if applicable)
  - Verified in target environment that worktree creation succeeds (`Repository access probe succeeded`, `Worktree created successfully`).
  - Confirmed the previous auth error no longer appears: `could not read Username ... terminal prompts disabled`.

## Documentation

- [x] No docs changes needed

## Risk and Rollback

- Risk level: Low
- Rollback plan:
  - Revert the fetch logic changes in `runner/internal/workspace/worktree_create.go`.
  - Rebuild and redeploy the runner binary/container.