### PR TITLE
fix(mcp): handle notifications per Streamable HTTP spec for Codex com…

### DIFF
--- a/backend/internal/service/channel/hook_pod_prompt.go
+++ b/backend/internal/service/channel/hook_pod_prompt.go
@@ -31,7 +31,7 @@ func NewPodPromptHook(router TerminalInputRouter, msgWriter SystemMessageWriter)
 			return nil
 		}
 
-		prompt := buildPodPrompt(mc.Message.Content, mc.Channel.Name, mc.Mentions.PodKeys)
+		prompt := buildPodPrompt(mc.Message.Content, mc.Channel.Name, mc.Channel.ID, mc.Mentions.PodKeys)
 
 		for _, podKey := range mc.Mentions.PodKeys {
 			// Skip if the message was sent by this pod (don't echo back)
@@ -97,7 +97,9 @@ func stripPodMentions(content string, podKeys []string) string {
 
 // buildPodPrompt builds a context-aware prompt matching the frontend's buildChannelPrompt.
 // Strips @pod mentions from content and wraps with channel context + reply instruction.
-func buildPodPrompt(content, channelName string, podKeys []string) string {
+// Includes channel_id so agents without built-in skills (e.g. Codex) can use
+// the send_channel_message MCP tool to reply directly.
+func buildPodPrompt(content, channelName string, channelID int64, podKeys []string) string {
 	rawPrompt := stripPodMentions(content, podKeys)
-	return fmt.Sprintf("Message from channel(#%s): %s\n\nIf you finish it, please reply to this channel.", channelName, rawPrompt)
+	return fmt.Sprintf("Message from channel(#%s, channel_id=%d): %s\n\nIf you finish it, please reply to this channel using send_channel_message(channel_id=%d).", channelName, channelID, rawPrompt, channelID)
 }

--- a/backend/internal/service/channel/hook_pod_prompt_test.go
+++ b/backend/internal/service/channel/hook_pod_prompt_test.go
@@ -70,6 +70,7 @@ func TestBuildPodPrompt(t *testing.T) {
 		name        string
 		content     string
 		channelName string
+		channelID   int64
 		podKeys     []string
 		want        string
 	}{
@@ -77,28 +78,31 @@ func TestBuildPodPrompt(t *testing.T) {
 			name:        "basic prompt with mention stripped",
 			content:     "@abcd1234 fix the login bug",
 			channelName: "dev-team",
+			channelID:   42,
 			podKeys:     []string{"abcd1234efgh5678"},
-			want:        "Message from channel(#dev-team): fix the login bug\n\nIf you finish it, please reply to this channel.",
+			want:        "Message from channel(#dev-team, channel_id=42): fix the login bug\n\nIf you finish it, please reply to this channel using send_channel_message(channel_id=42).",
 		},
 		{
 			name:        "no mentions to strip",
 			content:     "deploy to staging",
 			channelName: "ops",
+			channelID:   7,
 			podKeys:     []string{"abcd1234efgh5678"},
-			want:        "Message from channel(#ops): deploy to staging\n\nIf you finish it, please reply to this channel.",
+			want:        "Message from channel(#ops, channel_id=7): deploy to staging\n\nIf you finish it, please reply to this channel using send_channel_message(channel_id=7).",
 		},
 		{
 			name:        "multiple mentions stripped",
 			content:     "@aabbccdd @eeffgghh review PR #42",
 			channelName: "code-review",
+			channelID:   100,
 			podKeys:     []string{"aabbccddxxxxxxxx", "eeffgghhyyyyyyyy"},
-			want:        "Message from channel(#code-review): review PR #42\n\nIf you finish it, please reply to this channel.",
+			want:        "Message from channel(#code-review, channel_id=100): review PR #42\n\nIf you finish it, please reply to this channel using send_channel_message(channel_id=100).",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildPodPrompt(tt.content, tt.channelName, tt.podKeys)
+			got := buildPodPrompt(tt.content, tt.channelName, tt.channelID, tt.podKeys)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/runner/internal/mcp/http_server_handlers.go
+++ b/runner/internal/mcp/http_server_handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/anthropics/agentsmesh/runner/internal/logger"
@@ -82,6 +83,14 @@ func (s *HTTPServer) handleMCP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Debug("MCP request received", "method", req.Method, "id", req.ID, "pod_key", podKey)
+
+	// Handle MCP notifications (no "id" field, method starts with "notifications/").
+	// Per the Streamable HTTP spec, notifications MUST receive 202 Accepted with no body.
+	if strings.HasPrefix(req.Method, "notifications/") {
+		log.Debug("MCP notification received", "method", req.Method, "pod_key", podKey)
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
 
 	// Route request
 	switch req.Method {

--- a/runner/internal/mcp/http_server_mcp_protocol_test.go
+++ b/runner/internal/mcp/http_server_mcp_protocol_test.go
@@ -93,15 +93,32 @@ func TestHTTPServerMCPNotificationsInitialized(t *testing.T) {
 
 	server.handleMCP(rec, req)
 
-	// Notifications don't return a response
-	if rec.Body.Len() == 0 {
-		// This is expected for notifications
-		return
+	// Per Streamable HTTP spec, notifications MUST receive 202 Accepted with no body
+	if rec.Code != http.StatusAccepted {
+		t.Errorf("expected status 202 Accepted for notification, got %d", rec.Code)
 	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("expected empty body for notification, got %q", rec.Body.String())
+	}
+}
 
-	var resp MCPResponse
-	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
-		// Empty or no response is expected for notifications
-		return
+func TestHTTPServerMCPNotificationsCancelled(t *testing.T) {
+	server := NewHTTPServer(nil, 9090)
+	server.RegisterPod("test-pod", "test-org", nil, nil, "codex")
+
+	body := bytes.NewBufferString(`{
+		"jsonrpc": "2.0",
+		"method": "notifications/cancelled",
+		"params": {"requestId": 1}
+	}`)
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", body)
+	req.Header.Set("X-Pod-Key", "test-pod")
+	rec := httptest.NewRecorder()
+
+	server.handleMCP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Errorf("expected status 202 for notifications/cancelled, got %d", rec.Code)
 	}
 }


### PR DESCRIPTION
…patibility (#175)

Codex CLI pods could not auto-send results to channels because MCP tool discovery was failing. Two root causes:

1. The MCP HTTP server returned a JSON-RPC error for notification methods (e.g. notifications/initialized), violating the Streamable HTTP spec which requires 202 Accepted with no body. Codex CLI Rust's stricter MCP client would abort the connection on receiving this error, preventing tool discovery entirely.

2. The channel-to-pod prompt included only the channel name but not the channel_id. Without the am-channel skill (which Codex doesn't support), agents had no way to determine the channel_id required by send_channel_message.

## Summary

- What changed?
- Why was this change needed?

## Changes

- 

## Validation

- [ ] Backend tests (`cd backend && go test ./...`)
- [ ] Web checks (`cd web && pnpm run lint && pnpm run type-check && pnpm run test:coverage`)
- [ ] Runner checks (`cd runner && go test ./...`)
- [ ] Manual validation performed (if applicable)

## Documentation

- [ ] Docs updated (README/docs/inline comments)
- [ ] No docs changes needed

## Risk and Rollback

- Risk level: Low / Medium / High
- Rollback plan:
