### PR TITLE
fix: add timeout and observability for pods stuck in initializing (#145)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -321,6 +321,10 @@ func main() {
 	// Start scheduled jobs
 	subscriptionScheduler := startSubscriptionJobs(db, cfg, services.email, appLogger.Logger)
 
+	// Start pod init timeout checker (times out pods stuck in "initializing")
+	stopPodInitTimeout := startPodInitTimeoutChecker(services.pod)
+	defer stopPodInitTimeout()
+
 	// Start HTTP server
 	srv := startHTTPServer(cfg, router)
 

--- a/backend/cmd/server/server.go
+++ b/backend/cmd/server/server.go
@@ -52,6 +52,45 @@ func startSubscriptionJobs(db *gorm.DB, appConfig *config.Config, emailSvc email
 	return scheduler
 }
 
+// PodInitTimeoutChecker is an interface for timing out stuck initializing pods.
+type PodInitTimeoutChecker interface {
+	TimeoutInitializingPods(ctx context.Context, maxInitDuration time.Duration) (int64, error)
+}
+
+// startPodInitTimeoutChecker starts a background goroutine that periodically
+// checks for pods stuck in "initializing" state and marks them as "error".
+func startPodInitTimeoutChecker(checker PodInitTimeoutChecker) (stop func()) {
+	stopCh := make(chan struct{})
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(1 * time.Minute)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-stopCh:
+				return
+			case <-ticker.C:
+				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				count, err := checker.TimeoutInitializingPods(ctx, 5*time.Minute)
+				cancel()
+				if err != nil {
+					slog.Error("pod init timeout check failed", "error", err)
+				} else if count > 0 {
+					slog.Info("timed out initializing pods", "count", count)
+				}
+			}
+		}
+	}()
+
+	return func() {
+		close(stopCh)
+		<-done
+	}
+}
+
 // LoopSchedulerStopper is an interface for stopping the loop scheduler
 type LoopSchedulerStopper interface {
 	Stop()

--- a/backend/internal/domain/agentpod/repository.go
+++ b/backend/internal/domain/agentpod/repository.go
@@ -55,6 +55,9 @@ type PodRepository interface {
 	MarkStaleAsDisconnected(ctx context.Context, threshold time.Time) (int64, error)
 	// CleanupStale marks stale disconnected pods as terminated. Returns rows affected.
 	CleanupStale(ctx context.Context, threshold time.Time) (int64, error)
+	// TimeoutInitializingPods marks pods stuck in "initializing" beyond the threshold as "error".
+	// Returns the timed-out pods so callers can publish events per organization.
+	TimeoutInitializingPods(ctx context.Context, createdBefore time.Time) ([]*Pod, error)
 	// UpdateByKeyAndStatusCounted is like UpdateByKeyAndStatus but returns rows affected.
 	UpdateByKeyAndStatusCounted(ctx context.Context, podKey, status string, updates map[string]interface{}) (int64, error)
 	// UpdateTerminatedWithFallbackError updates a terminated pod, setting error_code

--- a/backend/internal/infra/agentpod_repo.go
+++ b/backend/internal/infra/agentpod_repo.go
@@ -233,6 +233,36 @@ func (r *podRepo) CleanupStale(ctx context.Context, threshold time.Time) (int64,
 	return result.RowsAffected, result.Error
 }
 
+func (r *podRepo) TimeoutInitializingPods(ctx context.Context, createdBefore time.Time) ([]*agentpod.Pod, error) {
+	// Find pods stuck in initializing
+	var pods []*agentpod.Pod
+	if err := r.db.WithContext(ctx).
+		Where("status = ? AND created_at < ?", agentpod.StatusInitializing, createdBefore).
+		Find(&pods).Error; err != nil {
+		return nil, err
+	}
+	if len(pods) == 0 {
+		return nil, nil
+	}
+
+	// Mark them as error with a descriptive message
+	now := time.Now()
+	errorMsg := "Pod initialization timed out. The runner may be unreachable or the setup process (git clone, sandbox preparation) may have stalled."
+	result := r.db.WithContext(ctx).Model(&agentpod.Pod{}).
+		Where("status = ? AND created_at < ?", agentpod.StatusInitializing, createdBefore).
+		Updates(map[string]interface{}{
+			"status":        agentpod.StatusError,
+			"error_code":    "INIT_TIMEOUT",
+			"error_message": errorMsg,
+			"finished_at":   now,
+		})
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return pods, nil
+}
+
 func (r *podRepo) UpdateByKeyAndStatusCounted(ctx context.Context, podKey, status string, updates map[string]interface{}) (int64, error) {
 	result := r.db.WithContext(ctx).Model(&agentpod.Pod{}).
 		Where("pod_key = ? AND status = ?", podKey, status).

--- a/backend/internal/service/agentpod/event_publisher.go
+++ b/backend/internal/service/agentpod/event_publisher.go
@@ -21,6 +21,7 @@ const (
 // This allows the service to be decoupled from the eventbus implementation
 type EventPublisher interface {
 	PublishPodEvent(ctx context.Context, eventType PodEventType, orgID int64, podKey, status, previousStatus, agentStatus string)
+	PublishPodErrorEvent(ctx context.Context, orgID int64, podKey, previousStatus, errorCode, errorMessage string)
 }
 
 // EventBusPublisher implements EventPublisher using EventBus
@@ -85,5 +86,30 @@ func (p *EventBusPublisher) PublishPodEvent(ctx context.Context, eventType PodEv
 			"type", eventType,
 			"pod_key", podKey,
 		)
+	}
+}
+
+// PublishPodErrorEvent publishes a pod error event with error code and message.
+func (p *EventBusPublisher) PublishPodErrorEvent(ctx context.Context, orgID int64, podKey, previousStatus, errorCode, errorMessage string) {
+	if p.eventBus == nil {
+		return
+	}
+
+	data := &eventbus.PodStatusChangedData{
+		PodKey:         podKey,
+		Status:         "error",
+		PreviousStatus: previousStatus,
+		ErrorCode:      errorCode,
+		ErrorMessage:   errorMessage,
+	}
+
+	event, err := eventbus.NewEntityEvent(eventbus.EventPodStatusChanged, orgID, "pod", podKey, data)
+	if err != nil {
+		p.logger.Error("failed to create pod error event", "error", err, "pod_key", podKey)
+		return
+	}
+
+	if err := p.eventBus.Publish(ctx, event); err != nil {
+		p.logger.Error("failed to publish pod error event", "error", err, "pod_key", podKey)
 	}
 }

--- a/backend/internal/service/agentpod/pod_lifecycle.go
+++ b/backend/internal/service/agentpod/pod_lifecycle.go
@@ -121,3 +121,30 @@ func (s *PodService) CleanupStalePods(ctx context.Context, maxIdleHours int) (in
 	threshold := time.Now().Add(-time.Duration(maxIdleHours) * time.Hour)
 	return s.repo.CleanupStale(ctx, threshold)
 }
+
+// TimeoutInitializingPods marks pods stuck in "initializing" for longer than
+// the given duration as "error" and publishes status change events so the
+// frontend receives immediate feedback instead of spinning forever.
+func (s *PodService) TimeoutInitializingPods(ctx context.Context, maxInitDuration time.Duration) (int64, error) {
+	threshold := time.Now().Add(-maxInitDuration)
+	pods, err := s.repo.TimeoutInitializingPods(ctx, threshold)
+	if err != nil {
+		return 0, err
+	}
+
+	// Publish error events so WebSocket clients get notified with error details
+	if s.eventPublisher != nil {
+		for _, pod := range pods {
+			s.eventPublisher.PublishPodErrorEvent(
+				ctx,
+				pod.OrganizationID,
+				pod.PodKey,
+				agentpod.StatusInitializing,
+				"INIT_TIMEOUT",
+				"Pod initialization timed out. The runner may be unreachable or the setup process (git clone, sandbox preparation) may have stalled.",
+			)
+		}
+	}
+
+	return int64(len(pods)), nil
+}

--- a/backend/internal/service/tasks/manager.go
+++ b/backend/internal/service/tasks/manager.go
@@ -15,6 +15,11 @@ type StalePodCleaner interface {
 	MarkStaleAsDisconnected(ctx context.Context, threshold time.Time) (int64, error)
 }
 
+// InitTimeoutHandler times out pods stuck in initializing state.
+type InitTimeoutHandler interface {
+	TimeoutInitializingPods(ctx context.Context, maxInitDuration time.Duration) (int64, error)
+}
+
 // DefaultConfig returns default task manager configuration
 func DefaultConfig() Config {
 	return Config{
@@ -39,17 +44,23 @@ type Config struct {
 
 // Manager coordinates all background tasks
 type Manager struct {
-	podCleaner StalePodCleaner
-	redis      *redis.Client
-	logger     *slog.Logger
-	cfg        Config
-	scheduler  *infraTasks.Scheduler
-	workers    *infraTasks.WorkerPool
-	wg         sync.WaitGroup
+	podCleaner     StalePodCleaner
+	initTimeout    InitTimeoutHandler
+	redis          *redis.Client
+	logger         *slog.Logger
+	cfg            Config
+	scheduler      *infraTasks.Scheduler
+	workers        *infraTasks.WorkerPool
+	wg             sync.WaitGroup
 
 	// Services
 	pipelinePoller *PipelinePollerService
 	taskProcessor  *TaskProcessorService
+}
+
+// SetInitTimeoutHandler sets the handler for pod initialization timeout checks.
+func (m *Manager) SetInitTimeoutHandler(h InitTimeoutHandler) {
+	m.initTimeout = h
 }
 
 // NewManager creates a new task manager
@@ -160,6 +171,16 @@ func (m *Manager) registerScheduledTasks() {
 			return m.cleanupStalePods(ctx)
 		},
 	})
+
+	// Pod Init Timeout - times out pods stuck in "initializing" for too long
+	_ = m.scheduler.Register(&infraTasks.Task{
+		Name:       "pod_init_timeout",
+		Interval:   1 * time.Minute,
+		RunOnStart: false,
+		Func: func(ctx context.Context) error {
+			return m.timeoutInitializingPods(ctx)
+		},
+	})
 }
 
 // monitorWorkerResults monitors worker results for logging/metrics
@@ -191,6 +212,24 @@ func (m *Manager) cleanupStalePods(ctx context.Context) error {
 	if rowsAffected > 0 {
 		m.logger.Info("cleaned up stale pods",
 			"count", rowsAffected)
+	}
+
+	return nil
+}
+
+// timeoutInitializingPods marks pods stuck in "initializing" as "error"
+func (m *Manager) timeoutInitializingPods(ctx context.Context) error {
+	if m.initTimeout == nil {
+		return nil
+	}
+
+	count, err := m.initTimeout.TimeoutInitializingPods(ctx, 5*time.Minute)
+	if err != nil {
+		return err
+	}
+
+	if count > 0 {
+		m.logger.Info("timed out initializing pods", "count", count)
 	}
 
 	return nil

--- a/runner/internal/client/errors.go
+++ b/runner/internal/client/errors.go
@@ -16,6 +16,7 @@ const (
 	ErrCodeDiskFull        = "DISK_FULL"
 	ErrCodePrepareScript   = "PREPARE_SCRIPT_FAILED"
 	ErrCodePTYError        = "PTY_READ_ERROR"
+	ErrCodeResourceDownload = "RESOURCE_DOWNLOAD_FAILED"
 )
 
 // PodError represents an error that occurred during pod operations.

--- a/runner/internal/runner/pod_builder_setup.go
+++ b/runner/internal/runner/pod_builder_setup.go
@@ -92,7 +92,7 @@ func (b *PodBuilder) setup(ctx context.Context) (string, string, string, error) 
 				slog.Warn("Failed to clean up sandbox after download error", "path", sandboxRoot, "error", rmErr)
 			}
 		}
-		return "", "", "", fmt.Errorf("failed to download resources: %w", err)
+		return "", "", "", err
 	}
 
 	logger.Pod().Info("Sandbox setup completed",
@@ -154,17 +154,25 @@ func (b *PodBuilder) downloadResources(ctx context.Context, sandboxRoot, workDir
 		return nil
 	}
 
+	b.sendProgress("preparing", 72, "Downloading resources...")
+
 	cacheDir := filepath.Join(b.deps.Config.WorkspaceRoot, "cache", "skills")
 	cacheManager, err := cache.NewSkillCacheManager(cacheDir)
 	if err != nil {
-		return fmt.Errorf("failed to create skill cache manager: %w", err)
+		return &client.PodError{
+			Code:    client.ErrCodeResourceDownload,
+			Message: fmt.Sprintf("failed to create skill cache manager: %v", err),
+		}
 	}
 
 	downloader := cache.NewDownloader(cacheManager)
 	for _, res := range b.cmd.ResourcesToDownload {
 		result, err := downloader.DownloadAndExtract(ctx, res, sandboxRoot, workDir)
 		if err != nil {
-			return fmt.Errorf("failed to download resource %s: %w", res.Sha, err)
+			return &client.PodError{
+				Code:    client.ErrCodeResourceDownload,
+				Message: fmt.Sprintf("failed to download resource %s: %v", res.Sha, err),
+			}
 		}
 		if result.CacheHit {
 			slog.Info("Resource cache hit", "sha", res.Sha)
@@ -172,6 +180,8 @@ func (b *PodBuilder) downloadResources(ctx context.Context, sandboxRoot, workDir
 			slog.Info("Resource downloaded", "sha", res.Sha, "bytes", result.BytesRead)
 		}
 	}
+
+	b.sendProgress("preparing", 76, "Resources downloaded")
 	return nil
 }
 

--- a/web/src/components/workspace/TerminalStateViews.tsx
+++ b/web/src/components/workspace/TerminalStateViews.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import {
@@ -8,6 +9,7 @@ import {
   AlertCircle,
   CheckCircle2,
   RefreshCw,
+  Clock,
 } from "lucide-react";
 
 interface InitProgress {
@@ -24,6 +26,29 @@ interface TerminalLoadingStateProps {
   onClose?: () => void;
 }
 
+/** Threshold in seconds after which we show a "taking longer than expected" warning */
+const SLOW_INIT_THRESHOLD_SEC = 120;
+
+function useElapsedSeconds() {
+  const [elapsed, setElapsed] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setElapsed((prev) => prev + 1);
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return elapsed;
+}
+
+function formatElapsed(totalSeconds: number): string {
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes === 0) return `${seconds}s`;
+  return `${minutes}m ${seconds.toString().padStart(2, "0")}s`;
+}
+
 /**
  * Loading/Waiting state view for TerminalPane
  */
@@ -33,6 +58,8 @@ export function TerminalLoadingState({
   onClose,
 }: TerminalLoadingStateProps) {
   const isCompleted = podStatus === "completed";
+  const elapsed = useElapsedSeconds();
+  const isSlowInit = !isCompleted && elapsed >= SLOW_INIT_THRESHOLD_SEC;
 
   return (
     <div className="flex-1 flex items-center justify-center bg-terminal-bg">
@@ -63,8 +90,23 @@ export function TerminalLoadingState({
             )}
           </p>
         )}
-        {/* Show close button when status is unknown or completed */}
-        {(podStatus === "unknown" || isCompleted) && onClose && (
+        {/* Elapsed time indicator for non-completed states */}
+        {!isCompleted && (
+          <p className="text-xs text-terminal-text-muted mt-2 flex items-center justify-center gap-1">
+            <Clock className="w-3 h-3" />
+            {formatElapsed(elapsed)}
+          </p>
+        )}
+        {/* Slow initialization warning */}
+        {isSlowInit && (
+          <div className="mt-3 p-2 rounded bg-yellow-500/10 border border-yellow-500/30">
+            <p className="text-xs text-yellow-500 dark:text-yellow-400">
+              Taking longer than expected. The runner may be cloning a large repository or experiencing connectivity issues.
+            </p>
+          </div>
+        )}
+        {/* Show close button when status is unknown, completed, or init is slow */}
+        {(podStatus === "unknown" || isCompleted || isSlowInit) && onClose && (
           <Button
             variant="outline"
             size="sm"


### PR DESCRIPTION
Pods could get stuck at "waiting for pod to be ready" indefinitely with no feedback when the runner was unreachable or setup stalled. This adds:

- Backend: periodic check (every 1min) that times out pods in "initializing" for >5min, marking them as "error" with INIT_TIMEOUT code and publishing WebSocket events so the frontend updates immediately
- Frontend: elapsed time counter during pod init, slow-init warning after 2min with option to close, better visual feedback
- Runner: progress events for resource downloads, proper PodError wrapping (was using generic fmt.Errorf)

## Summary

- What changed?
- Why was this change needed?

## Changes

- 

## Validation

- [ ] Backend tests (`cd backend && go test ./...`)
- [ ] Web checks (`cd web && pnpm run lint && pnpm run type-check && pnpm run test:coverage`)
- [ ] Runner checks (`cd runner && go test ./...`)
- [ ] Manual validation performed (if applicable)

## Documentation

- [ ] Docs updated (README/docs/inline comments)
- [ ] No docs changes needed

## Risk and Rollback

- Risk level: Low / Medium / High
- Rollback plan:
