### PR TITLE
fix(runner): always register token management routes regardless of PK…

### DIFF
--- a/backend/cmd/server/grpc_init.go
+++ b/backend/cmd/server/grpc_init.go
@@ -41,8 +41,9 @@ func initializePKIAndGRPC(
 	})
 	if err != nil {
 		slog.Error("Failed to initialize PKI service", "error", err)
-		slog.Warn("Continuing without gRPC/mTLS support")
-		return nil, nil
+		slog.Warn("Continuing without gRPC/mTLS support - token management routes still available")
+		// Return handler with nil pkiService so token management routes still work
+		return nil, v1.NewGRPCRunnerHandler(runnerSvc, nil, cfg)
 	}
 
 	slog.Info("PKI service initialized",

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -221,6 +221,8 @@ func main() {
 		}
 	} else {
 		slog.Warn("PKI CA files not configured, gRPC/mTLS disabled")
+		// Create handler without PKI so token management routes still work
+		grpcRunnerHandler = v1.NewGRPCRunnerHandler(services.runner, nil, cfg)
 	}
 
 	// Initialize Runner version checker (checks GitHub Releases for latest version)

--- a/backend/internal/api/rest/v1/runners_grpc.go
+++ b/backend/internal/api/rest/v1/runners_grpc.go
@@ -35,6 +35,11 @@ func NewGRPCRunnerHandler(runnerService *runner.Service, pkiService *pki.Service
 // POST /api/v1/runners/grpc/renew-certificate
 // Authenticated via mTLS - Nginx verifies client certificate and passes CN.
 func (h *GRPCRunnerHandler) RenewCertificate(c *gin.Context) {
+	if h.pkiService == nil {
+		apierr.ServiceUnavailable(c, apierr.SERVICE_UNAVAILABLE, "PKI service not configured")
+		return
+	}
+
 	// Get identity from Nginx-passed headers
 	nodeID := c.GetHeader("X-Client-Cert-CN")
 	oldSerial := c.GetHeader("X-Client-Cert-Serial")
@@ -117,6 +122,11 @@ func (h *GRPCRunnerHandler) GenerateReactivationToken(c *gin.Context) {
 // POST /api/v1/runners/grpc/reactivate
 // No authentication required - token serves as authentication.
 func (h *GRPCRunnerHandler) Reactivate(c *gin.Context) {
+	if h.pkiService == nil {
+		apierr.ServiceUnavailable(c, apierr.SERVICE_UNAVAILABLE, "PKI service not configured")
+		return
+	}
+
 	var req ReactivateRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		apierr.ValidationError(c, err.Error())

--- a/backend/internal/api/rest/v1/runners_grpc_auth.go
+++ b/backend/internal/api/rest/v1/runners_grpc_auth.go
@@ -46,6 +46,11 @@ func (h *GRPCRunnerHandler) RequestAuthURL(c *gin.Context) {
 // GET /api/v1/runners/grpc/auth-status?key=xxx
 // No authentication required - Runner polls for completion.
 func (h *GRPCRunnerHandler) GetAuthStatus(c *gin.Context) {
+	if h.pkiService == nil {
+		apierr.ServiceUnavailable(c, apierr.SERVICE_UNAVAILABLE, "PKI service not configured")
+		return
+	}
+
 	authKey := c.Query("key")
 	if authKey == "" {
 		apierr.BadRequest(c, apierr.VALIDATION_FAILED, "Missing auth key")

--- a/backend/internal/api/rest/v1/runners_grpc_token.go
+++ b/backend/internal/api/rest/v1/runners_grpc_token.go
@@ -125,6 +125,11 @@ func (h *GRPCRunnerHandler) DeleteGRPCToken(c *gin.Context) {
 // POST /api/v1/runners/grpc/register
 // No authentication required - token serves as authentication.
 func (h *GRPCRunnerHandler) RegisterWithToken(c *gin.Context) {
+	if h.pkiService == nil {
+		apierr.ServiceUnavailable(c, apierr.SERVICE_UNAVAILABLE, "PKI service not configured")
+		return
+	}
+
 	var req RegisterWithTokenRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		apierr.ValidationError(c, err.Error())


### PR DESCRIPTION
…I status

When PKI initialization failed (e.g., missing SSL cert files in selfhost deployment), GRPCRunnerHandler was nil causing token management routes to never be registered — returning 404 for POST /api/v1/orgs/:slug/runners/grpc/tokens.

Token management (generate/list/delete) doesn't require PKI. Only certificate operations (register, renew, reactivate) need it. Now the handler is always created, and PKI-dependent methods return 503 when PKI is unavailable.

Closes #133

## Summary

- What changed?
- Why was this change needed?

## Changes

- 

## Validation

- [ ] Backend tests (`cd backend && go test ./...`)
- [ ] Web checks (`cd web && pnpm run lint && pnpm run type-check && pnpm run test:coverage`)
- [ ] Runner checks (`cd runner && go test ./...`)
- [ ] Manual validation performed (if applicable)

## Documentation

- [ ] Docs updated (README/docs/inline comments)
- [ ] No docs changes needed

## Risk and Rollback

- Risk level: Low / Medium / High
- Rollback plan:
