### PR TITLE
fix(ci): use ECR Public only for Go services, keep Docker Hub for Node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,18 +307,23 @@ jobs:
           - service: backend
             dockerfile: ci/backend.Dockerfile
             context: .
+            use_ecr: true
           - service: web
             dockerfile: ci/web.Dockerfile
             context: ./web
+            use_ecr: false
           - service: web-admin
             dockerfile: ci/web-admin.Dockerfile
             context: ./web-admin
+            use_ecr: false
           - service: runner
             dockerfile: ci/runner.Dockerfile
             context: .
+            use_ecr: true
           - service: relay
             dockerfile: ci/relay.Dockerfile
             context: .
+            use_ecr: true
     steps:
       - uses: actions/checkout@v6
 
@@ -333,6 +338,6 @@ jobs:
           push: false
           build-args: |
             GO_VERSION=${{ env.GO_VERSION }}
-            REGISTRY_PREFIX=${{ env.REGISTRY_PREFIX }}
+            REGISTRY_PREFIX=${{ matrix.use_ecr && env.REGISTRY_PREFIX || '' }}
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,15 +28,19 @@ jobs:
           - service: backend
             dockerfile: ci/backend.Dockerfile
             context: .
+            use_ecr: true
           - service: web
             dockerfile: ci/web.Dockerfile
             context: ./web
+            use_ecr: false
           - service: web-admin
             dockerfile: ci/web-admin.Dockerfile
             context: ./web-admin
+            use_ecr: false
           - service: relay
             dockerfile: ci/relay.Dockerfile
             context: .
+            use_ecr: true
     steps:
       - uses: actions/checkout@v6
 
@@ -71,7 +75,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             GO_VERSION=${{ env.GO_VERSION }}
-            REGISTRY_PREFIX=${{ env.REGISTRY_PREFIX }}
+            REGISTRY_PREFIX=${{ matrix.use_ecr && env.REGISTRY_PREFIX || '' }}
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Summary
- ECR Public + QEMU arm64 emulation for Node.js builds causes 1h+ build times
- Only apply `REGISTRY_PREFIX` (ECR Public) to Go services: backend, relay, runner
- Node services (web, web-admin) keep using Docker Hub where builds are faster

Fixes the web-admin build timeout in v0.10.16 release.

## Test plan
- [ ] Verify all `docker-build-verify` jobs pass
- [ ] After merge, re-tag and verify release workflow completes normally