### PR TITLE
feat(runner): add daemon process stability monitoring

### DIFF
--- a/runner/cmd/runner/main.go
+++ b/runner/cmd/runner/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
 
 	"github.com/anthropics/agentsmesh/runner/internal/poddaemon"
 )
@@ -18,6 +19,14 @@ func main() {
 	// main loop instead of the normal CLI. The daemon holds the PTY fd and
 	// accepts IPC connections from the Runner for I/O forwarding.
 	if configPath := os.Getenv("_AGENTSMESH_POD_DAEMON"); configPath != "" {
+		defer func() {
+			if r := recover(); r != nil {
+				// stderr is redirected to pod_daemon.log by startDaemon,
+				// so this panic trace will be captured for diagnostics.
+				fmt.Fprintf(os.Stderr, "FATAL: pod daemon panic: %v\n%s\n", r, debug.Stack())
+				os.Exit(2)
+			}
+		}()
 		poddaemon.RunDaemon(configPath)
 		return
 	}

--- a/runner/internal/poddaemon/daemon.go
+++ b/runner/internal/poddaemon/daemon.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/anthropics/agentsmesh/runner/internal/envfilter"
+	"github.com/anthropics/agentsmesh/runner/internal/safego"
 )
 
 // RunDaemon is the main entry point for the daemon process.
