### PR TITLE
fix(acp): end-to-end ACP streaming pipeline

### DIFF
--- a/backend/internal/service/agent/config_builder_podfile.go
+++ b/backend/internal/service/agent/config_builder_podfile.go
@@ -44,13 +44,13 @@ func (b *ConfigBuilder) buildFromPodFile(
 	if len(parseErrors) > 0 {
 		return nil, fmt.Errorf("invalid user config layer: %s", parseErrors[0])
 	}
-	_ = merge.Merge(baseProg, userProg)
+	mergedProg := merge.Merge(baseProg, userProg)
 
 	// 4. Serialize merged AST to PodFile source
-	mergedSource := serialize.Serialize(baseProg)
+	mergedSource := serialize.Serialize(mergedProg)
 
 	// 5. Extract MODE/CREDENTIAL from merged PodFile to override request-level settings
-	spec := extract.Extract(baseProg)
+	spec := extract.Extract(mergedProg)
 	interactionMode := req.InteractionMode
 	if spec.Mode != "" {
 		interactionMode = spec.Mode

--- a/relay/internal/channel/terminal_channel_io.go
+++ b/relay/internal/channel/terminal_channel_io.go
@@ -157,7 +157,7 @@ func (c *TerminalChannel) forwardPublisherToSubscribers(epoch uint64) {
 		// Snapshot supersedes all buffered output — clear buffer and replace with
 		// the snapshot itself, so new subscribers joining after this point receive
 		// the complete terminal state instead of an empty buffer.
-		if msg != nil && msg.Type == protocol.MsgTypeSnapshot {
+		if msg != nil && (msg.Type == protocol.MsgTypeSnapshot || msg.Type == protocol.MsgTypeAcpSnapshot) {
 			c.clearOutputBuffer()
 			c.bufferOutput(data)
 		}

--- a/runner/internal/acp/claude/handler.go
+++ b/runner/internal/acp/claude/handler.go
@@ -174,6 +174,39 @@ func (t *Transport) handleCanUseTool(requestID string, req *controlRequestPayloa
 	}
 }
 
+// handleAssistant extracts text content from a non-streaming assistant message.
+// In non-streaming mode, Claude sends the complete response as an "assistant" message
+// rather than incremental stream_event chunks.
+func (t *Transport) handleAssistant(msg *message) {
+	if msg.Message == nil || t.callbacks.OnContentChunk == nil {
+		return
+	}
+
+	var assistantMsg struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(msg.Message, &assistantMsg); err != nil {
+		t.logger.Warn("failed to parse assistant message", "error", err)
+		return
+	}
+
+	t.sessionMu.RLock()
+	sid := t.sessionID
+	t.sessionMu.RUnlock()
+
+	for _, block := range assistantMsg.Content {
+		if block.Type == "text" && block.Text != "" {
+			t.callbacks.OnContentChunk(sid, acp.ContentChunk{
+				Text: block.Text,
+				Role: "assistant",
+			})
+		}
+	}
+}
+
 func (t *Transport) handleResult(msg *message) {
 	if msg.Subtype == "success" || msg.Subtype == "" {
 		if t.callbacks.OnStateChange != nil {

--- a/runner/internal/acp/claude/transport.go
+++ b/runner/internal/acp/claude/transport.go
@@ -181,7 +181,9 @@ func (t *Transport) handleMessage(msg *message) {
 	case "stream_event":
 		t.handleStreamEvent(msg)
 	case "assistant":
-		// Streaming mode: content already delivered via stream_event.
+		// In streaming mode, content is already delivered via stream_event.
+		// In non-streaming mode (no --print), extract text from the message.
+		t.handleAssistant(msg)
 	case "user":
 		t.handleUser(msg)
 	case "result":

--- a/runner/internal/acp/client.go
+++ b/runner/internal/acp/client.go
@@ -63,6 +63,7 @@ type ACPClient struct {
 	cancel       context.CancelFunc
 	done         chan struct{}
 	waitExitDone chan struct{} // closed when waitExit() completes
+	stateChanged chan struct{} // signaled on every state transition
 	stopOnce     sync.Once
 
 	logger *slog.Logger
@@ -87,6 +88,7 @@ func NewClient(cfg ClientConfig) *ACPClient {
 		cancel:       cancel,
 		done:         make(chan struct{}),
 		waitExitDone: make(chan struct{}),
+		stateChanged: make(chan struct{}, 1),
 		logger:       cfg.Logger.With("component", "acp-client"),
 	}
 }
@@ -104,8 +106,31 @@ func (c *ACPClient) setState(state string) {
 	c.state = state
 	c.stateMu.Unlock()
 
-	if old != state && c.cfg.Callbacks.OnStateChange != nil {
-		c.cfg.Callbacks.OnStateChange(state)
+	if old != state {
+		// Notify waiters that state changed (non-blocking broadcast).
+		select {
+		case c.stateChanged <- struct{}{}:
+		default:
+		}
+		if c.cfg.Callbacks.OnStateChange != nil {
+			c.cfg.Callbacks.OnStateChange(state)
+		}
+	}
+}
+
+// WaitReady blocks until the client leaves the initializing/uninitialized state
+// or the context expires. Returns the current state.
+func (c *ACPClient) WaitReady(ctx context.Context) string {
+	for {
+		s := c.State()
+		if s != StateInitializing && s != StateUninitialized {
+			return s
+		}
+		select {
+		case <-ctx.Done():
+			return c.State()
+		case <-c.stateChanged:
+		}
 	}
 }
 

--- a/runner/internal/runner/message_handler_acp.go
+++ b/runner/internal/runner/message_handler_acp.go
@@ -56,10 +56,23 @@ func (h *RunnerMessageHandler) wireAndStartACPPod(pod *Pod, cmd *runnerv1.Create
 	// Pre-declare so callbacks can capture it (NewClient returns the same pointer).
 	var acpClient *acp.ACPClient
 
+	// Inject transport-specific CLI flags for ACP mode.
+	acpArgs := pod.LaunchArgs
+	transportType := inferTransportType(pod.LaunchCommand)
+	if transportType == acp.TransportTypeClaudeStream {
+		acpArgs = append([]string{
+			"--print",
+			"--output-format", "stream-json",
+			"--input-format", "stream-json",
+			"--include-partial-messages",
+			"--verbose",
+		}, acpArgs...)
+	}
+
 	// Create ACPClient with event callbacks that forward via Relay.
 	acpClient = acp.NewClient(acp.ClientConfig{
 		Command:       pod.LaunchCommand,
-		Args:          pod.LaunchArgs,
+		Args:          acpArgs,
 		WorkDir:       pod.WorkDir,
 		Env:           pod.LaunchEnv,
 		Logger:        log.With("pod_key", podKey),

--- a/runner/internal/runner/message_handler_relay.go
+++ b/runner/internal/runner/message_handler_relay.go
@@ -1,11 +1,13 @@
 package runner
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"time"
 
+	"github.com/anthropics/agentsmesh/runner/internal/acp"
 	"github.com/anthropics/agentsmesh/runner/internal/client"
 	"github.com/anthropics/agentsmesh/runner/internal/logger"
 	"github.com/anthropics/agentsmesh/runner/internal/relay"
@@ -186,6 +188,16 @@ func (h *RunnerMessageHandler) handleAcpRelayCommand(pod *Pod, payload []byte) {
 
 	switch cmd.Type {
 	case "prompt":
+		// Wait for ACP client to finish initializing before sending prompt.
+		if acpIO, ok := pod.IO.(*ACPPodIO); ok {
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			s := acpIO.client.WaitReady(ctx)
+			cancel()
+			if s != acp.StateIdle {
+				log.Error("ACP client not ready for prompt", "pod_key", pod.PodKey, "state", s)
+				return
+			}
+		}
 		// Echo user message back to all relay subscribers so it appears in chat.
 		sendAcpViaRelay(pod, "content_chunk", "", map[string]string{
 			"text": cmd.Prompt, "role": "user",
@@ -197,6 +209,9 @@ func (h *RunnerMessageHandler) handleAcpRelayCommand(pod *Pod, payload []byte) {
 	case "permission_response":
 		if err := pod.IO.RespondToPermission(cmd.ReqID, cmd.Approv); err != nil {
 			log.Error("Failed to respond to ACP permission via relay", "pod_key", pod.PodKey, "error", err)
+		}
+		if pod.ACPClient != nil {
+			pod.ACPClient.RemovePendingPermission(cmd.ReqID)
 		}
 
 	case "cancel":

--- a/runner/internal/runner/pod_relay_acp.go
+++ b/runner/internal/runner/pod_relay_acp.go
@@ -26,6 +26,11 @@ func NewACPPodRelay(podKey string, acpClient *acp.ACPClient, onCommand func([]by
 
 func (r *ACPPodRelay) SetupHandlers(rc relay.RelayClient) {
 	rc.SetMessageHandler(relay.MsgTypeAcpCommand, r.onCommand)
+
+	// Handle Resync: browser requests a fresh ACP snapshot (e.g., after reconnect).
+	rc.SetMessageHandler(relay.MsgTypeResync, func(_ []byte) {
+		r.SendSnapshot(rc)
+	})
 }
 
 func (r *ACPPodRelay) SendSnapshot(rc relay.RelayClient) {

--- a/web/src/components/workspace/acp/AcpToolCallCard.tsx
+++ b/web/src/components/workspace/acp/AcpToolCallCard.tsx
@@ -27,6 +27,78 @@ function ToolStatusIcon({ toolCall }: { toolCall: AcpToolCall }) {
   return <Circle className="h-3.5 w-3.5 text-muted-foreground shrink-0" />;
 }
 
+interface EditArgs {
+  file_path?: string;
+  old_string?: string;
+  new_string?: string;
+}
+
+interface MultiEditArgs {
+  file_path?: string;
+  edits?: EditArgs[];
+}
+
+/** Renders a single old→new edit pair with terminal-style background for new content. */
+function EditPair({ old_string, new_string }: { old_string?: string; new_string?: string }) {
+  return (
+    <div className="space-y-1">
+      {old_string !== undefined && (
+        <pre className="text-xs bg-red-950/40 text-red-300 p-2 rounded overflow-x-auto whitespace-pre-wrap break-all">
+          {old_string}
+        </pre>
+      )}
+      {new_string !== undefined && (
+        <pre className="text-xs bg-terminal-bg text-terminal-text p-2 rounded overflow-x-auto whitespace-pre-wrap break-all">
+          {new_string}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+/** Structured view for Edit / MultiEdit tool calls. Falls back to raw JSON on parse error. */
+function EditArguments({ toolName, argumentsJson }: { toolName: string; argumentsJson: string }) {
+  let parsed: EditArgs | MultiEditArgs | null = null;
+  try {
+    parsed = JSON.parse(argumentsJson);
+  } catch {
+    // fall through to raw view
+  }
+
+  if (!parsed) {
+    return (
+      <pre className="text-xs bg-muted p-2 rounded overflow-x-auto">{argumentsJson}</pre>
+    );
+  }
+
+  if (toolName === "Edit") {
+    const args = parsed as EditArgs;
+    return (
+      <div className="space-y-1">
+        {args.file_path && (
+          <p className="text-[10px] font-mono text-muted-foreground truncate">{args.file_path}</p>
+        )}
+        <EditPair old_string={args.old_string} new_string={args.new_string} />
+      </div>
+    );
+  }
+
+  // MultiEdit
+  const args = parsed as MultiEditArgs;
+  return (
+    <div className="space-y-1">
+      {args.file_path && (
+        <p className="text-[10px] font-mono text-muted-foreground truncate">{args.file_path}</p>
+      )}
+      {args.edits?.map((edit, i) => (
+        <EditPair key={i} old_string={edit.old_string} new_string={edit.new_string} />
+      ))}
+    </div>
+  );
+}
+
+const EDIT_TOOLS = new Set(["Edit", "MultiEdit"]);
+
 export function AcpToolCallCard({ toolCall }: { toolCall: AcpToolCall }) {
   const [expanded, setExpanded] = useState(false);
 
@@ -46,9 +118,13 @@ export function AcpToolCallCard({ toolCall }: { toolCall: AcpToolCall }) {
       </button>
       {expanded && (
         <div className="ml-[18px] mt-1 space-y-1">
-          <pre className="text-xs bg-muted p-2 rounded overflow-x-auto">
-            {toolCall.arguments_json}
-          </pre>
+          {EDIT_TOOLS.has(toolCall.tool_name) ? (
+            <EditArguments toolName={toolCall.tool_name} argumentsJson={toolCall.arguments_json} />
+          ) : (
+            <pre className="text-xs bg-muted p-2 rounded overflow-x-auto">
+              {toolCall.arguments_json}
+            </pre>
+          )}
           {toolCall.result_text && (
             <pre className="text-xs bg-green-50 dark:bg-green-950 p-2 rounded overflow-x-auto">
               {toolCall.result_text}

--- a/web/src/hooks/useAcpRelay.ts
+++ b/web/src/hooks/useAcpRelay.ts
@@ -1,11 +1,11 @@
 import { useEffect } from "react";
 import { relayPool } from "@/stores/relayConnection";
-import { dispatchAcpRelayEvent } from "@/stores/acpEventDispatcher";
 
 /**
  * Subscribe to ACP relay messages for a pod.
- * Manages the relay subscription lifecycle (subscribe/unsubscribe)
- * and routes incoming ACP events to the session store.
+ * Manages the relay subscription lifecycle (subscribe/unsubscribe).
+ * ACP events are dispatched directly to the store in the WebSocket handler,
+ * so no listener registration is needed here.
  */
 export function useAcpRelay(podKey: string, paneId: string, active: boolean): void {
   useEffect(() => {
@@ -17,14 +17,8 @@ export function useAcpRelay(podKey: string, paneId: string, active: boolean): vo
     // The callback is a no-op because terminal output is irrelevant for ACP panels.
     relayPool.subscribe(podKey, subscriptionId, () => {});
 
-    // Listen for ACP-specific messages and route to store.
-    const unsubAcp = relayPool.onAcpMessage(podKey, (msgType, payload) => {
-      dispatchAcpRelayEvent(podKey, msgType, payload);
-    });
-
     return () => {
       relayPool.unsubscribe(podKey, subscriptionId);
-      unsubAcp();
     };
   }, [podKey, paneId, active]);
 }

--- a/web/src/stores/relayConnectionHandlers.ts
+++ b/web/src/stores/relayConnectionHandlers.ts
@@ -47,8 +47,20 @@ export function dispatchRelayMessage(
       callbacks.onRunnerReconnected(conn);
       break;
     case MsgType.AcpEvent:
-    case MsgType.AcpSnapshot:
     case MsgType.AcpCommand: {
+      const parsed = decodeJsonPayload(payload);
+      if (parsed !== null) {
+        callbacks.onAcpMessage(conn.podKey, type, parsed);
+      }
+      break;
+    }
+    case MsgType.AcpSnapshot: {
+      // Mark snapshot received so the retry timer stops sending Resync requests.
+      conn.snapshotReceived = true;
+      if (conn.snapshotTimer) {
+        clearTimeout(conn.snapshotTimer);
+        conn.snapshotTimer = null;
+      }
       const parsed = decodeJsonPayload(payload);
       if (parsed !== null) {
         callbacks.onAcpMessage(conn.podKey, type, parsed);

--- a/web/src/stores/relayConnectionWebSocket.ts
+++ b/web/src/stores/relayConnectionWebSocket.ts
@@ -7,6 +7,7 @@ import { MsgType, encodeMessage, encodeResize } from "./relayProtocol";
 import type { RelayConnection, ConnectionHandle } from "./relayConnectionTypes";
 import { dispatchRelayMessage, handleSnapshot, handleControl, handleRunnerDisconnected, handleRunnerReconnected } from "./relayConnectionHandlers";
 import { scheduleSnapshotRetry, scheduleReconnect } from "./relayConnectionRetry";
+import { dispatchAcpRelayEvent } from "./acpEventDispatcher";
 
 /** Pool internals needed by WebSocket lifecycle functions */
 export interface PoolContext {
@@ -89,7 +90,9 @@ function setupWebSocketHandlers(ctx: PoolContext, podKey: string, ws: WebSocket)
         ctx.notifyStatusChange(conn.podKey);
       },
       onAcpMessage: (pk, msgType, payload) => {
-        ctx.notifyAcpListeners(pk, msgType, payload);
+        // Dispatch directly to store (always available) so buffered snapshots
+        // arriving before useAcpRelay's useEffect are not lost.
+        dispatchAcpRelayEvent(pk, msgType, payload);
       },
     });
   };


### PR DESCRIPTION
## Summary
- **PodFile merge bug**: `merge.Merge()` return value was discarded — user layer overrides (MODE acp, CONFIG, CREDENTIAL) were silently lost
- **Claude ACP transport**: Add `--print --input-format stream-json --include-partial-messages` flags, handle `assistant` message type, add `WaitReady()` for handshake sync
- **Relay snapshot buffering**: Buffer `AcpSnapshot` so late-joining browsers receive session state
- **Frontend event dispatch**: Dispatch ACP events directly to store (not via listener) to prevent race with `useEffect`; fix duplicate messages; set `snapshotReceived` on AcpSnapshot

## Test plan
- [ ] Create ACP pod with Claude Code — should show streaming response
- [ ] Send multiple prompts in same ACP session — all should stream
- [ ] Refresh browser mid-session — should recover state via snapshot
- [ ] Create PTY pod — should still work as before (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)