### PR TITLE
content: rename Producer to Builder and Growth Hacker to GTM

### DIFF
--- a/web/src/messages/de/content.json
+++ b/web/src/messages/de/content.json
@@ -47,15 +47,15 @@
         "resp3": "Develop and optimize sandbox infrastructure for reproducible agent operations"
       },
       "producer": {
-        "title": "Producer",
-        "description": "Producers turn infrastructure into products that users love. You'll bridge the gap between technical capabilities and user needs, shaping every interaction with AgentsMesh into an intuitive and powerful experience.",
+        "title": "Builder",
+        "description": "Builders turn infrastructure into products that users love. You'll bridge the gap between technical capabilities and user needs, shaping every interaction with AgentsMesh into an intuitive and powerful experience.",
         "resp1": "Translate user needs into product requirements and features",
         "resp2": "Shape platform capabilities into polished, user-facing products",
         "resp3": "Gather feedback and iterate to deliver exceptional user experiences"
       },
       "growthHacker": {
-        "title": "Growth Hacker",
-        "description": "Growth Hackers take our product to market with creative, data-driven strategies. You'll help developers discover AgentsMesh, run rapid experiments, and turn early adopters into passionate advocates.",
+        "title": "GTM (Go to Market)",
+        "description": "GTM specialists take our product to market with creative, data-driven strategies. You'll help developers discover AgentsMesh, run rapid experiments, and turn early adopters into passionate advocates.",
         "resp1": "Design and execute data-driven growth experiments",
         "resp2": "Build relationships with developer communities and drive adoption",
         "resp3": "Optimize acquisition funnels and drive user retention"

--- a/web/src/messages/en/content.json
+++ b/web/src/messages/en/content.json
@@ -47,15 +47,15 @@
         "resp3": "Develop and optimize sandbox infrastructure for reproducible agent operations"
       },
       "producer": {
-        "title": "Producer",
-        "description": "Producers turn infrastructure into products that users love. You'll bridge the gap between technical capabilities and user needs, shaping every interaction with AgentsMesh into an intuitive and powerful experience.",
+        "title": "Builder",
+        "description": "Builders turn infrastructure into products that users love. You'll bridge the gap between technical capabilities and user needs, shaping every interaction with AgentsMesh into an intuitive and powerful experience.",
         "resp1": "Translate user needs into product requirements and features",
         "resp2": "Shape platform capabilities into polished, user-facing products",
         "resp3": "Gather feedback and iterate to deliver exceptional user experiences"
       },
       "growthHacker": {
-        "title": "Growth Hacker",
-        "description": "Growth Hackers take our product to market with creative, data-driven strategies. You'll help developers discover AgentsMesh, run rapid experiments, and turn early adopters into passionate advocates.",
+        "title": "GTM (Go to Market)",
+        "description": "GTM specialists take our product to market with creative, data-driven strategies. You'll help developers discover AgentsMesh, run rapid experiments, and turn early adopters into passionate advocates.",
         "resp1": "Design and execute data-driven growth experiments",
         "resp2": "Build relationships with developer communities and drive adoption",
         "resp3": "Optimize acquisition funnels and drive user retention"

--- a/web/src/messages/es/content.json
+++ b/web/src/messages/es/content.json
@@ -47,15 +47,15 @@
         "resp3": "Develop and optimize sandbox infrastructure for reproducible agent operations"
       },
       "producer": {
-        "title": "Producer",
-        "description": "Producers turn infrastructure into products that users love. You'll bridge the gap between technical capabilities and user needs, shaping every interaction with AgentsMesh into an intuitive and powerful experience.",
+        "title": "Builder",
+        "description": "Builders turn infrastructure into products that users love. You'll bridge the gap between technical capabilities and user needs, shaping every interaction with AgentsMesh into an intuitive and powerful experience.",
         "resp1": "Translate user needs into product requirements and features",
         "resp2": "Shape platform capabilities into polished, user-facing products",
         "resp3": "Gather feedback and iterate to deliver exceptional user experiences"
       },
       "growthHacker": {
-        "title": "Growth Hacker",
-        "description": "Growth Hackers take our product to market with creative, data-driven strategies. You'll help developers discover AgentsMesh, run rapid experiments, and turn early adopters into passionate advocates.",
+        "title": "GTM (Go to Market)",
+        "description": "GTM specialists take our product to market with creative, data-driven strategies. You'll help developers discover AgentsMesh, run rapid experiments, and turn early adopters into passionate advocates.",
         "resp1": "Design and execute data-driven growth experiments",
         "resp2": "Build relationships with developer communities and drive adoption",
         "resp3": "Optimize acquisition funnels and drive user retention"

--- a/web/src/messages/fr/content.json
+++ b/web/src/messages/fr/content.json
@@ -47,15 +47,15 @@
         "resp3": "Develop and optimize sandbox infrastructure for reproducible agent operations"
       },
       "producer": {
-        "title": "Producer",
-        "description": "Producers turn infrastructure into products that users love. You'll bridge the gap between technical capabilities and user needs, shaping every interaction with AgentsMesh into an intuitive and powerful experience.",
+        "title": "Builder",
+        "description": "Builders turn infrastructure into products that users love. You'll bridge the gap between technical capabilities and user needs, shaping every interaction with AgentsMesh into an intuitive and powerful experience.",
         "resp1": "Translate user needs into product requirements and features",
         "resp2": "Shape platform capabilities into polished, user-facing products",
         "resp3": "Gather feedback and iterate to deliver exceptional user experiences"
       },
       "growthHacker": {
-        "title": "Growth Hacker",
-        "description": "Growth Hackers take our product to market with creative, data-driven strategies. You'll help developers discover AgentsMesh, run rapid experiments, and turn early adopters into passionate advocates.",
+        "title": "GTM (Go to Market)",
+        "description": "GTM specialists take our product to market with creative, data-driven strategies. You'll help developers discover AgentsMesh, run rapid experiments, and turn early adopters into passionate advocates.",
         "resp1": "Design and execute data-driven growth experiments",
         "resp2": "Build relationships with developer communities and drive adoption",
         "resp3": "Optimize acquisition funnels and drive user retention"

--- a/web/src/messages/ja/content.json
+++ b/web/src/messages/ja/content.json
@@ -47,15 +47,15 @@
         "resp3": "Develop and optimize sandbox infrastructure for reproducible agent operations"
       },
       "producer": {
-        "title": "Producer",
-        "description": "Producers turn infrastructure into products that users love. You'll bridge the gap between technical capabilities and user needs, shaping every interaction with AgentsMesh into an intuitive and powerful experience.",
+        "title": "Builder",
+        "description": "Builders turn infrastructure into products that users love. You'll bridge the gap between technical capabilities and user needs, shaping every interaction with AgentsMesh into an intuitive and powerful experience.",
         "resp1": "Translate user needs into product requirements and features",
         "resp2": "Shape platform capabilities into polished, user-facing products",
         "resp3": "Gather feedback and iterate to deliver exceptional user experiences"
       },
       "growthHacker": {
-        "title": "Growth Hacker",
-        "description": "Growth Hackers take our product to market with creative, data-driven strategies. You'll help developers discover AgentsMesh, run rapid experiments, and turn early adopters into passionate advocates.",
+        "title": "GTM (Go to Market)",
+        "description": "GTM specialists take our product to market with creative, data-driven strategies. You'll help developers discover AgentsMesh, run rapid experiments, and turn early adopters into passionate advocates.",
         "resp1": "Design and execute data-driven growth experiments",
         "resp2": "Build relationships with developer communities and drive adoption",
         "resp3": "Optimize acquisition funnels and drive user retention"

--- a/web/src/messages/ko/content.json
+++ b/web/src/messages/ko/content.json
@@ -47,15 +47,15 @@
         "resp3": "Develop and optimize sandbox infrastructure for reproducible agent operations"
       },
       "producer": {
-        "title": "Producer",
-        "description": "Producers turn infrastructure into products that users love. You'll bridge the gap between technical capabilities and user needs, shaping every interaction with AgentsMesh into an intuitive and powerful experience.",
+        "title": "Builder",
+        "description": "Builders turn infrastructure into products that users love. You'll bridge the gap between technical capabilities and user needs, shaping every interaction with AgentsMesh into an intuitive and powerful experience.",
         "resp1": "Translate user needs into product requirements and features",
         "resp2": "Shape platform capabilities into polished, user-facing products",
         "resp3": "Gather feedback and iterate to deliver exceptional user experiences"
       },
       "growthHacker": {
-        "title": "Growth Hacker",
-        "description": "Growth Hackers take our product to market with creative, data-driven strategies. You'll help developers discover AgentsMesh, run rapid experiments, and turn early adopters into passionate advocates.",
+        "title": "GTM (Go to Market)",
+        "description": "GTM specialists take our product to market with creative, data-driven strategies. You'll help developers discover AgentsMesh, run rapid experiments, and turn early adopters into passionate advocates.",
         "resp1": "Design and execute data-driven growth experiments",
         "resp2": "Build relationships with developer communities and drive adoption",
         "resp3": "Optimize acquisition funnels and drive user retention"

--- a/web/src/messages/pt/content.json
+++ b/web/src/messages/pt/content.json
@@ -47,15 +47,15 @@
         "resp3": "Develop and optimize sandbox infrastructure for reproducible agent operations"
       },
       "producer": {
-        "title": "Producer",
-        "description": "Producers turn infrastructure into products that users love. You'll bridge the gap between technical capabilities and user needs, shaping every interaction with AgentsMesh into an intuitive and powerful experience.",
+        "title": "Builder",
+        "description": "Builders turn infrastructure into products that users love. You'll bridge the gap between technical capabilities and user needs, shaping every interaction with AgentsMesh into an intuitive and powerful experience.",
         "resp1": "Translate user needs into product requirements and features",
         "resp2": "Shape platform capabilities into polished, user-facing products",
         "resp3": "Gather feedback and iterate to deliver exceptional user experiences"
       },
       "growthHacker": {
-        "title": "Growth Hacker",
-        "description": "Growth Hackers take our product to market with creative, data-driven strategies. You'll help developers discover AgentsMesh, run rapid experiments, and turn early adopters into passionate advocates.",
+        "title": "GTM (Go to Market)",
+        "description": "GTM specialists take our product to market with creative, data-driven strategies. You'll help developers discover AgentsMesh, run rapid experiments, and turn early adopters into passionate advocates.",
         "resp1": "Design and execute data-driven growth experiments",
         "resp2": "Build relationships with developer communities and drive adoption",
         "resp3": "Optimize acquisition funnels and drive user retention"

--- a/web/src/messages/zh/content.json
+++ b/web/src/messages/zh/content.json
@@ -47,15 +47,15 @@
         "resp3": "开发和优化沙箱基础设施，确保智能体操作可复现"
       },
       "producer": {
-        "title": "Producer（产品制作人）",
-        "description": "Producer 将基础设施转化为用户喜爱的产品。你将连接技术能力与用户需求，将与 AgentsMesh 的每次交互打磨成直观而强大的体验。",
+        "title": "Builder（产品构建者）",
+        "description": "Builder 将基础设施转化为用户喜爱的产品。你将连接技术能力与用户需求，将与 AgentsMesh 的每次交互打磨成直观而强大的体验。",
         "resp1": "将用户需求转化为产品定义和功能设计",
         "resp2": "将平台能力塑造为精致的用户级产品",
         "resp3": "收集反馈并持续迭代，交付卓越的用户体验"
       },
       "growthHacker": {
-        "title": "Growth Hacker（增长黑客）",
-        "description": "Growth Hacker 以创造性的数据驱动策略将产品推向市场。你将帮助开发者发现 AgentsMesh，快速运行增长实验，将早期用户转化为热情的传播者。",
+        "title": "GTM（Go to Market）",
+        "description": "GTM 以创造性的数据驱动策略将产品推向市场。你将帮助开发者发现 AgentsMesh，快速运行增长实验，将早期用户转化为热情的传播者。",
         "resp1": "设计和执行数据驱动的增长实验",
         "resp2": "与开发者社区建立关系，推动产品采用",
         "resp3": "优化获客漏斗，驱动用户留存"


### PR DESCRIPTION
## Summary
- Rename **Producer** role to **Builder** across all 8 language files
- Rename **Growth Hacker** role to **GTM (Go to Market)** across all 8 language files
- Updated both titles and descriptions to reflect new naming

## Test plan
- [ ] Verify careers page renders correctly with new role names
- [ ] Check all 8 language variants display properly