### PR TITLE
fix(ci): use ECR Public mirror to avoid Docker Hub rate limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ env:
   GO_VERSION: "1.25"
   NODE_VERSION: "20"
   PNPM_VERSION: "9"
+  REGISTRY_PREFIX: "public.ecr.aws/docker/library/"
 
 jobs:
   # ===========================================================================
@@ -332,5 +333,6 @@ jobs:
           push: false
           build-args: |
             GO_VERSION=${{ env.GO_VERSION }}
+            REGISTRY_PREFIX=${{ env.REGISTRY_PREFIX }}
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 env:
   DOCKERHUB_NAMESPACE: agentsmesh
   GO_VERSION: "1.25"
+  REGISTRY_PREFIX: "public.ecr.aws/docker/library/"
 
 jobs:
   # ===========================================================================
@@ -70,6 +71,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             GO_VERSION=${{ env.GO_VERSION }}
+            REGISTRY_PREFIX=${{ env.REGISTRY_PREFIX }}
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Summary
- Pass `REGISTRY_PREFIX=public.ecr.aws/docker/library/` to Docker builds in GitHub Actions
- Avoids 429 Too Many Requests from Docker Hub when multiple CI jobs run concurrently
- CI Dockerfiles already support `${REGISTRY_PREFIX}` ARG, just needed to wire it up

## Test plan
- [ ] Verify `docker-build-verify` jobs pass (pulling from `public.ecr.aws` instead of `docker.io`)