@@ -19,6 +20,11 @@ import (
 func RunDaemon(configPath string) {
 	log := slog.Default()
 	log.Info("pod daemon starting", "config", configPath)
+
+	// Test-only: deliberate panic to verify the main.go panic recovery captures stack traces.
+	if msg := os.Getenv("_AGENTSMESH_DAEMON_TEST_PANIC"); msg != "" {
+		panic(msg)
+	}
 
 	// configPath is the full path; LoadState expects the sandbox directory
 	sandboxPath := filepath.Dir(configPath)
@@ -77,7 +83,7 @@ func RunDaemon(configPath string) {
 	}
 
 	// Wait for child process exit in background
-	go func() {
+	safego.Go("daemon-proc-wait", func() {
 		code, err := proc.Wait()
 		if err != nil {
 			log.Error("process wait error", "error", err)
@@ -85,7 +91,7 @@ func RunDaemon(configPath string) {
 		log.Info("child process exited", "exit_code", code)
 		d.exitCode = code
 		close(d.exitDone) // broadcast to all listeners
-	}()
+	})
 
 	d.run()
 }
@@ -117,14 +123,14 @@ type daemonServer struct {
 }
 
 func (d *daemonServer) run() {
-	// PTY reader goroutine: reads from PTY and forwards to current client
-	go d.ptyReader()
+	// PTY reader: must keep running, auto-restart on panic (otherwise terminal freezes)
+	safego.GoLoop("daemon-pty-reader", d.ptyReader, 0)
 
-	// Accept connections until child exits
-	go d.acceptLoop()
+	// Accept loop: must keep running, auto-restart on panic (otherwise Runner can't reconnect)
+	safego.GoLoop("daemon-accept-loop", d.acceptLoop, 0)
 
-	// Orphan protection: exit if state file is deleted (Runner cleanup)
-	go d.orphanChecker()
+	// Orphan protection: must keep running, auto-restart on panic (otherwise daemon leaks)
+	safego.GoLoop("daemon-orphan-checker", d.orphanChecker, 0)
 
 	// Wait for child exit or orphan signal
 	select {

--- a/runner/internal/poddaemon/daemon_io.go
+++ b/runner/internal/poddaemon/daemon_io.go
@@ -4,6 +4,8 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"net"
+
+	"github.com/anthropics/agentsmesh/runner/internal/safego"
 )
 
 // acceptLoop accepts IPC connections and handles them in goroutines.
@@ -15,7 +17,7 @@ func (d *daemonServer) acceptLoop() {
 			d.log.Debug("accept error (listener closed?)", "error", err)
 			return
 		}
-		go d.handleClient(conn)
+		safego.Go("daemon-handle-client", func() { d.handleClient(conn) })
 	}
 }
 

--- a/runner/internal/poddaemon/manager.go
+++ b/runner/internal/poddaemon/manager.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/anthropics/agentsmesh/runner/internal/process"
 )
 
 // PodDaemonManager manages the lifecycle of pod daemon sessions.
@@ -101,19 +103,23 @@ func (m *PodDaemonManager) CreateSession(opts CreateOpts) (*daemonPTY, *PodDaemo
 	log.Info("daemon started, waiting for IPC", "pid", pid, "ipc", ipcPath)
 
 	// Wait for daemon to start listening on IPC
-	dpty, err := m.waitForDaemon(ipcPath)
+	dpty, err := m.waitForDaemon(ipcPath, pid)
 	if err != nil {
+		status := daemonProcessStatus(pid)
+		log.Error("daemon failed to become ready",
+			"pod_key", opts.PodKey, "pid", pid, "process_status", status, "error", err)
 		captureDaemonLog(log, opts.SandboxPath, opts.PodKey)
 		_ = os.Remove(ipcPath) // Clean up socket file if daemon died before Listen()
 		_ = DeleteState(opts.SandboxPath)
-		return nil, nil, fmt.Errorf("connect to daemon: %w", err)
+		return nil, nil, fmt.Errorf("connect to daemon (pid %d, %s): %w", pid, status, err)
 	}
 
 	return dpty, state, nil
 }
 
 // waitForDaemon polls the IPC path until the daemon is ready.
-func (m *PodDaemonManager) waitForDaemon(ipcPath string) (*daemonPTY, error) {
+// It also checks if the daemon process is still alive to fail fast.
+func (m *PodDaemonManager) waitForDaemon(ipcPath string, pid int) (*daemonPTY, error) {
 	const maxAttempts = 50
 	const retryDelay = 100 * time.Millisecond
 
@@ -124,6 +130,12 @@ func (m *PodDaemonManager) waitForDaemon(ipcPath string) (*daemonPTY, error) {
 			return dpty, nil
 		}
 		lastErr = err
+
+		// Fail fast if daemon process is no longer alive
+		if pid > 0 && process.IsAlive(pid) != nil {
+			return nil, fmt.Errorf("daemon process (pid %d) exited before IPC ready: %w", pid, lastErr)
+		}
+
 		time.Sleep(retryDelay)
 	}
 	return nil, fmt.Errorf("daemon did not become ready within %v: %w", time.Duration(maxAttempts)*retryDelay, lastErr)
@@ -173,8 +185,16 @@ const daemonLogFile = "pod_daemon.log"
 // captureDaemonLog reads the daemon log and outputs to runner log for diagnostics.
 // Called when daemon fails to become ready, before sandbox cleanup destroys the log.
 func captureDaemonLog(log *slog.Logger, sandboxPath, podKey string) {
-	data, err := os.ReadFile(filepath.Join(sandboxPath, daemonLogFile))
-	if err != nil || len(data) == 0 {
+	logPath := filepath.Join(sandboxPath, daemonLogFile)
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		log.Error("pod daemon log unavailable",
+			"pod_key", podKey, "path", logPath, "error", err)
+		return
+	}
+	if len(data) == 0 {
+		log.Error("pod daemon log is empty (daemon likely crashed before any Go code executed)",
+			"pod_key", podKey, "path", logPath)
 		return
 	}
 	const maxLen = 2048
@@ -183,4 +203,15 @@ func captureDaemonLog(log *slog.Logger, sandboxPath, podKey string) {
 	}
 	log.Error("pod daemon log (process exited before IPC ready)",
 		"pod_key", podKey, "log", strings.TrimSpace(string(data)))
+}
+
+// daemonProcessStatus returns a human-readable status of the daemon process.
+func daemonProcessStatus(pid int) string {
+	if pid <= 0 {
+		return "unknown"
+	}
+	if process.IsAlive(pid) == nil {
+		return "alive"
+	}
+	return "dead"
 }

--- a/runner/internal/poddaemon/manager_test.go
+++ b/runner/internal/poddaemon/manager_test.go
@@ -2,6 +2,7 @@ package poddaemon
 
 import (
 	"encoding/json"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -240,8 +241,6 @@ func TestCleanupSessionNonExistent(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// TestRecoverSessionsMixedValidity verifies RecoverSessions handles a mix
-// of valid, corrupt, missing, and empty state files plus non-directory entries.
 func TestRecoverSessionsMixedValidity(t *testing.T) {
 	dir := t.TempDir()
 	socketDir := t.TempDir()
@@ -284,4 +283,75 @@ func TestRecoverSessionsMixedValidity(t *testing.T) {
 	}
 	assert.True(t, keys["pod-1"])
 	assert.True(t, keys["pod-2"])
+}
+
+func TestWaitForDaemonFailsFastOnDeadProcess(t *testing.T) {
+	socketDir := t.TempDir()
+	dir := t.TempDir()
+	mgr, err := NewPodDaemonManager(dir, socketDir)
+	require.NoError(t, err)
+
+	ipcPath := IPCPath(socketDir, "dead-daemon")
+
+	// Use a PID that definitely doesn't exist (max PID)
+	deadPID := 999999999
+
+	start := time.Now()
+	_, err = mgr.waitForDaemon(ipcPath, deadPID)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exited before IPC ready")
+	// Should fail much faster than the full 5s timeout
+	assert.Less(t, elapsed, 3*time.Second, "should fail fast when daemon is dead")
+}
+
+func TestWaitForDaemonZeroPIDSkipsAliveCheck(t *testing.T) {
+	socketDir := t.TempDir()
+	dir := t.TempDir()
+	mgr, err := NewPodDaemonManager(dir, socketDir)
+	require.NoError(t, err)
+
+	ipcPath := IPCPath(socketDir, "no-pid")
+
+	start := time.Now()
+	_, err = mgr.waitForDaemon(ipcPath, 0)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "did not become ready")
+	// With pid=0, alive check is skipped so it waits the full timeout
+	assert.GreaterOrEqual(t, elapsed, 4*time.Second)
+}
+
+func TestCaptureDaemonLogEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, daemonLogFile)
+	require.NoError(t, os.WriteFile(logPath, []byte{}, 0644))
+
+	// Should log "empty" diagnostic without panic
+	captureDaemonLog(slog.Default(), dir, "test-pod")
+}
+
+func TestCaptureDaemonLogMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	// No log file — should log "unavailable" diagnostic without panic
+	captureDaemonLog(slog.Default(), dir, "test-pod")
+}
+
+func TestCaptureDaemonLogWithContent(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, daemonLogFile)
+	content := "FATAL: pod daemon panic: runtime error: nil pointer\ngoroutine 1 [running]:\nmain.main()\n"
+	require.NoError(t, os.WriteFile(logPath, []byte(content), 0644))
+
+	// Should capture and log content without panic
+	captureDaemonLog(slog.Default(), dir, "test-pod")
+}
+
+func TestDaemonProcessStatus(t *testing.T) {
+	assert.Equal(t, "unknown", daemonProcessStatus(0))
+	assert.Equal(t, "unknown", daemonProcessStatus(-1))
+	assert.Equal(t, "alive", daemonProcessStatus(os.Getpid()))
+	assert.Equal(t, "dead", daemonProcessStatus(999999999))
 }

--- a/runner/internal/poddaemon/poddaemon_integration_test.go
+++ b/runner/internal/poddaemon/poddaemon_integration_test.go
@@ -5,6 +5,7 @@ package poddaemon
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -23,7 +24,7 @@ func TestCreateSessionAndIO(t *testing.T) {
 	workspace, sandbox := shortWorkspace(t, "io")
 
 	mgr := &PodDaemonManager{
-		workspaceRoot: workspace,
+		sandboxesDir: workspace,
 		socketDir:     workspace, // use workspace as socket dir in tests
 		runnerBinPath: binPath,
 	}
@@ -105,7 +106,7 @@ func TestCreateSessionExitCode(t *testing.T) {
 	workspace, sandbox := shortWorkspace(t, "ex")
 
 	mgr := &PodDaemonManager{
-		workspaceRoot: workspace,
+		sandboxesDir: workspace,
 		socketDir:     workspace,
 		runnerBinPath: binPath,
 	}
@@ -144,7 +145,7 @@ func TestCreateSessionGracefulStop(t *testing.T) {
 	workspace, sandbox := shortWorkspace(t, "gs")
 
 	mgr := &PodDaemonManager{
-		workspaceRoot: workspace,
+		sandboxesDir: workspace,
 		socketDir:     workspace,
 		runnerBinPath: binPath,
 	}
@@ -186,7 +187,7 @@ func TestRecoverSessionsIntegration(t *testing.T) {
 	workspace, sandbox := shortWorkspace(t, "rc")
 
 	mgr := &PodDaemonManager{
-		workspaceRoot: workspace,
+		sandboxesDir: workspace,
 		socketDir:     workspace,
 		runnerBinPath: binPath,
 	}
@@ -380,7 +381,7 @@ func TestWaitForDaemonRetry(t *testing.T) {
 	ipcPath := IPCPath(socketDir, "w")
 
 	mgr := &PodDaemonManager{
-		workspaceRoot: t.TempDir(),
+		sandboxesDir: t.TempDir(),
 		socketDir:     socketDir,
 		runnerBinPath: "unused",
 	}
@@ -408,7 +409,7 @@ func TestWaitForDaemonRetry(t *testing.T) {
 		time.Sleep(2 * time.Second)
 	}()
 
-	dpty, err := mgr.waitForDaemon(ipcPath)
+	dpty, err := mgr.waitForDaemon(ipcPath, 0)
 	require.NoError(t, err)
 	defer dpty.Close()
 	assert.Equal(t, 999, dpty.Pid())
@@ -421,12 +422,64 @@ func TestWaitForDaemonTimeout(t *testing.T) {
 	}
 
 	mgr := &PodDaemonManager{
-		workspaceRoot: t.TempDir(),
+		sandboxesDir: t.TempDir(),
 		socketDir:     t.TempDir(),
 		runnerBinPath: "unused",
 	}
 
-	_, err := mgr.waitForDaemon("/nonexistent/socket.sock")
+	_, err := mgr.waitForDaemon("/nonexistent/socket.sock", 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "did not become ready")
+}
+
+// TestDaemonPanicRecoveryWritesStackTrace verifies that when the daemon process
+// panics, the main.go defer recover captures the stack trace into pod_daemon.log.
+// This is the top-level safety net for daemon crash diagnostics.
+func TestDaemonPanicRecoveryWritesStackTrace(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	binPath := buildTestRunner(t)
+
+	sandbox, err := os.MkdirTemp("/tmp", "pd-panic-")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(sandbox) })
+
+	// Create a minimal valid state file (daemon needs it to get past LoadState)
+	state := &PodDaemonState{
+		PodKey:      "panic-test",
+		IPCPath:     IPCPath(sandbox, "panic-test"),
+		SandboxPath: sandbox,
+		WorkDir:     sandbox,
+		Command:     "echo",
+		Args:        []string{"should-not-reach"},
+		Cols:        80,
+		Rows:        24,
+	}
+	require.NoError(t, SaveState(state))
+
+	// Start daemon with _AGENTSMESH_DAEMON_TEST_PANIC to trigger deliberate panic.
+	// startDaemon passes env vars to the daemon subprocess.
+	panicMsg := "deliberate test panic for stack trace verification"
+	env := append(os.Environ(), "_AGENTSMESH_DAEMON_TEST_PANIC="+panicMsg)
+
+	pid, err := startDaemon(binPath, StatePath(sandbox), sandbox, env)
+	require.NoError(t, err)
+	t.Logf("daemon started with PID %d (will panic)", pid)
+
+	// Wait for daemon to crash and write its log
+	time.Sleep(2 * time.Second)
+
+	// Read pod_daemon.log — should contain the panic stack trace
+	logPath := filepath.Join(sandbox, "pod_daemon.log")
+	data, err := os.ReadFile(logPath)
+	require.NoError(t, err, "pod_daemon.log should exist")
+
+	logContent := string(data)
+	t.Logf("pod_daemon.log content:\n%s", logContent)
+
+	assert.Contains(t, logContent, "FATAL: pod daemon panic")
+	assert.Contains(t, logContent, panicMsg)
+	assert.Contains(t, logContent, "goroutine") // stack trace should be present
 }

--- a/runner/internal/poddaemon/poddaemon_recovery_unix_test.go
+++ b/runner/internal/poddaemon/poddaemon_recovery_unix_test.go
@@ -49,7 +49,7 @@ func TestDaemonSurvivesParentDeath(t *testing.T) {
 	workspace, sandbox := shortWorkspace(t, "survive")
 
 	mgr := &PodDaemonManager{
-		workspaceRoot: workspace,
+		sandboxesDir: workspace,
 		socketDir:     workspace,
 		runnerBinPath: binPath,
 	}
@@ -109,7 +109,7 @@ func TestDaemonSurvivesParentDeath(t *testing.T) {
 
 	// Phase 4: Fresh manager recovers sessions (simulates Runner B starting)
 	mgr2 := &PodDaemonManager{
-		workspaceRoot: workspace,
+		sandboxesDir: workspace,
 		socketDir:     workspace,
 		runnerBinPath: binPath,
 	}
@@ -154,7 +154,7 @@ func TestDaemonSurvivesMultipleReattachCycles(t *testing.T) {
 	workspace, sandbox := shortWorkspace(t, "multi")
 
 	mgr := &PodDaemonManager{
-		workspaceRoot: workspace,
+		sandboxesDir: workspace,
 		socketDir:     workspace,
 		runnerBinPath: binPath,
 	}
@@ -231,7 +231,7 @@ func TestRecoveredSessionResize(t *testing.T) {
 	workspace, sandbox := shortWorkspace(t, "rsz")
 
 	mgr := &PodDaemonManager{
-		workspaceRoot: workspace,
+		sandboxesDir: workspace,
 		socketDir:     workspace,
 		runnerBinPath: binPath,
 	}
@@ -292,7 +292,7 @@ func TestRecoveredSessionGracefulStop(t *testing.T) {
 	workspace, sandbox := shortWorkspace(t, "gstop")
 
 	mgr := &PodDaemonManager{
-		workspaceRoot: workspace,
+		sandboxesDir: workspace,
 		socketDir:     workspace,
 		runnerBinPath: binPath,
 	}
@@ -353,7 +353,7 @@ func TestOrphanCleanupAfterRecovery(t *testing.T) {
 	workspace, sandbox := shortWorkspace(t, "orph")
 
 	mgr := &PodDaemonManager{
-		workspaceRoot: workspace,
+		sandboxesDir: workspace,
 		socketDir:     workspace,
 		runnerBinPath: binPath,
 	}

--- a/runner/internal/poddaemon/poddaemon_recovery_windows_test.go
+++ b/runner/internal/poddaemon/poddaemon_recovery_windows_test.go
@@ -28,7 +28,7 @@ func TestDaemonSurvivesParentDeathWindows(t *testing.T) {
 	workspace, sandbox := shortWorkspace(t, "survive")
 
 	mgr := &PodDaemonManager{
-		workspaceRoot: workspace,
+		sandboxesDir: workspace,
 		socketDir:     workspace,
 		runnerBinPath: binPath,
 	}
@@ -90,7 +90,7 @@ func TestDaemonSurvivesParentDeathWindows(t *testing.T) {
 
 	// Phase 4: Fresh manager recovers sessions
 	mgr2 := &PodDaemonManager{
-		workspaceRoot: workspace,
+		sandboxesDir: workspace,
 		socketDir:     workspace,
 		runnerBinPath: binPath,
 	}
@@ -139,7 +139,7 @@ func TestDaemonSurvivesMultipleReattachCyclesWindows(t *testing.T) {
 	workspace, sandbox := shortWorkspace(t, "multi")
 
 	mgr := &PodDaemonManager{
-		workspaceRoot: workspace,
+		sandboxesDir: workspace,
 		socketDir:     workspace,
 		runnerBinPath: binPath,
 	}
@@ -214,7 +214,7 @@ func TestRecoveredSessionResizeWindows(t *testing.T) {
 	workspace, sandbox := shortWorkspace(t, "rsz")
 
 	mgr := &PodDaemonManager{
-		workspaceRoot: workspace,
+		sandboxesDir: workspace,
 		socketDir:     workspace,
 		runnerBinPath: binPath,
 	}
@@ -273,7 +273,7 @@ func TestRecoveredSessionKillWindows(t *testing.T) {
 	workspace, sandbox := shortWorkspace(t, "kill")
 
 	mgr := &PodDaemonManager{
-		workspaceRoot: workspace,
+		sandboxesDir: workspace,
 		socketDir:     workspace,
 		runnerBinPath: binPath,
 	}


### PR DESCRIPTION
## Summary

- Pod daemon 子进程缺乏 runner 主进程已有的稳定性基建（safego、panic recovery），导致 daemon 崩溃时完全无法诊断（空日志、无堆栈）
- 将 runner 的分层稳定性模式移植到 daemon：进程级 panic recovery + goroutine 级 safego.GoLoop 自动重启
- 增强 Runner 侧对 daemon 死亡的快速检测和诊断信息

## Changes

- **main.go**: daemon 入口增加 `defer recover()` 捕获 panic 堆栈到 `pod_daemon.log`
- **daemon.go**: 关键 goroutine（ptyReader, acceptLoop, orphanChecker）使用 `safego.GoLoop` 实现 panic 后自动重启
- **daemon_io.go**: handleClient 使用 `safego.Go` 隔离 panic
- **manager.go**: `waitForDaemon` 增加进程存活检测快速失败；`captureDaemonLog` 不再静默（报告空日志/缺失文件）；失败路径增加 PID + 进程状态上下文
- **integration tests**: 修复已有的 `workspaceRoot` → `sandboxesDir` 字段名不匹配；新增 daemon panic recovery 集成测试

## Test plan

- [x] `go test ./internal/poddaemon/...` 单元测试全部通过
- [x] `go test -tags integration ./internal/poddaemon/... -run TestDaemonPanicRecoveryWritesStackTrace` 集成测试验证 panic 堆栈写入 pod_daemon.log
- [x] `go build ./...` 和 `go build -tags integration ./internal/poddaemon/...` 编译通过