### PR TITLE
fix(runner): remove early buffer, fix pod status mismark, add per-pod command queue

### DIFF
--- a/backend/internal/domain/agentpod/repository.go
+++ b/backend/internal/domain/agentpod/repository.go
@@ -62,6 +62,12 @@ type PodRepository interface {
 	// UpdateTerminatedWithFallbackError updates a terminated pod, setting error_code
 	// only if not already set (uses COALESCE(NULLIF(error_code, ''), fallbackCode)).
 	UpdateTerminatedWithFallbackError(ctx context.Context, podKey string, updates map[string]interface{}, fallbackErrorCode string) error
+	// UpdateTerminatedIfActive is like UpdateTerminatedWithFallbackError but only
+	// updates pods that are still in an active state. Returns rows affected.
+	UpdateTerminatedIfActive(ctx context.Context, podKey string, updates map[string]interface{}, fallbackErrorCode string) (int64, error)
+	// UpdateByKeyAndActiveStatus updates a pod only if it's in an active state.
+	// Returns rows affected so the caller can detect if the pod was already terminal.
+	UpdateByKeyAndActiveStatus(ctx context.Context, podKey string, updates map[string]interface{}) (int64, error)
 	// GetByKeyAndRunner returns a pod by pod_key and runner_id (no preloads).
 	GetByKeyAndRunner(ctx context.Context, podKey string, runnerID int64) (*Pod, error)
 	// CountActiveByKeys counts how many of the given pod keys are in active status.

--- a/backend/internal/infra/agentpod_repo.go
+++ b/backend/internal/infra/agentpod_repo.go
@@ -255,6 +255,26 @@ func (r *podRepo) UpdateTerminatedWithFallbackError(ctx context.Context, podKey 
 		Updates(updates).Error
 }
 
+// UpdateTerminatedIfActive updates a terminated pod with error info, but only if
+// the pod is still in an active state (initializing/running/paused/disconnected).
+// Returns rows affected so the caller can detect if the pod was already in a terminal state.
+func (r *podRepo) UpdateTerminatedIfActive(ctx context.Context, podKey string, updates map[string]interface{}, fallbackErrorCode string) (int64, error) {
+	updates["error_code"] = gorm.Expr("COALESCE(NULLIF(error_code, ''), ?)", fallbackErrorCode)
+	result := r.db.WithContext(ctx).Model(&agentpod.Pod{}).
+		Where("pod_key = ? AND status IN ?", podKey, agentpod.ActiveStatuses()).
+		Updates(updates)
+	return result.RowsAffected, result.Error
+}
+
+// UpdateByKeyAndActiveStatus updates a pod only if it's in an active state.
+// Returns rows affected so the caller can detect if the pod was already in a terminal state.
+func (r *podRepo) UpdateByKeyAndActiveStatus(ctx context.Context, podKey string, updates map[string]interface{}) (int64, error) {
+	result := r.db.WithContext(ctx).Model(&agentpod.Pod{}).
+		Where("pod_key = ? AND status IN ?", podKey, agentpod.ActiveStatuses()).
+		Updates(updates)
+	return result.RowsAffected, result.Error
+}
+
 func (r *podRepo) GetByKeyAndRunner(ctx context.Context, podKey string, runnerID int64) (*agentpod.Pod, error) {
 	var pod agentpod.Pod
 	err := r.db.WithContext(ctx).

--- a/backend/internal/service/runner/pod_lifecycle_handler.go
+++ b/backend/internal/service/runner/pod_lifecycle_handler.go
@@ -61,37 +61,56 @@ func (pc *PodCoordinator) handlePodTerminated(runnerID int64, data *runnerv1.Pod
 
 	now := time.Now()
 
-	// Determine status: if the process exited with an error and provided early output,
-	// mark as error so the user can see why the process failed.
-	status := agentpod.StatusCompleted
+	// Status is decided by Runner and sent explicitly in data.Status.
+	// Backend stores it directly — no interpretation of exit codes or error messages.
+	status := data.Status
+	if status == "" {
+		// Backward compatibility: old runners without status field.
+		// Fall back to ErrorMessage-based inference.
+		if data.ErrorMessage != "" {
+			status = agentpod.StatusError
+		} else {
+			status = agentpod.StatusCompleted
+		}
+	}
+
 	updates := map[string]interface{}{
 		"agent_status": agentpod.AgentStatusIdle,
 		"finished_at":  now,
 		"pty_pid":      nil,
+		"status":       status,
+	}
+	if data.ErrorMessage != "" {
+		updates["error_message"] = data.ErrorMessage
 	}
 
-	if data.ErrorMessage != "" {
-		// Process exited with early output (e.g., invalid CLI arguments, PTY error).
-		// Store the error message so the frontend can display why the pod failed.
-		status = agentpod.StatusError
-		updates["error_message"] = data.ErrorMessage
-		updates["status"] = status
-		// Preserve existing error_code if already set by a prior error event
-		// (e.g., PTY_READ_ERROR from handlePodError). Only set the default
-		// "process_exit" code when no specific error code exists yet.
-		if err := pc.podRepo.UpdateTerminatedWithFallbackError(ctx, data.PodKey, updates, "process_exit"); err != nil {
+	// Only update if pod is still active — prevents overwriting a pod already
+	// in terminal state (e.g., server-initiated TerminatePod pre-sets completed).
+	if status == agentpod.StatusError {
+		rowsAffected, err := pc.podRepo.UpdateTerminatedIfActive(ctx, data.PodKey, updates, "process_exit")
+		if err != nil {
 			pc.logger.Error("failed to update pod on termination",
-				"pod_key", data.PodKey,
-				"error", err)
+				"pod_key", data.PodKey, "error", err)
 			return
 		}
+		if rowsAffected == 0 {
+			pc.logger.Info("pod already in terminal state, skipping status update",
+				"pod_key", data.PodKey)
+			status = ""
+		}
 	} else {
-		updates["status"] = status
-		if _, err := pc.podRepo.UpdateByKey(ctx, data.PodKey, updates); err != nil {
+		rowsAffected, err := pc.podRepo.UpdateByKeyAndActiveStatus(ctx, data.PodKey, updates)
+		if err != nil {
 			pc.logger.Error("failed to update pod on termination",
-				"pod_key", data.PodKey,
-				"error", err)
+				"pod_key", data.PodKey, "error", err)
 			return
+		}
+		if rowsAffected > 0 {
+			// keep status as-is
+		} else {
+			pc.logger.Info("pod already in terminal state, skipping status update",
+				"pod_key", data.PodKey)
+			status = ""
 		}
 	}
 
@@ -106,10 +125,10 @@ func (pc *PodCoordinator) handlePodTerminated(runnerID int64, data *runnerv1.Pod
 		"pod_key", data.PodKey,
 		"runner_id", runnerID,
 		"exit_code", data.ExitCode,
-		"has_early_output", data.ErrorMessage != "")
+		"status", status)
 
-	// Notify status change
-	if pc.onStatusChange != nil {
+	// Notify status change (skip if pod was already in terminal state)
+	if pc.onStatusChange != nil && status != "" {
 		pc.onStatusChange(data.PodKey, status, "")
 	}
 }

--- a/proto/gen/go/runner/v1/runner.pb.go
+++ b/proto/gen/go/runner/v1/runner.pb.go
@@ -1020,7 +1020,8 @@ type PodTerminatedEvent struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	PodKey        string                 `protobuf:"bytes,1,opt,name=pod_key,json=podKey,proto3" json:"pod_key,omitempty"`
 	ExitCode      int32                  `protobuf:"varint,2,opt,name=exit_code,json=exitCode,proto3" json:"exit_code,omitempty"`
-	ErrorMessage  string                 `protobuf:"bytes,3,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
+	ErrorMessage  string                 `protobuf:"bytes,3,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"` // Diagnostic info for display (not used for status decision)
+	Status        string                 `protobuf:"bytes,4,opt,name=status,proto3" json:"status,omitempty"`                                 // "completed" or "error" — decided by Runner
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1072,6 +1073,13 @@ func (x *PodTerminatedEvent) GetExitCode() int32 {
 func (x *PodTerminatedEvent) GetErrorMessage() string {
 	if x != nil {
 		return x.ErrorMessage
+	}
+	return ""
+}
+
+func (x *PodTerminatedEvent) GetStatus() string {
+	if x != nil {
+		return x.Status
 	}
 	return ""
 }
@@ -5494,11 +5502,12 @@ const file_runner_v1_runner_proto_rawDesc = "" +
 	"\x03pid\x18\x02 \x01(\x05R\x03pid\x12!\n" +
 	"\fsandbox_path\x18\x03 \x01(\tR\vsandboxPath\x12\x1f\n" +
 	"\vbranch_name\x18\x04 \x01(\tR\n" +
-	"branchName\"o\n" +
+	"branchName\"\x87\x01\n" +
 	"\x12PodTerminatedEvent\x12\x17\n" +
 	"\apod_key\x18\x01 \x01(\tR\x06podKey\x12\x1b\n" +
 	"\texit_code\x18\x02 \x01(\x05R\bexitCode\x12#\n" +
-	"\rerror_message\x18\x03 \x01(\tR\ferrorMessage\"B\n" +
+	"\rerror_message\x18\x03 \x01(\tR\ferrorMessage\x12\x16\n" +
+	"\x06status\x18\x04 \x01(\tR\x06status\"B\n" +
 	"\x13TerminalOutputEvent\x12\x17\n" +
 	"\apod_key\x18\x01 \x01(\tR\x06podKey\x12\x12\n" +
 	"\x04data\x18\x02 \x01(\fR\x04data\"C\n" +

--- a/proto/runner/v1/runner.proto
+++ b/proto/runner/v1/runner.proto
@@ -118,7 +118,8 @@ message PodCreatedEvent {
 message PodTerminatedEvent {
   string pod_key = 1;
   int32 exit_code = 2;
-  string error_message = 3;
+  string error_message = 3;  // Diagnostic info for display (not used for status decision)
+  string status = 4;         // "completed" or "error" — decided by Runner
 }
 
 // TerminalOutputEvent 终端输出事件

--- a/runner/internal/client/grpc_connection.go
+++ b/runner/internal/client/grpc_connection.go
@@ -110,6 +110,10 @@ type GRPCConnection struct {
 	// so Stop() can wait for in-flight handlers to finish.
 	handlerWg sync.WaitGroup
 
+	// podQueue serializes commands per pod to eliminate race conditions
+	// (e.g., create_autopilot arriving before create_pod finishes).
+	podQueue *PodCommandQueue
+
 	// loopWg tracks the connectionLoop goroutine for clean shutdown.
 	loopWg sync.WaitGroup
 }
@@ -139,6 +143,7 @@ func NewGRPCConnection(endpoint, nodeID, orgSlug, certFile, keyFile, caFile stri
 		certUrgentDays:           7,  // Urgent reconnection 7 days before expiry
 		terminalRateLimit:        50 * 1024, // Default: 50KB/s (conservative for shared bandwidth)
 		agentProbe:               NewAgentProbe(),
+		podQueue:                 NewPodCommandQueue(),
 	}
 
 	for _, opt := range opts {

--- a/runner/internal/client/grpc_handler.go
+++ b/runner/internal/client/grpc_handler.go
@@ -54,21 +54,23 @@ func (c *GRPCConnection) handleServerMessage(msg *runnerv1.ServerMessage) {
 	case *runnerv1.ServerMessage_InitializeResult:
 		c.handleInitializeResult(payload.InitializeResult)
 
-	// Heavy operations - async dispatch to avoid blocking readLoop.
-	// Tracked by handlerWg so Stop() can wait for them to finish.
+	// Heavy operations - dispatched via per-pod command queue.
+	// Same pod's commands execute sequentially (create_pod before create_autopilot).
+	// Different pods execute concurrently. Tracked by handlerWg for clean shutdown.
 	case *runnerv1.ServerMessage_CreatePod:
 		c.handlerWg.Add(1)
-		go func() {
+		c.podQueue.Enqueue(payload.CreatePod.PodKey, func() {
 			defer c.handlerWg.Done()
 			c.handleCreatePod(payload.CreatePod)
-		}()
+		})
 
 	case *runnerv1.ServerMessage_TerminatePod:
 		c.handlerWg.Add(1)
-		go func() {
+		c.podQueue.Enqueue(payload.TerminatePod.PodKey, func() {
 			defer c.handlerWg.Done()
 			c.handleTerminatePod(payload.TerminatePod)
-		}()
+			c.podQueue.Remove(payload.TerminatePod.PodKey)
+		})
 
 	case *runnerv1.ServerMessage_SubscribeTerminal:
 		c.handlerWg.Add(1)
@@ -79,10 +81,10 @@ func (c *GRPCConnection) handleServerMessage(msg *runnerv1.ServerMessage) {
 
 	case *runnerv1.ServerMessage_CreateAutopilot:
 		c.handlerWg.Add(1)
-		go func() {
+		c.podQueue.Enqueue(payload.CreateAutopilot.PodKey, func() {
 			defer c.handlerWg.Done()
 			c.handleCreateAutopilot(payload.CreateAutopilot)
-		}()
+		})
 
 	// Lightweight operations - synchronous to preserve ordering
 	case *runnerv1.ServerMessage_TerminalInput:

--- a/runner/internal/client/grpc_handler_dispatch_test.go
+++ b/runner/internal/client/grpc_handler_dispatch_test.go
@@ -18,6 +18,7 @@ func newTestConnection() *GRPCConnection {
 		reconnectCh:       make(chan struct{}, 1),
 		initResultCh:      make(chan *runnerv1.InitializeResult, 1),
 		heartbeatInterval: 30 * time.Second,
+		podQueue:          NewPodCommandQueue(),
 	}
 }
 

--- a/runner/internal/client/grpc_sender_pod.go
+++ b/runner/internal/client/grpc_sender_pod.go
@@ -24,13 +24,14 @@ func (c *GRPCConnection) SendPodCreated(podKey string, pid int32, sandboxPath, b
 }
 
 // SendPodTerminated sends a pod_terminated event to the server (control message).
-func (c *GRPCConnection) SendPodTerminated(podKey string, exitCode int32, errorMsg string) error {
+func (c *GRPCConnection) SendPodTerminated(podKey string, exitCode int32, errorMsg string, status string) error {
 	msg := &runnerv1.RunnerMessage{
 		Payload: &runnerv1.RunnerMessage_PodTerminated{
 			PodTerminated: &runnerv1.PodTerminatedEvent{
 				PodKey:       podKey,
 				ExitCode:     exitCode,
 				ErrorMessage: errorMsg,
+				Status:       status,
 			},
 		},
 		Timestamp: time.Now().UnixMilli(),

--- a/runner/internal/client/grpc_sender_test.go
+++ b/runner/internal/client/grpc_sender_test.go
@@ -168,7 +168,7 @@ func TestSendPodTerminated(t *testing.T) {
 	conn := newTestConnection()
 	setFakeStream(conn)
 
-	err := conn.SendPodTerminated("pod-1", 0, "")
+	err := conn.SendPodTerminated("pod-1", 0, "", "completed")
 	require.NoError(t, err)
 
 	msg := <-conn.controlCh

--- a/runner/internal/client/interface.go
+++ b/runner/internal/client/interface.go
@@ -28,7 +28,8 @@ type ConnectionSender interface {
 	SendPodCreated(podKey string, pid int32, sandboxPath, branchName string) error
 
 	// SendPodTerminated sends a pod_terminated event to the server.
-	SendPodTerminated(podKey string, exitCode int32, errorMsg string) error
+	// status is "completed" or "error" — decided by Runner.
+	SendPodTerminated(podKey string, exitCode int32, errorMsg string, status string) error
 
 	// SendPtyResized sends a PTY resize event to the server.
 	SendPtyResized(podKey string, cols, rows int32) error

--- a/runner/internal/client/mock_connection.go
+++ b/runner/internal/client/mock_connection.go
@@ -106,13 +106,13 @@ func (m *MockConnection) SendPodCreated(podKey string, pid int32, sandboxPath, b
 }
 
 // SendPodTerminated implements Connection.
-func (m *MockConnection) SendPodTerminated(podKey string, exitCode int32, errorMsg string) error {
+func (m *MockConnection) SendPodTerminated(podKey string, exitCode int32, errorMsg string, status string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.SendErr != nil {
 		return m.SendErr
 	}
-	m.Events = append(m.Events, EventCall{Type: MsgTypePodTerminated, Data: map[string]interface{}{"pod_key": podKey, "exit_code": exitCode, "error": errorMsg}})
+	m.Events = append(m.Events, EventCall{Type: MsgTypePodTerminated, Data: map[string]interface{}{"pod_key": podKey, "exit_code": exitCode, "error": errorMsg, "status": status}})
 	return nil
 }
 

--- a/runner/internal/client/mock_connection_test.go
+++ b/runner/internal/client/mock_connection_test.go
@@ -45,7 +45,7 @@ func TestMockConnection_SendEvents(t *testing.T) {
 	mc := NewMockConnection()
 
 	_ = mc.SendPodCreated("pod-1", 1234, "/sandbox", "main")
-	_ = mc.SendPodTerminated("pod-1", 0, "")
+	_ = mc.SendPodTerminated("pod-1", 0, "", "completed")
 	_ = mc.SendPtyResized("pod-1", 80, 24)
 	_ = mc.SendError("pod-1", "err", "msg")
 	_ = mc.SendPodInitProgress("pod-1", "clone", 50, "cloning...")
@@ -66,7 +66,7 @@ func TestMockConnection_SendErr(t *testing.T) {
 	mc.SendErr = assert.AnError
 
 	assert.Error(t, mc.SendPodCreated("pod-1", 1, "", ""))
-	assert.Error(t, mc.SendPodTerminated("pod-1", 0, ""))
+	assert.Error(t, mc.SendPodTerminated("pod-1", 0, "", "completed"))
 	assert.Error(t, mc.SendError("pod-1", "", ""))
 	assert.Error(t, mc.SendAgentStatus("pod-1", ""))
 	assert.Error(t, mc.SendMessage(&runnerv1.RunnerMessage{}))

--- a/runner/internal/client/pod_command_queue.go
+++ b/runner/internal/client/pod_command_queue.go
@@ -1,0 +1,79 @@
+package client
+
+import (
+	"sync"
+
+	"github.com/anthropics/agentsmesh/runner/internal/logger"
+)
+
+// PodCommandQueue dispatches commands per pod sequentially.
+// Each pod_key gets a dedicated buffered channel and worker goroutine.
+// Different pods run concurrently; same pod's commands execute in order.
+//
+// This eliminates race conditions between dependent commands (e.g., create_pod
+// must complete before create_autopilot can find the pod in the store).
+type PodCommandQueue struct {
+	queues sync.Map     // map[string]chan func()
+	wg     sync.WaitGroup
+}
+
+// NewPodCommandQueue creates a new per-pod command queue.
+func NewPodCommandQueue() *PodCommandQueue {
+	return &PodCommandQueue{}
+}
+
+// podQueueSize is the buffer size for per-pod command channels.
+// 16 is generous — a pod rarely has more than a few commands in flight.
+const podQueueSize = 16
+
+// Enqueue sends a command to the pod's queue for sequential execution.
+// The worker goroutine is lazily created on first enqueue for each pod.
+// This method never blocks (buffered channel).
+func (q *PodCommandQueue) Enqueue(podKey string, fn func()) {
+	ch := q.getOrCreate(podKey)
+	ch <- fn
+}
+
+// getOrCreate returns the channel for a pod, creating a worker if needed.
+func (q *PodCommandQueue) getOrCreate(podKey string) chan func() {
+	if v, ok := q.queues.Load(podKey); ok {
+		return v.(chan func())
+	}
+	ch := make(chan func(), podQueueSize)
+	if actual, loaded := q.queues.LoadOrStore(podKey, ch); loaded {
+		// Another goroutine created it first — use theirs.
+		return actual.(chan func())
+	}
+	// We won the race — start worker for this pod.
+	q.wg.Add(1)
+	go func() {
+		defer q.wg.Done()
+		for fn := range ch {
+			q.safeExec(fn)
+		}
+	}()
+	return ch
+}
+
+// safeExec runs fn with panic recovery so one bad command doesn't kill the worker.
+func (q *PodCommandQueue) safeExec(fn func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.GRPC().Error("Panic in pod command", "panic", r)
+		}
+	}()
+	fn()
+}
+
+// Remove closes and removes a pod's queue after the pod is fully terminated.
+// Any pending commands in the channel will be drained by the worker before it exits.
+func (q *PodCommandQueue) Remove(podKey string) {
+	if v, ok := q.queues.LoadAndDelete(podKey); ok {
+		close(v.(chan func()))
+	}
+}
+
+// Wait waits for all pod workers to finish (used during shutdown).
+func (q *PodCommandQueue) Wait() {
+	q.wg.Wait()
+}

--- a/runner/internal/client/pod_command_queue_test.go
+++ b/runner/internal/client/pod_command_queue_test.go
@@ -1,0 +1,225 @@
+package client
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestPodCommandQueue_SequentialPerPod(t *testing.T) {
+	q := NewPodCommandQueue()
+	defer q.Wait()
+
+	var order []string
+	var mu sync.Mutex
+	done := make(chan struct{})
+
+	// Enqueue two commands for the same pod — must execute in order.
+	q.Enqueue("pod-1", func() {
+		time.Sleep(50 * time.Millisecond) // simulate slow create_pod
+		mu.Lock()
+		order = append(order, "create_pod")
+		mu.Unlock()
+	})
+	q.Enqueue("pod-1", func() {
+		mu.Lock()
+		order = append(order, "create_autopilot")
+		mu.Unlock()
+		close(done)
+	})
+
+	<-done
+	q.Remove("pod-1")
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(order) != 2 || order[0] != "create_pod" || order[1] != "create_autopilot" {
+		t.Errorf("Expected [create_pod, create_autopilot], got %v", order)
+	}
+}
+
+func TestPodCommandQueue_LongChainOrder(t *testing.T) {
+	q := NewPodCommandQueue()
+
+	var order []int
+	var mu sync.Mutex
+	const n = 10
+
+	for i := 0; i < n; i++ {
+		i := i
+		q.Enqueue("pod-1", func() {
+			mu.Lock()
+			order = append(order, i)
+			mu.Unlock()
+		})
+	}
+
+	q.Remove("pod-1")
+	q.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(order) != n {
+		t.Fatalf("Expected %d commands, got %d", n, len(order))
+	}
+	for i := 0; i < n; i++ {
+		if order[i] != i {
+			t.Errorf("Command %d executed at position %d", i, order[i])
+		}
+	}
+}
+
+func TestPodCommandQueue_ConcurrentAcrossPods(t *testing.T) {
+	q := NewPodCommandQueue()
+	defer q.Wait()
+
+	var concurrent atomic.Int32
+	var maxConcurrent atomic.Int32
+	var wg sync.WaitGroup
+
+	for i := 0; i < 5; i++ {
+		podKey := fmt.Sprintf("pod-%d", i)
+		wg.Add(1)
+		q.Enqueue(podKey, func() {
+			defer wg.Done()
+			cur := concurrent.Add(1)
+			for {
+				old := maxConcurrent.Load()
+				if cur <= old || maxConcurrent.CompareAndSwap(old, cur) {
+					break
+				}
+			}
+			time.Sleep(50 * time.Millisecond)
+			concurrent.Add(-1)
+		})
+	}
+
+	wg.Wait()
+	for i := 0; i < 5; i++ {
+		q.Remove(fmt.Sprintf("pod-%d", i))
+	}
+
+	if maxConcurrent.Load() < 2 {
+		t.Errorf("Expected concurrent execution across pods, max was %d", maxConcurrent.Load())
+	}
+}
+
+func TestPodCommandQueue_RemoveDrainsRemaining(t *testing.T) {
+	q := NewPodCommandQueue()
+
+	var count atomic.Int32
+
+	q.Enqueue("pod-1", func() { count.Add(1) })
+	q.Enqueue("pod-1", func() { count.Add(1) })
+	q.Enqueue("pod-1", func() { count.Add(1) })
+
+	q.Remove("pod-1")
+	q.Wait()
+
+	if count.Load() != 3 {
+		t.Errorf("Expected 3 commands executed, got %d", count.Load())
+	}
+}
+
+func TestPodCommandQueue_DoubleRemoveNoPanic(t *testing.T) {
+	q := NewPodCommandQueue()
+
+	q.Enqueue("pod-1", func() {})
+	q.Remove("pod-1")
+	q.Remove("pod-1") // should not panic
+	q.Wait()
+}
+
+func TestPodCommandQueue_EnqueueAfterRemove(t *testing.T) {
+	// Simulates session recovery: same pod_key reused after previous instance was removed.
+	q := NewPodCommandQueue()
+
+	var count atomic.Int32
+
+	// First lifecycle
+	q.Enqueue("pod-1", func() { count.Add(1) })
+	q.Remove("pod-1")
+	q.Wait()
+
+	if count.Load() != 1 {
+		t.Fatalf("First lifecycle: expected 1, got %d", count.Load())
+	}
+
+	// Second lifecycle — new worker should be created for the same pod_key
+	q.Enqueue("pod-1", func() { count.Add(1) })
+	q.Remove("pod-1")
+	q.Wait()
+
+	if count.Load() != 2 {
+		t.Errorf("Second lifecycle: expected 2, got %d", count.Load())
+	}
+}
+
+func TestPodCommandQueue_PanicRecovery(t *testing.T) {
+	// A panic in one command must not kill the worker or block subsequent commands.
+	q := NewPodCommandQueue()
+
+	var executed atomic.Int32
+	done := make(chan struct{})
+
+	q.Enqueue("pod-1", func() {
+		executed.Add(1)
+		panic("simulated crash")
+	})
+	q.Enqueue("pod-1", func() {
+		executed.Add(1)
+		close(done)
+	})
+
+	select {
+	case <-done:
+		// second command executed despite first panicking
+	case <-time.After(3 * time.Second):
+		t.Fatal("Second command was not executed after panic in first")
+	}
+
+	q.Remove("pod-1")
+	q.Wait()
+
+	if executed.Load() != 2 {
+		t.Errorf("Expected 2 commands executed, got %d", executed.Load())
+	}
+}
+
+func TestPodCommandQueue_EmptyWaitNonBlocking(t *testing.T) {
+	q := NewPodCommandQueue()
+	// Wait on a queue with no pods should return immediately
+	done := make(chan struct{})
+	go func() {
+		q.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Wait() blocked on empty queue")
+	}
+}
+
+func TestPodCommandQueue_ConcurrentCreateAndRemove(t *testing.T) {
+	// Race detector stress test: many pods created and removed concurrently.
+	q := NewPodCommandQueue()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		podKey := fmt.Sprintf("pod-%d", i)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			q.Enqueue(podKey, func() {
+				time.Sleep(time.Millisecond)
+			})
+			q.Enqueue(podKey, func() {})
+			q.Remove(podKey)
+		}()
+	}
+	wg.Wait()
+	q.Wait()
+}

--- a/runner/internal/client/rpc_test.go
+++ b/runner/internal/client/rpc_test.go
@@ -35,7 +35,7 @@ func (m *mockSender) getLastMsg() *runnerv1.RunnerMessage {
 // stubSender stubs SendMessage and also provides the ConnectionSender interface methods.
 // Only SendMessage is used by RPCClient.
 func (m *mockSender) SendPodCreated(string, int32, string, string) error { return nil }
-func (m *mockSender) SendPodTerminated(string, int32, string) error      { return nil }
+func (m *mockSender) SendPodTerminated(string, int32, string, string) error      { return nil }
 func (m *mockSender) SendPodInitProgress(string, string, int32, string) error {
 	return nil
 }

--- a/runner/internal/runner/handler_events.go
+++ b/runner/internal/runner/handler_events.go
@@ -106,7 +106,8 @@ func (h *RunnerMessageHandler) createExitHandler(podKey string) func(int) {
 			h.runner.RemoveAutopilot(ac.Key())
 		}
 
-		var earlyOutput string
+		var errorMsg string
+		var podStatus string
 
 		pod.SetStatus(PodStatusStopped)
 
@@ -119,27 +120,26 @@ func (h *RunnerMessageHandler) createExitHandler(podKey string) func(int) {
 		// when closed, causing silent data loss).
 		if pod.Aggregator != nil {
 			pod.Aggregator.Stop()
-
-			// Retrieve any early output that was buffered before the relay connected.
-			// This captures error messages from fast-exiting processes.
-			// Must be outside PTYLogger check — PTYLogger is nil in most
-			// production environments, but early output must still be captured.
-			if buf := pod.Aggregator.DrainEarlyBuffer(); len(buf) > 0 {
-				earlyOutput = string(buf)
-				log.Info("Captured early output from fast-exiting process",
-					"pod_key", podKey, "bytes", len(buf))
-			}
 		}
 		if pod.PTYLogger != nil {
 			pod.PTYLogger.Close()
 		}
 
-		// If a PTY error was recorded (e.g., disk full causing I/O error),
-		// use it as the error message so the backend sets error status.
-		if ptyErr := pod.GetPTYError(); ptyErr != "" && earlyOutput == "" {
-			earlyOutput = ptyErr
-			log.Info("Using stored PTY error as termination reason",
-				"pod_key", podKey, "error", ptyErr)
+		// Runner owns the status decision.
+		// Exit code conventions (Unix):
+		//   0       = success → completed
+		//   1-127   = process-reported error → error
+		//   >= 128  = killed by signal (128 + signal number) → completed
+		podStatus = "completed"
+		if exitCode > 0 && exitCode < 128 {
+			podStatus = "error"
+			errorMsg = fmt.Sprintf("process exited with code %d", exitCode)
+		}
+
+		// PTY error takes precedence (e.g., disk full causing I/O error).
+		if ptyErr := pod.GetPTYError(); ptyErr != "" {
+			podStatus = "error"
+			errorMsg = ptyErr
 		}
 
 		pod.DisconnectRelay()
@@ -160,10 +160,9 @@ func (h *RunnerMessageHandler) createExitHandler(podKey string) func(int) {
 			agentMon.UnregisterPod(podKey)
 		}
 
-		// Include early output or PTY error in the termination event so the
-		// backend can display why the process failed and set error status.
+		// Send termination event with Runner-decided status.
 		if h.conn != nil {
-			if err := h.conn.SendPodTerminated(podKey, int32(exitCode), earlyOutput); err != nil {
+			if err := h.conn.SendPodTerminated(podKey, int32(exitCode), errorMsg, podStatus); err != nil {
 				log.Error("Failed to send pod terminated event", "error", err)
 			}
 		}

--- a/runner/internal/runner/message_handler.go
+++ b/runner/internal/runner/message_handler.go
@@ -273,17 +273,8 @@ func (h *RunnerMessageHandler) OnTerminatePod(req client.TerminatePodRequest) er
 	// Stop aggregator BEFORE disconnecting relay, so the final flush
 	// can still be sent through the relay (matches createExitHandler order).
 	// Close PTYLogger AFTER Aggregator.Stop() to avoid silent data loss.
-	var earlyOutput string
 	if pod.Aggregator != nil {
 		pod.Aggregator.Stop()
-
-		// Drain early output buffered before relay connected (matches createExitHandler).
-		// Without this, error messages from fast-exiting processes are silently lost.
-		if buf := pod.Aggregator.DrainEarlyBuffer(); len(buf) > 0 {
-			earlyOutput = string(buf)
-			log.Info("Drained early output on terminate",
-				"pod_key", req.PodKey, "bytes", len(buf))
-		}
 	}
 	if pod.PTYLogger != nil {
 		pod.PTYLogger.Close()
@@ -305,10 +296,16 @@ func (h *RunnerMessageHandler) OnTerminatePod(req client.TerminatePodRequest) er
 		agentMon.UnregisterPod(req.PodKey)
 	}
 
-	// Include early output in the termination event so the backend can
-	// display why the process failed (matches createExitHandler behavior).
+	// Server-initiated termination: Runner decides final status.
+	// Default is completed, unless a PTY error was recorded during runtime.
+	var errorMsg string
+	podStatus := "completed"
+	if ptyErr := pod.GetPTYError(); ptyErr != "" {
+		podStatus = "error"
+		errorMsg = ptyErr
+	}
 	if h.conn != nil {
-		if err := h.conn.SendPodTerminated(req.PodKey, 0, earlyOutput); err != nil {
+		if err := h.conn.SendPodTerminated(req.PodKey, 0, errorMsg, podStatus); err != nil {
 			log.Error("Failed to send pod terminated event", "error", err)
 		}
 	}

--- a/runner/internal/runner/message_handler_events_test.go
+++ b/runner/internal/runner/message_handler_events_test.go
@@ -55,7 +55,7 @@ func TestSendPodTerminated(t *testing.T) {
 
 	// Production code calls h.conn.SendPodTerminated directly (with exitCode and earlyOutput).
 	// Test the same path used by createExitHandler and OnTerminatePod.
-	if err := handler.conn.SendPodTerminated("pod-1", 0, ""); err != nil {
+	if err := handler.conn.SendPodTerminated("pod-1", 0, "", "completed"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -175,7 +175,7 @@ func TestCreatePTYErrorHandler(t *testing.T) {
 	pod := &Pod{
 		ID:         "pty-error-pod",
 		Status:     PodStatusRunning,
-		Aggregator: aggregator.NewSmartAggregator(nil, nil),
+		Aggregator: aggregator.NewSmartAggregator(nil),
 	}
 
 	ptyErrorHandler := handler.createPTYErrorHandler("pty-error-pod", pod)
@@ -292,7 +292,7 @@ func TestCreateExitHandler_EarlyOutputTakesPriority(t *testing.T) {
 	pod := &Pod{
 		ID:         "priority-pod",
 		Status:     PodStatusRunning,
-		Aggregator: aggregator.NewSmartAggregator(nil, nil),
+		Aggregator: aggregator.NewSmartAggregator(nil),
 	}
 	pod.SetPTYError("PTY read error: something")
 	store.Put("priority-pod", pod)
@@ -300,9 +300,7 @@ func TestCreateExitHandler_EarlyOutputTakesPriority(t *testing.T) {
 	exitHandler := handler.createExitHandler("priority-pod")
 	exitHandler(1)
 
-	// When early output is empty (relay was connected), PTY error should be used.
-	// The aggregator's DrainEarlyBuffer returns empty because relay was "connected"
-	// (no early buffer data), so PTY error should be the fallback.
+	// When there is no early output, PTY error should be used as the fallback.
 	events := mockConn.GetEvents()
 	for _, e := range events {
 		if e.Type == client.MsgTypePodTerminated {

--- a/runner/internal/runner/message_handler_regression_test.go
+++ b/runner/internal/runner/message_handler_regression_test.go
@@ -11,42 +11,9 @@ import (
 // Regression tests for issues found during deep review rounds 4-5.
 // Each test targets a specific bug fix to prevent future regressions.
 
-// --- H1: OnTerminatePod must call DrainEarlyBuffer ---
-// Bug: OnTerminatePod previously skipped DrainEarlyBuffer(), causing early
-// output (error messages from fast-exiting processes) to be silently lost
-// when pods were terminated via server request.
+// --- OnTerminatePod with nil aggregator must not panic ---
 
-func TestOnTerminatePod_DrainEarlyBuffer(t *testing.T) {
-	store := NewInMemoryPodStore()
-	mockConn := client.NewMockConnection()
-	runner := &Runner{cfg: &config.Config{}}
-	handler := NewRunnerMessageHandler(runner, store, mockConn)
-
-	// Create aggregator without relay — output goes to early buffer.
-	agg := aggregator.NewSmartAggregator(nil, nil)
-	agg.Write([]byte("error: command not found\n"))
-	agg.Write([]byte("exit status 127\n"))
-
-	pod := &Pod{
-		PodKey:     "drain-pod",
-		Status:     PodStatusRunning,
-		Aggregator: agg,
-	}
-	store.Put("drain-pod", pod)
-
-	err := handler.OnTerminatePod(client.TerminatePodRequest{PodKey: "drain-pod"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	// After termination, early buffer should have been drained (consumed).
-	// A second drain should return nil, proving the first drain happened.
-	if buf := agg.DrainEarlyBuffer(); buf != nil {
-		t.Errorf("early buffer should have been drained during termination, got %d bytes", len(buf))
-	}
-}
-
-func TestOnTerminatePod_DrainEarlyBuffer_NilAggregator(t *testing.T) {
+func TestOnTerminatePod_NilAggregator(t *testing.T) {
 	store := NewInMemoryPodStore()
 	mockConn := client.NewMockConnection()
 	runner := &Runner{cfg: &config.Config{}}
@@ -59,37 +26,6 @@ func TestOnTerminatePod_DrainEarlyBuffer_NilAggregator(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-}
-
-// Verify createExitHandler also drains (was already correct, but test for symmetry).
-func TestCreateExitHandler_DrainEarlyBuffer(t *testing.T) {
-	store := NewInMemoryPodStore()
-	mockConn := client.NewMockConnection()
-	runner := &Runner{cfg: &config.Config{}}
-	handler := NewRunnerMessageHandler(runner, store, mockConn)
-
-	agg := aggregator.NewSmartAggregator(nil, nil)
-	agg.Write([]byte("fatal: not a git repository\n"))
-
-	pod := &Pod{
-		PodKey:     "exit-drain-pod",
-		Status:     PodStatusRunning,
-		Aggregator: agg,
-	}
-	store.Put("exit-drain-pod", pod)
-
-	exitHandler := handler.createExitHandler("exit-drain-pod")
-	exitHandler(1)
-
-	// DrainEarlyBuffer was called during exit handler. A second drain
-	// returns nil because earlyDone is already set (idempotent).
-	if buf := agg.DrainEarlyBuffer(); buf != nil {
-		t.Errorf("early buffer should have been drained during exit, got %d bytes", len(buf))
-	}
-
-	// Verify terminated event was sent (content depends on async Route timing,
-	// so we only verify the event exists — not its error message content).
-	assertHasEvent(t, mockConn, client.MsgTypePodTerminated)
 }
 
 // --- M1: OnTerminalResize must check pod.Terminal != nil ---
@@ -191,7 +127,7 @@ func TestConcurrentExitAndTerminate_OnlyOneCleanup(t *testing.T) {
 	runner := &Runner{cfg: &config.Config{}}
 	handler := NewRunnerMessageHandler(runner, store, mockConn)
 
-	agg := aggregator.NewSmartAggregator(nil, nil)
+	agg := aggregator.NewSmartAggregator(nil)
 	store.Put("race-pod", &Pod{
 		PodKey:     "race-pod",
 		Status:     PodStatusRunning,

--- a/runner/internal/runner/pod_builder_build.go
+++ b/runner/internal/runner/pod_builder_build.go
@@ -108,7 +108,7 @@ func (b *PodBuilder) Build(ctx context.Context) (*Pod, error) {
 	}
 
 	// Create SmartAggregator for adaptive frame rate output
-	agg := aggregator.NewSmartAggregator(nil, nil,
+	agg := aggregator.NewSmartAggregator(nil,
 		aggregator.WithFullRedrawThrottling(),
 	)
 

--- a/runner/internal/runner/pod_output_test.go
+++ b/runner/internal/runner/pod_output_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestCreateOutputHandler_DetectorPanicIsolation(t *testing.T) {
 	// Setup: Pod with aggregator but no detector/VT.
-	agg := aggregator.NewSmartAggregator(nil, nil)
+	agg := aggregator.NewSmartAggregator(nil)
 
 	pod := &Pod{
 		PodKey:     "panic-pod",
@@ -55,7 +55,7 @@ func TestCreateOutputHandler_NilAggregator_NoPanic(t *testing.T) {
 func TestCreateOutputHandler_NilVTAndDetector(t *testing.T) {
 	// Normal path: no VirtualTerminal, no StateDetector.
 	// Aggregator receives all data.
-	agg := aggregator.NewSmartAggregator(nil, nil)
+	agg := aggregator.NewSmartAggregator(nil)
 
 	pod := &Pod{
 		PodKey:     "simple-pod",

--- a/runner/internal/runner/recovery.go
+++ b/runner/internal/runner/recovery.go
@@ -81,7 +81,7 @@ func (r *Runner) recoverSingleSession(state *poddaemon.PodDaemonState) (*Pod, er
 	virtualTerm := vt.NewVirtualTerminal(state.Cols, state.Rows, state.VTHistoryLimit)
 	virtualTerm.SetOSCHandler(r.messageHandler.createOSCHandler(state.PodKey))
 
-	agg := aggregator.NewSmartAggregator(nil, nil,
+	agg := aggregator.NewSmartAggregator(nil,
 		aggregator.WithFullRedrawThrottling(),
 	)
 

--- a/runner/internal/terminal/aggregator/output_router.go
+++ b/runner/internal/terminal/aggregator/output_router.go
@@ -3,15 +3,7 @@ package aggregator
 
 import (
 	"sync"
-	"sync/atomic"
-	"time"
-
-	"github.com/anthropics/agentsmesh/runner/internal/logger"
 )
-
-// earlyBufferMaxSize is the maximum size for buffering output before any callback is set.
-// 64KB is generous enough for error messages and early startup output.
-const earlyBufferMaxSize = 64 * 1024
 
 // RelayWriter abstracts the relay client for output routing.
 // Route() checks IsConnected() at call time, eliminating stale-closure races.
@@ -20,54 +12,27 @@ type RelayWriter interface {
 	IsConnected() bool
 }
 
-// OutputRouter routes terminal output to appropriate destinations.
-// Supports both legacy gRPC output and modern Relay WebSocket output.
+// OutputRouter routes terminal output to the Relay WebSocket destination.
 //
-// Priority: Relay > gRPC (when Relay is connected, gRPC is not used)
-// When Relay is registered but disconnected, output falls back to gRPC automatically.
-//
-// Early buffer: when no callback is set (during the window between pod creation
-// and relay subscription), output is buffered internally. The buffer is replayed
-// when a callback is first set, ensuring no output is lost during startup.
+// When Relay is connected, output is sent via WebSocket.
+// When Relay is not connected (no subscriber, or during reconnect), output is
+// silently dropped — this is expected behavior since no one is observing the terminal.
 type OutputRouter struct {
-	mu      sync.RWMutex
-	onFlush func([]byte)  // gRPC fallback callback
-	relay   RelayWriter   // Relay client reference (checked at Route time)
-
-	// Early buffer: captures output before any callback is set.
-	// Once a callback is set and the buffer is drained, no further buffering occurs.
-	earlyBuffer []byte
-	earlyDone   bool // true after buffer has been drained (prevents re-buffering)
-
-	// Rate limiting for "early buffer full" warning to prevent log flooding.
-	// Accessed atomically outside the mutex for lock-free fast path.
-	lastDropWarnUnixNano atomic.Int64
-	droppedSinceLastWarn atomic.Int64
+	mu    sync.RWMutex
+	relay RelayWriter // Relay client reference (checked at Route time)
 }
 
 // NewOutputRouter creates a new output router.
-//
-// Parameters:
-// - onFlush: legacy gRPC callback (always set)
-func NewOutputRouter(onFlush func([]byte)) *OutputRouter {
-	return &OutputRouter{
-		onFlush: onFlush,
-	}
+func NewOutputRouter() *OutputRouter {
+	return &OutputRouter{}
 }
 
-// dropWarnInterval limits "early buffer full" warnings to at most once per 5 seconds.
-// Without this, high-frequency terminal output can flood the logger with thousands
-// of warnings per second, causing extreme pressure on slog/fmt and potentially
-// triggering runtime crashes (e.g., SIGBUS on ARM64 via asyncPreempt).
-const dropWarnInterval = 5 * time.Second
-
-// Route sends data to the appropriate destination.
-// Priority: Relay (connected) > gRPC > early buffer
+// Route sends data to the Relay if connected, otherwise drops it.
 //
-// Unlike callback-based routing, this checks relay.IsConnected() at call time,
-// so stale closures from old relay clients cannot intercept output.
-// When relay is registered but disconnected (e.g., during reconnect), output
-// automatically falls back to gRPC — no silent data loss.
+// This checks relay.IsConnected() at call time so stale closures from old
+// relay clients cannot intercept output. When relay is disconnected (e.g.,
+// during reconnect or no subscriber), output is dropped — this is fine
+// because no one is observing the terminal.
 //
 // This method is safe to call from any goroutine.
 func (r *OutputRouter) Route(data []byte) {
@@ -75,125 +40,24 @@ func (r *OutputRouter) Route(data []byte) {
 		return
 	}
 
-	// Fast path: read fields under RLock
 	r.mu.RLock()
 	relay := r.relay
-	onFlush := r.onFlush
 	r.mu.RUnlock()
 
-	// Priority: Relay mode (only when connected) > Legacy gRPC mode
 	if relay != nil && relay.IsConnected() {
-		if err := relay.SendOutput(data); err != nil {
-			if onFlush != nil {
-				onFlush(data)
-			}
-		}
-		return
+		_ = relay.SendOutput(data)
 	}
-	if onFlush != nil {
-		onFlush(data)
-		return
-	}
-
-	// No callback set — buffer for later replay
-	r.mu.Lock()
-	// Re-check under write lock (fields may have been set between RUnlock and Lock)
-	if r.relay != nil && r.relay.IsConnected() {
-		rl := r.relay
-		r.mu.Unlock()
-		if err := rl.SendOutput(data); err == nil {
-			return
-		}
-		// Relay send failed — try gRPC fallback (re-acquire lock to read onFlush)
-		r.mu.RLock()
-		fn := r.onFlush
-		r.mu.RUnlock()
-		if fn != nil {
-			fn(data)
-		}
-		return
-	}
-	if r.onFlush != nil {
-		fn := r.onFlush
-		r.mu.Unlock()
-		fn(data)
-		return
-	}
-	if !r.earlyDone {
-		remaining := earlyBufferMaxSize - len(r.earlyBuffer)
-		if remaining > 0 {
-			if len(data) > remaining {
-				data = data[:remaining]
-			}
-			r.earlyBuffer = append(r.earlyBuffer, data...)
-		} else {
-			// Buffer full — track drops and emit a rate-limited warning.
-			// Logging is done outside the lock to avoid holding it during I/O.
-			r.droppedSinceLastWarn.Add(1)
-		}
-	}
-	r.mu.Unlock()
-
-	// Rate-limited warning outside the lock (lock-free fast path via atomics)
-	r.emitDropWarning(len(data))
-}
-
-// emitDropWarning emits a rate-limited warning when output is being dropped.
-// Uses atomics for a lock-free fast path; only acquires the logger when actually logging.
-func (r *OutputRouter) emitDropWarning(bytes int) {
-	dropped := r.droppedSinceLastWarn.Load()
-	if dropped == 0 {
-		return
-	}
-
-	now := time.Now().UnixNano()
-	last := r.lastDropWarnUnixNano.Load()
-	if now-last < int64(dropWarnInterval) {
-		return
-	}
-
-	// CAS to prevent concurrent goroutines from all logging at once
-	if !r.lastDropWarnUnixNano.CompareAndSwap(last, now) {
-		return
-	}
-
-	count := r.droppedSinceLastWarn.Swap(0)
-	logger.Terminal().Warn("OutputRouter: early buffer full, dropping output",
-		"dropped_chunks", count, "last_bytes", bytes)
+	// No relay or not connected: output is dropped.
+	// This is expected — terminal output is only meaningful when someone is watching.
 }
 
 // SetRelayClient sets the relay client reference.
-// If there is buffered early output, it is replayed through the client immediately.
-// Pass nil to disable relay output and fall back to gRPC.
+// Pass nil to clear the relay client.
 // Thread-safe.
 func (r *OutputRouter) SetRelayClient(client RelayWriter) {
 	r.mu.Lock()
 	r.relay = client
-	buffered := r.drainEarlyBufferLocked()
 	r.mu.Unlock()
-
-	// Replay buffered data outside the lock to avoid deadlocks
-	if client != nil && client.IsConnected() && len(buffered) > 0 {
-		logger.Terminal().Info("OutputRouter: replaying early buffer via relay", "bytes", len(buffered))
-		if err := client.SendOutput(buffered); err != nil {
-			logger.Terminal().Warn("OutputRouter: failed to replay early buffer via relay, trying gRPC", "error", err)
-			r.mu.RLock()
-			fn := r.onFlush
-			r.mu.RUnlock()
-			if fn != nil {
-				fn(buffered)
-			}
-		}
-	} else if client == nil && len(buffered) > 0 {
-		// Clearing relay with buffered data — send via gRPC
-		r.mu.RLock()
-		fn := r.onFlush
-		r.mu.RUnlock()
-		if fn != nil {
-			logger.Terminal().Info("OutputRouter: replaying early buffer via gRPC (relay cleared)", "bytes", len(buffered))
-			fn(buffered)
-		}
-	}
 }
 
 // HasRelayClient returns whether a relay client is configured.
@@ -201,41 +65,4 @@ func (r *OutputRouter) HasRelayClient() bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.relay != nil
-}
-
-// SetOnFlush updates the gRPC callback.
-// If there is buffered early output, it is replayed through the new callback immediately.
-func (r *OutputRouter) SetOnFlush(fn func([]byte)) {
-	r.mu.Lock()
-	r.onFlush = fn
-	buffered := r.drainEarlyBufferLocked()
-	r.mu.Unlock()
-
-	// Replay buffered data outside the lock
-	if fn != nil && len(buffered) > 0 {
-		logger.Terminal().Info("OutputRouter: replaying early buffer via gRPC", "bytes", len(buffered))
-		fn(buffered)
-	}
-}
-
-// DrainEarlyBuffer returns and clears any buffered early output.
-// This is used by the exit handler to retrieve output that was never sent
-// (e.g., when the process exits before the relay connects).
-// After calling this, further output will not be buffered.
-func (r *OutputRouter) DrainEarlyBuffer() []byte {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return r.drainEarlyBufferLocked()
-}
-
-// drainEarlyBufferLocked returns and clears the early buffer. Must be called with lock held.
-func (r *OutputRouter) drainEarlyBufferLocked() []byte {
-	if len(r.earlyBuffer) == 0 {
-		r.earlyDone = true
-		return nil
-	}
-	buf := r.earlyBuffer
-	r.earlyBuffer = nil
-	r.earlyDone = true
-	return buf
 }

--- a/runner/internal/terminal/aggregator/output_router_test.go
+++ b/runner/internal/terminal/aggregator/output_router_test.go
@@ -1,7 +1,6 @@
 package aggregator
 
 import (
-	"bytes"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -13,6 +12,7 @@ type mockRelayWriter struct {
 	data      []byte
 	connected atomic.Bool
 	sendErr   error
+	calls     atomic.Int32
 }
 
 func newMockRelayWriter(connected bool) *mockRelayWriter {
@@ -25,6 +25,7 @@ func (m *mockRelayWriter) SendOutput(data []byte) error {
 	if m.sendErr != nil {
 		return m.sendErr
 	}
+	m.calls.Add(1)
 	m.mu.Lock()
 	m.data = append(m.data, data...)
 	m.mu.Unlock()
@@ -41,255 +42,123 @@ func (m *mockRelayWriter) getData() []byte {
 	return append([]byte(nil), m.data...)
 }
 
-func TestOutputRouter_NewOutputRouter(t *testing.T) {
-	var received []byte
-	or := NewOutputRouter(func(data []byte) {
-		received = data
-	})
+func (m *mockRelayWriter) sendCount() int32 {
+	return m.calls.Load()
+}
 
+func TestOutputRouter_New(t *testing.T) {
+	or := NewOutputRouter()
 	if or == nil {
 		t.Fatal("NewOutputRouter should not return nil")
-		return
 	}
-
-	// Route should use onFlush when no relay
-	or.Route([]byte("test"))
-	if string(received) != "test" {
-		t.Errorf("Expected 'test', got '%s'", received)
+	if or.HasRelayClient() {
+		t.Error("should not have relay initially")
 	}
 }
 
 func TestOutputRouter_Route_EmptyData(t *testing.T) {
-	var callCount int
-	or := NewOutputRouter(func(data []byte) {
-		callCount++
-	})
+	or := NewOutputRouter()
+	relay := newMockRelayWriter(true)
+	or.SetRelayClient(relay)
 
 	or.Route(nil)
 	or.Route([]byte{})
 
-	if callCount != 0 {
-		t.Errorf("Route should not call callback for empty data, called %d times", callCount)
+	if len(relay.getData()) != 0 {
+		t.Error("Route should not send empty data")
 	}
 }
 
-func TestOutputRouter_Route_PrefersRelay(t *testing.T) {
-	var grpcData []byte
-	or := NewOutputRouter(func(data []byte) {
-		grpcData = data
-	})
-
-	// Set relay client (connected)
+func TestOutputRouter_Route_SendsToRelay(t *testing.T) {
+	or := NewOutputRouter()
 	relay := newMockRelayWriter(true)
 	or.SetRelayClient(relay)
 
-	or.Route([]byte("test"))
-
-	// Should use relay, not gRPC
-	if grpcData != nil {
-		t.Error("gRPC should not be called when relay is connected")
-	}
-	if string(relay.getData()) != "test" {
-		t.Errorf("Relay should receive data, got '%s'", relay.getData())
+	or.Route([]byte("hello"))
+	if string(relay.getData()) != "hello" {
+		t.Errorf("Expected 'hello', got '%s'", relay.getData())
 	}
 }
 
-func TestOutputRouter_Route_FallbackToGRPC_WhenDisconnected(t *testing.T) {
-	var grpcData []byte
-	or := NewOutputRouter(func(data []byte) {
-		grpcData = data
-	})
+func TestOutputRouter_Route_DropsWhenNoRelay(t *testing.T) {
+	or := NewOutputRouter()
+	// No relay set — data should be silently dropped (no panic)
+	or.Route([]byte("dropped"))
+}
 
-	// Set relay client but disconnected
-	relay := newMockRelayWriter(false)
+func TestOutputRouter_Route_DropsWhenDisconnected(t *testing.T) {
+	or := NewOutputRouter()
+	relay := newMockRelayWriter(false) // disconnected
 	or.SetRelayClient(relay)
 
-	or.Route([]byte("test"))
-
-	// Should fall back to gRPC when relay is disconnected
-	if string(grpcData) != "test" {
-		t.Errorf("Should fallback to gRPC when relay disconnected, got '%s'", grpcData)
-	}
+	or.Route([]byte("dropped"))
 	if len(relay.getData()) > 0 {
-		t.Error("Disconnected relay should not receive data")
-	}
-}
-
-func TestOutputRouter_Route_FallbackToGRPC_WhenCleared(t *testing.T) {
-	var grpcData []byte
-	or := NewOutputRouter(func(data []byte) {
-		grpcData = data
-	})
-
-	// Set then clear relay
-	relay := newMockRelayWriter(true)
-	or.SetRelayClient(relay)
-	or.SetRelayClient(nil)
-
-	or.Route([]byte("test"))
-
-	if string(grpcData) != "test" {
-		t.Errorf("Should fallback to gRPC, got '%s'", grpcData)
+		t.Error("disconnected relay should not receive data")
 	}
 }
 
 func TestOutputRouter_SetRelayClient(t *testing.T) {
-	or := NewOutputRouter(nil)
-
-	if or.HasRelayClient() {
-		t.Error("Should not have relay initially")
-	}
+	or := NewOutputRouter()
 
 	relay := newMockRelayWriter(true)
 	or.SetRelayClient(relay)
-
 	if !or.HasRelayClient() {
-		t.Error("Should have relay after SetRelayClient")
+		t.Error("should have relay after SetRelayClient")
 	}
 
 	or.SetRelayClient(nil)
-
 	if or.HasRelayClient() {
-		t.Error("Should not have relay after setting nil")
+		t.Error("should not have relay after clearing")
 	}
 }
 
-func TestOutputRouter_HasRelayClient(t *testing.T) {
-	or := NewOutputRouter(nil)
-
-	if or.HasRelayClient() {
-		t.Error("HasRelayClient should be false initially")
-	}
-
+func TestOutputRouter_RelayDisconnectAndReconnect(t *testing.T) {
+	or := NewOutputRouter()
 	relay := newMockRelayWriter(true)
 	or.SetRelayClient(relay)
 
-	if !or.HasRelayClient() {
-		t.Error("HasRelayClient should be true after setting relay")
+	// Connected — data goes to relay
+	or.Route([]byte("a"))
+	if string(relay.getData()) != "a" {
+		t.Errorf("Expected 'a', got '%s'", relay.getData())
+	}
+
+	// Disconnect — data is dropped
+	relay.connected.Store(false)
+	or.Route([]byte("dropped"))
+	if string(relay.getData()) != "a" {
+		t.Error("disconnected relay should not receive new data")
+	}
+
+	// Reconnect — data flows again
+	relay.connected.Store(true)
+	or.Route([]byte("b"))
+	if string(relay.getData()) != "ab" {
+		t.Errorf("Expected 'ab', got '%s'", relay.getData())
 	}
 }
 
-func TestOutputRouter_SetOnFlush(t *testing.T) {
-	or := NewOutputRouter(nil)
+func TestOutputRouter_StaleClientReplacement(t *testing.T) {
+	or := NewOutputRouter()
 
-	var received []byte
-	or.SetOnFlush(func(data []byte) {
-		received = data
-	})
+	oldRelay := newMockRelayWriter(true)
+	or.SetRelayClient(oldRelay)
+
+	newRelay := newMockRelayWriter(true)
+	or.SetRelayClient(newRelay)
+
+	oldRelay.connected.Store(false)
 
 	or.Route([]byte("test"))
-
-	if string(received) != "test" {
-		t.Errorf("New onFlush should be used, got '%s'", received)
-	}
-}
-
-func TestOutputRouter_NoCallbacks_BuffersEarlyOutput(t *testing.T) {
-	or := NewOutputRouter(nil)
-
-	// Should buffer data when no callbacks are set
-	or.Route([]byte("error: invalid argument\n"))
-
-	buf := or.DrainEarlyBuffer()
-	if string(buf) != "error: invalid argument\n" {
-		t.Errorf("Expected buffered early output, got '%s'", buf)
-	}
-
-	// After drain, buffer should be empty and done
-	buf2 := or.DrainEarlyBuffer()
-	if buf2 != nil {
-		t.Errorf("Expected nil after second drain, got '%s'", buf2)
-	}
-
-	// Further routes should not buffer (earlyDone=true)
-	or.Route([]byte("more data"))
-	buf3 := or.DrainEarlyBuffer()
-	if buf3 != nil {
-		t.Errorf("Expected nil for post-drain route, got '%s'", buf3)
-	}
-}
-
-func TestOutputRouter_EarlyBuffer_ReplayOnRelayConnect(t *testing.T) {
-	or := NewOutputRouter(nil)
-
-	// Buffer some early output
-	or.Route([]byte("startup "))
-	or.Route([]byte("output"))
-
-	// When relay connects, buffered data should be replayed
-	relay := newMockRelayWriter(true)
-	or.SetRelayClient(relay)
-
-	if string(relay.getData()) != "startup output" {
-		t.Errorf("Expected replayed 'startup output', got '%s'", relay.getData())
-	}
-
-	// Subsequent routes go directly through relay
-	or.Route([]byte(" live"))
-	if string(relay.getData()) != "startup output live" {
-		t.Errorf("Expected 'startup output live', got '%s'", relay.getData())
-	}
-}
-
-func TestOutputRouter_EarlyBuffer_ReplayOnFlushSet(t *testing.T) {
-	or := NewOutputRouter(nil)
-
-	// Buffer some early output
-	or.Route([]byte("buffered data"))
-
-	// When onFlush is set, buffered data should be replayed
-	var flushReceived []byte
-	or.SetOnFlush(func(data []byte) {
-		flushReceived = append(flushReceived, data...)
-	})
-
-	if string(flushReceived) != "buffered data" {
-		t.Errorf("Expected replayed 'buffered data', got '%s'", flushReceived)
-	}
-}
-
-func TestOutputRouter_EarlyBuffer_MaxSize(t *testing.T) {
-	or := NewOutputRouter(nil)
-
-	// Fill beyond max buffer size
-	bigData := bytes.Repeat([]byte("x"), earlyBufferMaxSize+1000)
-	or.Route(bigData)
-
-	buf := or.DrainEarlyBuffer()
-	if len(buf) != earlyBufferMaxSize {
-		t.Errorf("Expected buffer capped at %d, got %d", earlyBufferMaxSize, len(buf))
-	}
-}
-
-func TestOutputRouter_EarlyBuffer_NotUsedWhenCallbackSet(t *testing.T) {
-	var received []byte
-	or := NewOutputRouter(func(data []byte) {
-		received = append(received, data...)
-	})
-
-	// With onFlush set, data should go directly, not buffer
-	or.Route([]byte("direct"))
-
-	if string(received) != "direct" {
-		t.Errorf("Expected 'direct', got '%s'", received)
-	}
-
-	// Early buffer should be empty
-	buf := or.DrainEarlyBuffer()
-	if buf != nil {
-		t.Errorf("Expected nil early buffer when callback is set, got '%s'", buf)
+	if string(newRelay.getData()) != "test" {
+		t.Errorf("Expected new relay to receive 'test', got '%s'", newRelay.getData())
 	}
 }
 
 func TestOutputRouter_Concurrent(t *testing.T) {
-	// Track total bytes across ALL destinations (gRPC + relay).
-	// When a connected relay is set, data flows to relay.SendOutput instead of gRPC callback,
-	// so we must count both to verify no data is lost.
-	var totalBytes atomic.Int64
-
-	or := NewOutputRouter(func(data []byte) {
-		totalBytes.Add(int64(len(data)))
-	})
+	or := NewOutputRouter()
+	relay := newMockRelayWriter(true)
+	or.SetRelayClient(relay)
 
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
@@ -302,122 +171,15 @@ func TestOutputRouter_Concurrent(t *testing.T) {
 		}()
 	}
 
-	// Concurrent relay updates — relay also counts bytes via SendOutput
+	// Concurrent relay swaps
 	go func() {
 		for i := 0; i < 50; i++ {
-			relay := &countingRelayWriter{totalBytes: &totalBytes}
-			relay.connected.Store(true)
-			or.SetRelayClient(relay)
-			or.SetRelayClient(nil)
+			r := newMockRelayWriter(true)
+			or.SetRelayClient(r)
 		}
+		or.SetRelayClient(relay) // restore original
 	}()
 
 	wg.Wait()
-
-	got := totalBytes.Load()
-	if got != 1000 {
-		t.Errorf("Expected 1000 bytes routed, got %d", got)
-	}
-}
-
-// countingRelayWriter is a RelayWriter that adds byte counts to a shared counter.
-type countingRelayWriter struct {
-	connected  atomic.Bool
-	totalBytes *atomic.Int64
-}
-
-func (c *countingRelayWriter) SendOutput(data []byte) error {
-	c.totalBytes.Add(int64(len(data)))
-	return nil
-}
-
-func (c *countingRelayWriter) IsConnected() bool {
-	return c.connected.Load()
-}
-
-func TestOutputRouter_LargeData(t *testing.T) {
-	var received []byte
-	or := NewOutputRouter(func(data []byte) {
-		received = data
-	})
-
-	// Test with large data
-	largeData := bytes.Repeat([]byte("x"), 1024*1024) // 1MB
-	or.Route(largeData)
-
-	if len(received) != len(largeData) {
-		t.Errorf("Expected %d bytes, got %d", len(largeData), len(received))
-	}
-}
-
-func TestOutputRouter_RelayDisconnectAutoFallback(t *testing.T) {
-	// Core test for the deadlock fix: when relay disconnects,
-	// output should automatically fall back to gRPC
-	var grpcData []byte
-	or := NewOutputRouter(func(data []byte) {
-		grpcData = append(grpcData, data...)
-	})
-
-	relay := newMockRelayWriter(true)
-	or.SetRelayClient(relay)
-
-	// Send while connected — should go to relay
-	or.Route([]byte("connected"))
-	if string(relay.getData()) != "connected" {
-		t.Errorf("Expected relay to receive 'connected', got '%s'", relay.getData())
-	}
-	if grpcData != nil {
-		t.Error("gRPC should not receive data while relay is connected")
-	}
-
-	// Simulate disconnect (relay client stays registered but disconnected)
-	relay.connected.Store(false)
-
-	// Send while disconnected — should fall back to gRPC
-	or.Route([]byte("disconnected"))
-	if string(grpcData) != "disconnected" {
-		t.Errorf("Expected gRPC fallback to receive 'disconnected', got '%s'", grpcData)
-	}
-
-	// Simulate reconnect
-	relay.connected.Store(true)
-
-	grpcData = nil
-	or.Route([]byte("reconnected"))
-	if string(relay.getData()) != "connectedreconnected" {
-		t.Errorf("Expected relay to receive 'reconnected', got '%s'", relay.getData())
-	}
-	if grpcData != nil {
-		t.Error("gRPC should not receive data after relay reconnects")
-	}
-}
-
-func TestOutputRouter_StaleClientCannotIntercept(t *testing.T) {
-	// Simulates the original bug scenario: old client's callback should not
-	// intercept output after a new client is set
-	var grpcData []byte
-	or := NewOutputRouter(func(data []byte) {
-		grpcData = append(grpcData, data...)
-	})
-
-	// Old client
-	oldRelay := newMockRelayWriter(true)
-	or.SetRelayClient(oldRelay)
-
-	// Replace with new client
-	newRelay := newMockRelayWriter(true)
-	or.SetRelayClient(newRelay)
-
-	// Old client is stopped (disconnected)
-	oldRelay.connected.Store(false)
-
-	// Output should go to new client, not old
-	or.Route([]byte("test"))
-	if len(oldRelay.getData()) > 0 {
-		// Old relay might have data from before replacement, but not "test"
-		// After SetRelayClient(newRelay), the router holds newRelay reference
-	}
-	if string(newRelay.getData()) != "test" {
-		t.Errorf("Expected new relay to receive 'test', got '%s'", newRelay.getData())
-	}
+	// No race/panic is the success criterion
 }

--- a/runner/internal/terminal/aggregator/smart_aggregator.go
+++ b/runner/internal/terminal/aggregator/smart_aggregator.go
@@ -19,7 +19,7 @@ import (
 // - Adaptive delay based on queue pressure (50ms → 500ms)
 // - Backpressure: pauses when consumer signals overload
 // - ttyd-style flow control: propagates backpressure to PTY layer
-// - Relay output: optional callback for sending output to Relay in addition to gRPC
+// - Relay output: sends flushed data via WebSocket to connected terminal viewers
 // - Serialize mode: use VirtualTerminal.Serialize() for bandwidth optimization
 // - Full redraw throttling: detects high-frequency redraws and reduces transmission rate
 //
@@ -55,9 +55,8 @@ type SmartAggregator struct {
 // NewSmartAggregator creates a new smart aggregator.
 //
 // Parameters:
-// - onFlush: callback invoked with aggregated data
 // - queueUsageFn: returns queue usage ratio (0.0 to 1.0), used for adaptive delay
-func NewSmartAggregator(onFlush func([]byte), queueUsageFn func() float64, opts ...SmartAggregatorOption) *SmartAggregator {
+func NewSmartAggregator(queueUsageFn func() float64, opts ...SmartAggregatorOption) *SmartAggregator {
 	// Default configuration
 	baseDelay := 50 * time.Millisecond  // 20 FPS - more aggressive aggregation
 	maxDelay := 500 * time.Millisecond  // 2 FPS - allow more buffering under load
@@ -67,7 +66,7 @@ func NewSmartAggregator(onFlush func([]byte), queueUsageFn func() float64, opts 
 		buffer:       NewFrameBuffer(maxSize),
 		delay:        NewAdaptiveDelay(baseDelay, maxDelay, queueUsageFn),
 		backpressure: NewBackpressureController(nil, nil),
-		router:       NewOutputRouter(onFlush),
+		router:       NewOutputRouter(),
 	}
 
 	for _, opt := range opts {
@@ -224,8 +223,8 @@ func (a *SmartAggregator) BufferLen() int {
 }
 
 // SetRelayClient sets the relay client reference for output routing.
-// When set and connected, flushed data is sent through Relay instead of gRPC.
-// When disconnected, output automatically falls back to gRPC.
+// When set and connected, flushed data is sent through Relay WebSocket.
+// When not connected, output is dropped (no one is observing the terminal).
 // Pass nil to disable relay output.
 // Thread-safe: can be called from any goroutine.
 func (a *SmartAggregator) SetRelayClient(client RelayWriter) {
@@ -238,13 +237,6 @@ func (a *SmartAggregator) SetPTYLogger(logger *PTYLogger) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.ptyLogger = logger
-}
-
-// DrainEarlyBuffer returns any buffered early output from the router.
-// This is used by the exit handler to retrieve output that was generated
-// before the relay connected (e.g., fast-exiting processes).
-func (a *SmartAggregator) DrainEarlyBuffer() []byte {
-	return a.router.DrainEarlyBuffer()
 }
 
 // calculateDelay is kept for backward compatibility with tests.

--- a/runner/internal/terminal/aggregator/smart_aggregator_backpressure_test.go
+++ b/runner/internal/terminal/aggregator/smart_aggregator_backpressure_test.go
@@ -2,7 +2,6 @@ package aggregator
 
 import (
 	"bytes"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -11,15 +10,9 @@ import (
 // TestSmartAggregator_Backpressure tests pause/resume functionality
 func TestSmartAggregator_Backpressure(t *testing.T) {
 	var pauseCalled, resumeCalled bool
-	var flushCount int
-	var mu sync.Mutex
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			mu.Lock()
-			flushCount++
-			mu.Unlock()
-		},
 		func() float64 { return 0.0 },
 		WithSmartBaseDelay(10*time.Millisecond),
 		WithBackpressureCallbacks(
@@ -27,6 +20,7 @@ func TestSmartAggregator_Backpressure(t *testing.T) {
 			func() { resumeCalled = true },
 		),
 	)
+	agg.SetRelayClient(relay)
 
 	// Initial state
 	if agg.IsPaused() {
@@ -46,9 +40,7 @@ func TestSmartAggregator_Backpressure(t *testing.T) {
 	agg.Write([]byte("paused data"))
 	time.Sleep(50 * time.Millisecond)
 
-	mu.Lock()
-	countWhilePaused := flushCount
-	mu.Unlock()
+	dataWhilePaused := len(relay.getData())
 
 	// Resume
 	agg.Resume()
@@ -62,12 +54,10 @@ func TestSmartAggregator_Backpressure(t *testing.T) {
 	// Wait for flush after resume
 	time.Sleep(50 * time.Millisecond)
 
-	mu.Lock()
-	countAfterResume := flushCount
-	mu.Unlock()
+	dataAfterResume := len(relay.getData())
 
-	if countAfterResume <= countWhilePaused {
-		t.Logf("Flush count: paused=%d, after_resume=%d", countWhilePaused, countAfterResume)
+	if dataAfterResume <= dataWhilePaused {
+		t.Logf("Data length: paused=%d, after_resume=%d", dataWhilePaused, dataAfterResume)
 	}
 
 	agg.Stop()
@@ -75,43 +65,22 @@ func TestSmartAggregator_Backpressure(t *testing.T) {
 
 // TestSmartAggregator_SetRelayClient tests relay client configuration
 func TestSmartAggregator_SetRelayClient(t *testing.T) {
-	var grpcData []byte
-	var mu sync.Mutex
-
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			mu.Lock()
-			grpcData = append(grpcData, data...)
-			mu.Unlock()
-		},
 		func() float64 { return 0.0 },
 		WithSmartBaseDelay(10*time.Millisecond),
 	)
 
-	// Write without relay - should go to gRPC
-	agg.Write([]byte("grpc"))
+	// Write without relay - data is dropped (no relay connected)
+	agg.Write([]byte("dropped"))
 	time.Sleep(50 * time.Millisecond)
-
-	mu.Lock()
-	if !bytes.Contains(grpcData, []byte("grpc")) {
-		t.Error("Data should go to gRPC when no relay")
-	}
-	grpcData = nil
-	mu.Unlock()
 
 	// Set relay client (connected)
 	relay := newMockRelayWriter(true)
 	agg.SetRelayClient(relay)
 
-	// Write with relay - should go to relay only
+	// Write with relay - should go to relay
 	agg.Write([]byte("relay"))
 	time.Sleep(50 * time.Millisecond)
-
-	mu.Lock()
-	if bytes.Contains(grpcData, []byte("relay")) {
-		t.Error("Data should not go to gRPC when relay is connected")
-	}
-	mu.Unlock()
 
 	if !bytes.Contains(relay.getData(), []byte("relay")) {
 		t.Error("Data should go to relay")
@@ -123,7 +92,6 @@ func TestSmartAggregator_SetRelayClient(t *testing.T) {
 // TestSmartAggregator_SetPTYLogger tests PTY logger configuration
 func TestSmartAggregator_SetPTYLogger(t *testing.T) {
 	agg := NewSmartAggregator(
-		func(data []byte) {},
 		func() float64 { return 0.0 },
 	)
 
@@ -137,17 +105,13 @@ func TestSmartAggregator_SetPTYLogger(t *testing.T) {
 
 // TestSmartAggregator_TimerFlushPaused tests timer flush when paused
 func TestSmartAggregator_TimerFlushPaused(t *testing.T) {
-	var flushCount int32
-	done := make(chan struct{}, 10)
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			atomic.AddInt32(&flushCount, 1)
-			done <- struct{}{}
-		},
 		func() float64 { return 0.0 },
 		WithSmartBaseDelay(10*time.Millisecond),
 	)
+	agg.SetRelayClient(relay)
 
 	// Write data then pause
 	agg.Write([]byte("data"))
@@ -159,11 +123,11 @@ func TestSmartAggregator_TimerFlushPaused(t *testing.T) {
 	// Resume and wait for flush
 	agg.Resume()
 
-	select {
-	case <-done:
-		// OK - flush happened
-	case <-time.After(200 * time.Millisecond):
-		// Also OK - may have flushed before pause
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify data was eventually flushed
+	if len(relay.getData()) == 0 {
+		t.Log("Data may have flushed before pause - this is acceptable")
 	}
 
 	agg.Stop()
@@ -173,16 +137,14 @@ func TestSmartAggregator_TimerFlushPaused(t *testing.T) {
 func TestSmartAggregator_TimerFlushCriticalLoad(t *testing.T) {
 	var usage atomic.Int64
 	usage.Store(60) // 0.6 * 100 = 60, Critical load
-	var flushCount int32
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			atomic.AddInt32(&flushCount, 1)
-		},
 		func() float64 { return float64(usage.Load()) / 100.0 },
 		WithSmartBaseDelay(20*time.Millisecond),
 		WithSmartMaxDelay(100*time.Millisecond),
 	)
+	agg.SetRelayClient(relay)
 
 	// Write data under critical load
 	agg.Write([]byte("data"))
@@ -196,8 +158,7 @@ func TestSmartAggregator_TimerFlushCriticalLoad(t *testing.T) {
 	// Wait for flush (generous margin for Windows timer resolution ~15ms)
 	time.Sleep(300 * time.Millisecond)
 
-	count := atomic.LoadInt32(&flushCount)
-	if count == 0 {
+	if len(relay.getData()) == 0 {
 		t.Error("Should have flushed after load decreased")
 	}
 
@@ -206,18 +167,13 @@ func TestSmartAggregator_TimerFlushCriticalLoad(t *testing.T) {
 
 // TestSmartAggregator_FlushWithIncompleteFrame tests that incomplete frames are handled
 func TestSmartAggregator_FlushWithIncompleteFrame(t *testing.T) {
-	var flushed []byte
-	var mu sync.Mutex
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			mu.Lock()
-			flushed = append(flushed, data...)
-			mu.Unlock()
-		},
 		func() float64 { return 0.0 },
 		WithSmartBaseDelay(10*time.Millisecond),
 	)
+	agg.SetRelayClient(relay)
 
 	// Write complete frame + incomplete frame
 	syncStart := "\x1b[?2026h"
@@ -231,9 +187,7 @@ func TestSmartAggregator_FlushWithIncompleteFrame(t *testing.T) {
 	// Wait for timer flush
 	time.Sleep(50 * time.Millisecond)
 
-	mu.Lock()
-	data := flushed
-	mu.Unlock()
+	data := relay.getData()
 
 	// Should flush complete frame
 	if !bytes.Contains(data, []byte("complete")) {
@@ -250,7 +204,6 @@ func TestSmartAggregator_FlushWithIncompleteFrame(t *testing.T) {
 // TestSmartAggregator_ResumeWithoutPause tests resume when not paused
 func TestSmartAggregator_ResumeWithoutPause(t *testing.T) {
 	agg := NewSmartAggregator(
-		func(data []byte) {},
 		func() float64 { return 0.0 },
 	)
 
@@ -266,23 +219,21 @@ func TestSmartAggregator_ResumeWithoutPause(t *testing.T) {
 
 // TestSmartAggregator_WriteAfterStop tests that writes are ignored after stop
 func TestSmartAggregator_WriteAfterStop(t *testing.T) {
-	var flushCount int
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			flushCount++
-		},
 		func() float64 { return 0.0 },
 	)
+	agg.SetRelayClient(relay)
 
 	agg.Stop()
-	initialCount := flushCount
+	initialLen := len(relay.getData())
 
 	// Write after stop should be ignored
 	agg.Write([]byte("ignored"))
 	time.Sleep(50 * time.Millisecond)
 
-	if flushCount != initialCount {
+	if len(relay.getData()) != initialLen {
 		t.Error("Write after stop should be ignored")
 	}
 }

--- a/runner/internal/terminal/aggregator/smart_aggregator_basic_test.go
+++ b/runner/internal/terminal/aggregator/smart_aggregator_basic_test.go
@@ -1,7 +1,6 @@
 package aggregator
 
 import (
-	"sync"
 	"testing"
 	"time"
 )
@@ -9,45 +8,28 @@ import (
 // Tests for basic aggregation functionality
 
 func TestSmartAggregator_BasicAggregation(t *testing.T) {
-	var received []byte
-	var mu sync.Mutex
-	done := make(chan struct{})
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			mu.Lock()
-			received = append(received, data...)
-			mu.Unlock()
-			select {
-			case done <- struct{}{}:
-			default:
-			}
-		},
 		func() float64 { return 0 }, // No queue pressure
 		WithSmartBaseDelay(10*time.Millisecond),
 	)
+	agg.SetRelayClient(relay)
 
 	// Write some data
 	agg.Write([]byte("hello"))
 	agg.Write([]byte(" world"))
 
 	// Wait for flush
-	select {
-	case <-done:
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("Timeout waiting for flush")
-	}
+	time.Sleep(100 * time.Millisecond)
 
-	mu.Lock()
-	defer mu.Unlock()
-	if string(received) != "hello world" {
-		t.Errorf("Expected 'hello world', got '%s'", string(received))
+	if string(relay.getData()) != "hello world" {
+		t.Errorf("Expected 'hello world', got '%s'", string(relay.getData()))
 	}
 }
 
 func TestSmartAggregator_AdaptiveDelay(t *testing.T) {
 	agg := NewSmartAggregator(
-		func(data []byte) {},
 		func() float64 { return 0 },
 		WithSmartBaseDelay(16*time.Millisecond),
 		WithSmartMaxDelay(200*time.Millisecond),
@@ -81,66 +63,47 @@ func TestSmartAggregator_AdaptiveDelay(t *testing.T) {
 }
 
 func TestSmartAggregator_NilQueueUsageFn(t *testing.T) {
-	done := make(chan struct{})
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			close(done)
-		},
 		nil,
 		WithSmartBaseDelay(10*time.Millisecond),
 	)
+	agg.SetRelayClient(relay)
 
 	agg.Write([]byte("test"))
 
-	select {
-	case <-done:
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("Timeout waiting for flush")
+	time.Sleep(100 * time.Millisecond)
+
+	if len(relay.getData()) == 0 {
+		t.Fatal("Expected data to be flushed")
 	}
 
 	agg.Stop()
 }
 
 func TestSmartAggregator_Flush(t *testing.T) {
-	var received []byte
-	var mu sync.Mutex
-	done := make(chan struct{}, 1)
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			mu.Lock()
-			received = data
-			mu.Unlock()
-			select {
-			case done <- struct{}{}:
-			default:
-			}
-		},
 		func() float64 { return 0 },
 		WithSmartBaseDelay(1*time.Second),
 	)
+	agg.SetRelayClient(relay)
 	defer agg.Stop()
 
 	agg.Write([]byte("data"))
 	agg.Flush()
 
-	select {
-	case <-done:
-	case <-time.After(50 * time.Millisecond):
-		t.Fatal("Expected immediate flush")
-	}
+	time.Sleep(50 * time.Millisecond)
 
-	mu.Lock()
-	defer mu.Unlock()
-	if string(received) != "data" {
-		t.Errorf("Expected 'data', got '%s'", string(received))
+	if string(relay.getData()) != "data" {
+		t.Errorf("Expected 'data', got '%s'", string(relay.getData()))
 	}
 }
 
 func TestSmartAggregator_IsStopped(t *testing.T) {
 	agg := NewSmartAggregator(
-		func(data []byte) {},
 		func() float64 { return 0 },
 	)
 

--- a/runner/internal/terminal/aggregator/smart_aggregator_concurrent_test.go
+++ b/runner/internal/terminal/aggregator/smart_aggregator_concurrent_test.go
@@ -10,37 +10,21 @@ import (
 // Tests for concurrent access and stop behavior
 
 func TestSmartAggregator_Stop(t *testing.T) {
-	var received []byte
-	var mu sync.Mutex
-	done := make(chan struct{}, 1)
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			mu.Lock()
-			received = data
-			mu.Unlock()
-			select {
-			case done <- struct{}{}:
-			default:
-			}
-		},
 		func() float64 { return 0 },
 		WithSmartBaseDelay(1*time.Second),
 	)
+	agg.SetRelayClient(relay)
 
 	agg.Write([]byte("pending data"))
 	agg.Stop()
 
-	select {
-	case <-done:
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("Expected flush on stop")
-	}
+	time.Sleep(100 * time.Millisecond)
 
-	mu.Lock()
-	defer mu.Unlock()
-	if string(received) != "pending data" {
-		t.Errorf("Expected 'pending data', got '%s'", string(received))
+	if string(relay.getData()) != "pending data" {
+		t.Errorf("Expected 'pending data', got '%s'", string(relay.getData()))
 	}
 
 	agg.Write([]byte("ignored"))
@@ -50,18 +34,13 @@ func TestSmartAggregator_Stop(t *testing.T) {
 }
 
 func TestSmartAggregator_ConcurrentWrites(t *testing.T) {
-	var totalBytes int64
-	var mu sync.Mutex
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			mu.Lock()
-			totalBytes += int64(len(data))
-			mu.Unlock()
-		},
 		func() float64 { return 0 },
 		WithSmartBaseDelay(5*time.Millisecond),
 	)
+	agg.SetRelayClient(relay)
 
 	var wg sync.WaitGroup
 	numWriters := 10
@@ -82,10 +61,8 @@ func TestSmartAggregator_ConcurrentWrites(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
-	mu.Lock()
-	defer mu.Unlock()
-
 	expected := int64(numWriters * bytesPerWriter)
+	totalBytes := int64(len(relay.getData()))
 	if totalBytes != expected {
 		t.Errorf("Expected %d bytes, got %d", expected, totalBytes)
 	}
@@ -93,19 +70,14 @@ func TestSmartAggregator_ConcurrentWrites(t *testing.T) {
 
 func TestSmartAggregator_LargeChunkExceedsMaxSize(t *testing.T) {
 	maxSize := 100
-	var flushed []byte
-	var mu sync.Mutex
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			mu.Lock()
-			flushed = append(flushed, data...)
-			mu.Unlock()
-		},
 		func() float64 { return 0 },
 		WithSmartMaxSize(maxSize),
 		WithSmartBaseDelay(10*time.Millisecond),
 	)
+	agg.SetRelayClient(relay)
 
 	agg.Write([]byte("prefix"))
 	largeChunk := bytes.Repeat([]byte("L"), 200)

--- a/runner/internal/terminal/aggregator/smart_aggregator_frame_test.go
+++ b/runner/internal/terminal/aggregator/smart_aggregator_frame_test.go
@@ -2,7 +2,6 @@ package aggregator
 
 import (
 	"bytes"
-	"sync"
 	"testing"
 	"time"
 )
@@ -10,20 +9,13 @@ import (
 // Tests for frame handling and synchronized output
 
 func TestSmartAggregator_PreservesIncrementalFrames(t *testing.T) {
-	var received []byte
-	var mu sync.Mutex
-	done := make(chan struct{}, 10)
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			mu.Lock()
-			received = append(received, data...)
-			mu.Unlock()
-			done <- struct{}{}
-		},
 		func() float64 { return 0.3 }, // Moderate pressure
 		WithSmartBaseDelay(10*time.Millisecond),
 	)
+	agg.SetRelayClient(relay)
 	defer agg.Stop()
 
 	// Write incremental sync frames - all should be preserved
@@ -35,14 +27,9 @@ func TestSmartAggregator_PreservesIncrementalFrames(t *testing.T) {
 	agg.Write([]byte(syncStart + "frame 3" + syncEnd))
 
 	// Wait for flush
-	select {
-	case <-done:
-	case <-time.After(200 * time.Millisecond):
-		t.Fatal("Timeout waiting for flush")
-	}
+	time.Sleep(200 * time.Millisecond)
 
-	mu.Lock()
-	defer mu.Unlock()
+	received := relay.getData()
 
 	// All incremental frames should be preserved (content-aware discard)
 	if !bytes.Contains(received, []byte("frame 1")) {
@@ -59,20 +46,13 @@ func TestSmartAggregator_PreservesIncrementalFrames(t *testing.T) {
 // TestSmartAggregator_SynchronizedOutputFrameBoundary tests frame boundary detection
 // with content-aware discard: old frames are only discarded when a full redraw frame arrives
 func TestSmartAggregator_SynchronizedOutputFrameBoundary(t *testing.T) {
-	var received []byte
-	var mu sync.Mutex
-	done := make(chan struct{}, 10)
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			mu.Lock()
-			received = data
-			mu.Unlock()
-			done <- struct{}{}
-		},
 		func() float64 { return 0.3 },
 		WithSmartBaseDelay(10*time.Millisecond),
 	)
+	agg.SetRelayClient(relay)
 	defer agg.Stop()
 
 	syncStart := "\x1b[?2026h"
@@ -84,14 +64,9 @@ func TestSmartAggregator_SynchronizedOutputFrameBoundary(t *testing.T) {
 	// Write Frame 2 (full redraw frame with ESC[2J - triggers discard of old frame)
 	agg.Write([]byte(syncStart + clearScreen + "new frame content" + syncEnd))
 
-	select {
-	case <-done:
-	case <-time.After(200 * time.Millisecond):
-		t.Fatal("Timeout waiting for flush")
-	}
+	time.Sleep(200 * time.Millisecond)
 
-	mu.Lock()
-	defer mu.Unlock()
+	received := relay.getData()
 
 	if !bytes.Contains(received, []byte(syncStart)) {
 		t.Errorf("Expected sync output start sequence in result")
@@ -111,20 +86,13 @@ func TestSmartAggregator_SynchronizedOutputFrameBoundary(t *testing.T) {
 // TestSmartAggregator_SyncOutputPriorityOverClearScreen tests that full redraw frame
 // discards content before it (content-aware discard)
 func TestSmartAggregator_SyncOutputPriorityOverClearScreen(t *testing.T) {
-	var received []byte
-	var mu sync.Mutex
-	done := make(chan struct{}, 10)
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			mu.Lock()
-			received = data
-			mu.Unlock()
-			done <- struct{}{}
-		},
 		func() float64 { return 0.3 },
 		WithSmartBaseDelay(10*time.Millisecond),
 	)
+	agg.SetRelayClient(relay)
 	defer agg.Stop()
 
 	syncStart := "\x1b[?2026h"
@@ -136,14 +104,9 @@ func TestSmartAggregator_SyncOutputPriorityOverClearScreen(t *testing.T) {
 	// Write a full redraw sync frame (contains ESC[2J inside)
 	agg.Write([]byte(syncStart + clearScreen + "sync frame" + syncEnd))
 
-	select {
-	case <-done:
-	case <-time.After(200 * time.Millisecond):
-		t.Fatal("Timeout waiting for flush")
-	}
+	time.Sleep(200 * time.Millisecond)
 
-	mu.Lock()
-	defer mu.Unlock()
+	received := relay.getData()
 
 	if !bytes.Contains(received, []byte(syncStart)) {
 		t.Errorf("Expected sync output start sequence")

--- a/runner/internal/terminal/aggregator/smart_aggregator_serialize_test.go
+++ b/runner/internal/terminal/aggregator/smart_aggregator_serialize_test.go
@@ -17,20 +17,11 @@ import (
 // TestSmartAggregator_SerializeMode tests the serialize mode functionality
 // where Write() only marks pending data and flushLocked() calls the serialize callback
 func TestSmartAggregator_SerializeMode(t *testing.T) {
-	var mu sync.Mutex
-	var flushedData []byte
-	var flushCount int
-
 	// Simulated VirtualTerminal serialized output
 	serializedOutput := []byte("Hello\x1b[5CWorld")
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			mu.Lock()
-			flushedData = append(flushedData, data...)
-			flushCount++
-			mu.Unlock()
-		},
 		func() float64 { return 0.0 },
 		WithSmartBaseDelay(10*time.Millisecond),
 		// Serialize callback returns compressed data
@@ -38,6 +29,7 @@ func TestSmartAggregator_SerializeMode(t *testing.T) {
 			return serializedOutput
 		}),
 	)
+	agg.SetRelayClient(relay)
 
 	// Write with nil data - in serialize mode, data is ignored
 	agg.Write(nil)
@@ -45,62 +37,50 @@ func TestSmartAggregator_SerializeMode(t *testing.T) {
 	// Wait for flush
 	time.Sleep(50 * time.Millisecond)
 
-	mu.Lock()
-	result := flushedData
-	count := flushCount
-	mu.Unlock()
+	result := relay.getData()
 
 	// Verify serialized output was sent
 	if !bytes.Equal(result, serializedOutput) {
 		t.Errorf("Expected serialized output %q, got %q", serializedOutput, result)
 	}
 
-	if count != 1 {
-		t.Errorf("Expected 1 flush, got %d", count)
-	}
-
 	agg.Stop()
-	t.Logf("✅ Serialize mode test: correctly sent serialized output")
+	t.Logf("Serialize mode test: correctly sent serialized output")
 }
 
 // TestSmartAggregator_SerializeModeNoPendingData tests that flush is skipped when no pending data
 func TestSmartAggregator_SerializeModeNoPendingData(t *testing.T) {
-	var flushCount int
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			flushCount++
-		},
 		func() float64 { return 0.0 },
 		WithSmartBaseDelay(5*time.Millisecond),
 		WithSerializeCallback(func() []byte {
 			return []byte("should not be called if no pending data")
 		}),
 	)
+	agg.SetRelayClient(relay)
 
 	// Force flush without any Write() - should not flush
 	agg.Flush()
+	time.Sleep(20 * time.Millisecond)
 
-	if flushCount != 0 {
-		t.Errorf("Expected 0 flushes when no pending data, got %d", flushCount)
+	if len(relay.getData()) != 0 {
+		t.Errorf("Expected 0 bytes flushed when no pending data, got %d", len(relay.getData()))
 	}
 
 	agg.Stop()
-	t.Logf("✅ Serialize mode no-pending-data test: correctly skipped flush")
+	t.Logf("Serialize mode no-pending-data test: correctly skipped flush")
 }
 
 // TestSmartAggregator_SerializeModeMultipleWrites tests aggregation with multiple writes
 func TestSmartAggregator_SerializeModeMultipleWrites(t *testing.T) {
 	var mu sync.Mutex
-	var flushCount int
 	var callbackCount int
 
+	relay := newMockRelayWriter(true)
+
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			mu.Lock()
-			flushCount++
-			mu.Unlock()
-		},
 		func() float64 { return 0.0 },
 		WithSmartBaseDelay(50*time.Millisecond),
 		WithSerializeCallback(func() []byte {
@@ -110,6 +90,7 @@ func TestSmartAggregator_SerializeModeMultipleWrites(t *testing.T) {
 			return []byte("serialized")
 		}),
 	)
+	agg.SetRelayClient(relay)
 
 	// Multiple rapid writes should be aggregated
 	for i := 0; i < 10; i++ {
@@ -121,33 +102,26 @@ func TestSmartAggregator_SerializeModeMultipleWrites(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	mu.Lock()
-	fc := flushCount
 	cc := callbackCount
 	mu.Unlock()
 
 	// Should have aggregated multiple writes into fewer flushes
-	if fc == 0 {
-		t.Errorf("Expected at least 1 flush, got 0")
+	if cc == 0 {
+		t.Errorf("Expected at least 1 callback, got 0")
 	}
-	if fc > 3 {
-		t.Errorf("Expected aggregation, but got %d flushes for 10 writes", fc)
-	}
-	if cc != fc {
-		t.Errorf("Callback count (%d) should match flush count (%d)", cc, fc)
+	if cc > 3 {
+		t.Errorf("Expected aggregation, but got %d callbacks for 10 writes", cc)
 	}
 
 	agg.Stop()
-	t.Logf("✅ Serialize mode aggregation test: %d flushes for 10 writes", fc)
+	t.Logf("Serialize mode aggregation test: %d callbacks for 10 writes", cc)
 }
 
 // TestSmartAggregator_SerializeModeEmptyCallback tests handling of empty callback result
 func TestSmartAggregator_SerializeModeEmptyCallback(t *testing.T) {
-	var flushCount int
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			flushCount++
-		},
 		func() float64 { return 0.0 },
 		WithSmartBaseDelay(5*time.Millisecond),
 		// Callback returns empty data
@@ -155,29 +129,27 @@ func TestSmartAggregator_SerializeModeEmptyCallback(t *testing.T) {
 			return nil
 		}),
 	)
+	agg.SetRelayClient(relay)
 
 	agg.Write(nil)
 	time.Sleep(20 * time.Millisecond)
 
-	// Should not call onFlush when callback returns empty data
-	if flushCount != 0 {
-		t.Errorf("Expected 0 flushes when callback returns nil, got %d", flushCount)
+	// Should not send data when callback returns nil
+	if len(relay.getData()) != 0 {
+		t.Errorf("Expected 0 bytes when callback returns nil, got %d", len(relay.getData()))
 	}
 
 	agg.Stop()
-	t.Logf("✅ Serialize mode empty callback test: correctly skipped empty data")
+	t.Logf("Serialize mode empty callback test: correctly skipped empty data")
 }
 
 // TestSmartAggregator_SerializeModeCriticalLoad tests serialize mode under critical load
 func TestSmartAggregator_SerializeModeCriticalLoad(t *testing.T) {
 	var usage atomic.Int64
 	usage.Store(60) // 0.6 * 100 = 60, Critical load (stored as int to avoid float64 atomic issues)
-	var flushCount atomic.Int32
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			flushCount.Add(1)
-		},
 		func() float64 { return float64(usage.Load()) / 100.0 },
 		WithSmartBaseDelay(10*time.Millisecond),
 		WithSmartMaxDelay(50*time.Millisecond),
@@ -185,6 +157,7 @@ func TestSmartAggregator_SerializeModeCriticalLoad(t *testing.T) {
 			return []byte("data")
 		}),
 	)
+	agg.SetRelayClient(relay)
 
 	// Write under critical load
 	agg.Write(nil)
@@ -199,5 +172,5 @@ func TestSmartAggregator_SerializeModeCriticalLoad(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	agg.Stop()
-	t.Logf("✅ Serialize mode critical load test completed, flushes: %d", flushCount.Load())
+	t.Logf("Serialize mode critical load test completed, relay data: %d bytes", len(relay.getData()))
 }

--- a/runner/internal/terminal/aggregator/smart_aggregator_size_test.go
+++ b/runner/internal/terminal/aggregator/smart_aggregator_size_test.go
@@ -2,8 +2,6 @@ package aggregator
 
 import (
 	"bytes"
-	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -11,50 +9,37 @@ import (
 // Tests for max size handling and buffer limits
 
 func TestSmartAggregator_MaxSizeFlush(t *testing.T) {
-	var flushCount int32
-	done := make(chan struct{}, 10)
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			atomic.AddInt32(&flushCount, 1)
-			done <- struct{}{}
-		},
 		func() float64 { return 0 },
 		WithSmartMaxSize(100),
 		WithSmartBaseDelay(1*time.Second),
 	)
+	agg.SetRelayClient(relay)
 	defer agg.Stop()
 
 	data := bytes.Repeat([]byte("x"), 150)
 	agg.Write(data)
 
-	select {
-	case <-done:
-	case <-time.After(50 * time.Millisecond):
-		t.Fatal("Expected immediate flush on max size exceeded")
-	}
+	// Wait for immediate flush on max size exceeded
+	time.Sleep(50 * time.Millisecond)
 
-	count := atomic.LoadInt32(&flushCount)
-	if count < 1 {
-		t.Errorf("Expected at least 1 flush, got %d", count)
+	if len(relay.getData()) < 1 {
+		t.Fatal("Expected immediate flush on max size exceeded")
 	}
 }
 
 func TestSmartAggregator_BufferLimitEnforced(t *testing.T) {
 	maxSize := 1000
-	var totalFlushed int64
-	var mu sync.Mutex
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			mu.Lock()
-			totalFlushed += int64(len(data))
-			mu.Unlock()
-		},
 		func() float64 { return 0.9 },
 		WithSmartMaxSize(maxSize),
 		WithSmartBaseDelay(50*time.Millisecond),
 	)
+	agg.SetRelayClient(relay)
 
 	totalWritten := 0
 	for i := 0; i < 100; i++ {
@@ -74,20 +59,14 @@ func TestSmartAggregator_BufferLimitEnforced(t *testing.T) {
 
 func TestSmartAggregator_BufferLimitWithClearScreen(t *testing.T) {
 	maxSize := 500
-	var lastFlush []byte
-	var mu sync.Mutex
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			mu.Lock()
-			lastFlush = make([]byte, len(data))
-			copy(lastFlush, data)
-			mu.Unlock()
-		},
 		func() float64 { return 0.5 },
 		WithSmartMaxSize(maxSize),
 		WithSmartBaseDelay(10*time.Millisecond),
 	)
+	agg.SetRelayClient(relay)
 
 	agg.Write(bytes.Repeat([]byte("old"), 100))
 	agg.Write([]byte("\x1b[2J"))
@@ -96,8 +75,7 @@ func TestSmartAggregator_BufferLimitWithClearScreen(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	agg.Stop()
 
-	mu.Lock()
-	defer mu.Unlock()
+	lastFlush := relay.getData()
 
 	if !bytes.Contains(lastFlush, []byte("\x1b[2J")) {
 		t.Error("Clear screen should be preserved")

--- a/runner/internal/terminal/aggregator/smart_aggregator_stress_test.go
+++ b/runner/internal/terminal/aggregator/smart_aggregator_stress_test.go
@@ -3,32 +3,22 @@ package aggregator
 import (
 	"bytes"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 )
 
 // TestSmartAggregator_HighLoadFrameDropping verifies frame dropping under high load.
 func TestSmartAggregator_HighLoadFrameDropping(t *testing.T) {
-	var totalBytes int64
-	var flushCount int64
-	var mu sync.Mutex
-	var lastData []byte
+	relay := newMockRelayWriter(true)
 
 	// Simulate high queue pressure (80%)
 	queueUsage := 0.8
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			atomic.AddInt64(&flushCount, 1)
-			atomic.AddInt64(&totalBytes, int64(len(data)))
-			mu.Lock()
-			lastData = data
-			mu.Unlock()
-		},
 		func() float64 { return queueUsage },
 		WithSmartBaseDelay(5*time.Millisecond), // Faster for testing
 	)
+	agg.SetRelayClient(relay)
 
 	// Send multiple frames with clear screen sequences
 	for i := 0; i < 10; i++ {
@@ -43,16 +33,14 @@ func TestSmartAggregator_HighLoadFrameDropping(t *testing.T) {
 	agg.Stop()
 	time.Sleep(50 * time.Millisecond) // Wait for async flush
 
-	mu.Lock()
-	defer mu.Unlock()
+	lastData := relay.getData()
 
 	// Last data should start with clear screen (old content discarded)
 	if !bytes.HasPrefix(lastData, clearScreenSeq) {
 		t.Errorf("Expected last data to start with clear screen sequence")
 	}
 
-	t.Logf("✅ High load frame dropping test:")
-	t.Logf("   Flush count: %d, Total bytes: %d", flushCount, totalBytes)
+	t.Logf("High load frame dropping test:")
 	t.Logf("   Last data length: %d (starts with ESC[2J: %v)",
 		len(lastData), bytes.HasPrefix(lastData, clearScreenSeq))
 }
@@ -74,19 +62,13 @@ func TestSmartAggregator_AdaptiveDelayUnderPressure(t *testing.T) {
 		return queueUsage
 	}
 
-	var flushTimes []time.Time
-	var flushMu sync.Mutex
-
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			flushMu.Lock()
-			flushTimes = append(flushTimes, time.Now())
-			flushMu.Unlock()
-		},
 		getUsage,
 		WithSmartBaseDelay(10*time.Millisecond),
 		WithSmartMaxDelay(100*time.Millisecond),
 	)
+	relay := newMockRelayWriter(true)
+	agg.SetRelayClient(relay)
 
 	// Test at different load levels
 	testCases := []struct {
@@ -101,9 +83,6 @@ func TestSmartAggregator_AdaptiveDelayUnderPressure(t *testing.T) {
 
 	for _, tc := range testCases {
 		setUsage(tc.usage)
-		flushMu.Lock()
-		flushTimes = nil
-		flushMu.Unlock()
 
 		start := time.Now()
 		for i := 0; i < 5; i++ {
@@ -111,31 +90,23 @@ func TestSmartAggregator_AdaptiveDelayUnderPressure(t *testing.T) {
 			time.Sleep(tc.maxInterval)
 		}
 
-		flushMu.Lock()
-		count := len(flushTimes)
-		flushMu.Unlock()
-
 		elapsed := time.Since(start)
-		t.Logf("   Usage %.0f%%: %d flushes in %v", tc.usage*100, count, elapsed)
+		t.Logf("   Usage %.0f%%: elapsed %v", tc.usage*100, elapsed)
 	}
 
 	agg.Stop()
-	t.Logf("✅ Adaptive delay test completed")
+	t.Logf("Adaptive delay test completed")
 }
 
 // TestSmartAggregator_ConcurrentHighVolume simulates multiple terminals.
 func TestSmartAggregator_ConcurrentHighVolume(t *testing.T) {
-	var totalFlushed int64
-	var totalBytes int64
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			atomic.AddInt64(&totalFlushed, 1)
-			atomic.AddInt64(&totalBytes, int64(len(data)))
-		},
 		func() float64 { return 0.3 }, // Moderate pressure
 		WithSmartBaseDelay(5*time.Millisecond),
 	)
+	agg.SetRelayClient(relay)
 
 	var wg sync.WaitGroup
 	numWriters := 10
@@ -159,12 +130,11 @@ func TestSmartAggregator_ConcurrentHighVolume(t *testing.T) {
 
 	elapsed := time.Since(start)
 	expectedBytes := int64(numWriters * writesPerWriter * len("terminal output data from writer"))
-	finalFlushed := atomic.LoadInt64(&totalFlushed)
-	finalBytes := atomic.LoadInt64(&totalBytes)
+	finalBytes := int64(len(relay.getData()))
 
-	t.Logf("✅ Concurrent high volume test:")
-	t.Logf("   Writers: %d × %d writes = %d total", numWriters, writesPerWriter, numWriters*writesPerWriter)
-	t.Logf("   Flushed: %d times, %d bytes (expected: %d)", finalFlushed, finalBytes, expectedBytes)
+	t.Logf("Concurrent high volume test:")
+	t.Logf("   Writers: %d x %d writes = %d total", numWriters, writesPerWriter, numWriters*writesPerWriter)
+	t.Logf("   Flushed: %d bytes (expected: %d)", finalBytes, expectedBytes)
 	t.Logf("   Elapsed: %v, Throughput: %.0f writes/sec", elapsed, float64(numWriters*writesPerWriter)/elapsed.Seconds())
 
 	// Should capture all bytes
@@ -175,16 +145,14 @@ func TestSmartAggregator_ConcurrentHighVolume(t *testing.T) {
 
 // TestSmartAggregator_RapidStartStop verifies no data loss on rapid start/stop.
 func TestSmartAggregator_RapidStartStop(t *testing.T) {
-	var totalBytes int64
+	relay := newMockRelayWriter(true)
 
 	for i := 0; i < 100; i++ {
 		agg := NewSmartAggregator(
-			func(data []byte) {
-				atomic.AddInt64(&totalBytes, int64(len(data)))
-			},
 			func() float64 { return 0 },
 			WithSmartBaseDelay(1*time.Millisecond),
 		)
+		agg.SetRelayClient(relay)
 
 		agg.Write([]byte("quick data"))
 		agg.Stop()
@@ -193,29 +161,23 @@ func TestSmartAggregator_RapidStartStop(t *testing.T) {
 	time.Sleep(100 * time.Millisecond) // Wait for all async flushes
 
 	expectedBytes := int64(100 * len("quick data"))
-	finalBytes := atomic.LoadInt64(&totalBytes)
+	finalBytes := int64(len(relay.getData()))
 	if finalBytes != expectedBytes {
 		t.Errorf("Expected %d bytes, got %d (data loss: %d)", expectedBytes, finalBytes, expectedBytes-finalBytes)
 	}
 
-	t.Logf("✅ Rapid start/stop test: %d bytes captured (no data loss)", finalBytes)
+	t.Logf("Rapid start/stop test: %d bytes captured (no data loss)", finalBytes)
 }
 
 // TestSmartAggregator_ClearScreenDetection verifies ESC[2J detection accuracy.
 func TestSmartAggregator_ClearScreenDetection(t *testing.T) {
-	var lastData []byte
-	var mu sync.Mutex
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			mu.Lock()
-			lastData = make([]byte, len(data))
-			copy(lastData, data)
-			mu.Unlock()
-		},
 		func() float64 { return 0.8 }, // High pressure to trigger discard
 		WithSmartBaseDelay(5*time.Millisecond),
 	)
+	agg.SetRelayClient(relay)
 
 	// Test various clear screen sequences
 	testCases := []struct {
@@ -228,9 +190,9 @@ func TestSmartAggregator_ClearScreenDetection(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		mu.Lock()
-		lastData = nil
-		mu.Unlock()
+		// Reset relay for each test case
+		newRelay := newMockRelayWriter(true)
+		agg.SetRelayClient(newRelay)
 
 		for _, data := range tc.input {
 			agg.Write(data)
@@ -238,21 +200,18 @@ func TestSmartAggregator_ClearScreenDetection(t *testing.T) {
 		agg.Flush()
 		time.Sleep(20 * time.Millisecond)
 
-		mu.Lock()
-		result := lastData
-		mu.Unlock()
+		result := newRelay.getData()
 
 		t.Logf("   %s: input=%d parts, output=%d bytes", tc.name, len(tc.input), len(result))
 	}
 
 	agg.Stop()
-	t.Logf("✅ Clear screen detection test completed")
+	t.Logf("Clear screen detection test completed")
 }
 
 // BenchmarkSmartAggregator_Write measures write throughput.
 func BenchmarkSmartAggregator_Write(b *testing.B) {
 	agg := NewSmartAggregator(
-		func(data []byte) {},
 		func() float64 { return 0 },
 	)
 	defer agg.Stop()
@@ -268,7 +227,6 @@ func BenchmarkSmartAggregator_Write(b *testing.B) {
 // BenchmarkSmartAggregator_WriteUnderPressure measures write with high queue pressure.
 func BenchmarkSmartAggregator_WriteUnderPressure(b *testing.B) {
 	agg := NewSmartAggregator(
-		func(data []byte) {},
 		func() float64 { return 0.9 }, // High pressure
 	)
 	defer agg.Stop()
@@ -286,7 +244,6 @@ func BenchmarkSmartAggregator_WriteUnderPressure(b *testing.B) {
 // BenchmarkSmartAggregator_ConcurrentWrite measures concurrent write performance.
 func BenchmarkSmartAggregator_ConcurrentWrite(b *testing.B) {
 	agg := NewSmartAggregator(
-		func(data []byte) {},
 		func() float64 { return 0.5 },
 	)
 	defer agg.Stop()

--- a/runner/internal/terminal/aggregator/smart_aggregator_throttle_basic_test.go
+++ b/runner/internal/terminal/aggregator/smart_aggregator_throttle_basic_test.go
@@ -2,26 +2,15 @@ package aggregator
 
 import (
 	"bytes"
-	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 )
 
 // TestSmartAggregator_FullRedrawThrottling_Enabled tests that throttling reduces flush rate
 func TestSmartAggregator_FullRedrawThrottling_Enabled(t *testing.T) {
-	var flushCount int32
-	var mu sync.Mutex
-	var lastData []byte
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			atomic.AddInt32(&flushCount, 1)
-			mu.Lock()
-			lastData = make([]byte, len(data))
-			copy(lastData, data)
-			mu.Unlock()
-		},
 		func() float64 { return 0 },
 		WithSmartBaseDelay(10*time.Millisecond),
 		WithFullRedrawThrottling(
@@ -32,6 +21,7 @@ func TestSmartAggregator_FullRedrawThrottling_Enabled(t *testing.T) {
 			WithThrottlerMinDelay(100*time.Millisecond),
 		),
 	)
+	agg.SetRelayClient(relay)
 	defer agg.Stop()
 
 	// Send multiple full redraw frames rapidly
@@ -44,7 +34,7 @@ func TestSmartAggregator_FullRedrawThrottling_Enabled(t *testing.T) {
 	// Wait for any pending flushes
 	time.Sleep(200 * time.Millisecond)
 
-	count := atomic.LoadInt32(&flushCount)
+	count := int32(relay.sendCount())
 
 	// With throttling, we should have significantly fewer flushes than frames
 	// Without throttling, we'd have ~10 flushes (one per frame)
@@ -56,11 +46,8 @@ func TestSmartAggregator_FullRedrawThrottling_Enabled(t *testing.T) {
 	}
 
 	// Verify we still get the latest data
-	mu.Lock()
-	hasLatestFrame := bytes.Contains(lastData, []byte("frame content"))
-	mu.Unlock()
-
-	if !hasLatestFrame {
+	data := relay.getData()
+	if !bytes.Contains(data, []byte("frame content")) {
 		t.Error("Latest frame data should be preserved")
 	}
 }
@@ -68,12 +55,9 @@ func TestSmartAggregator_FullRedrawThrottling_Enabled(t *testing.T) {
 // TestSmartAggregator_FullRedrawThrottling_IncrementalNotThrottled tests that
 // incremental frames are not throttled
 func TestSmartAggregator_FullRedrawThrottling_IncrementalNotThrottled(t *testing.T) {
-	var flushCount int32
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			atomic.AddInt32(&flushCount, 1)
-		},
 		func() float64 { return 0 },
 		WithSmartBaseDelay(10*time.Millisecond),
 		WithFullRedrawThrottling(
@@ -84,6 +68,7 @@ func TestSmartAggregator_FullRedrawThrottling_IncrementalNotThrottled(t *testing
 			WithThrottlerMinDelay(200*time.Millisecond),
 		),
 	)
+	agg.SetRelayClient(relay)
 	defer agg.Stop()
 
 	// Send incremental frames (small, no clear screen)
@@ -96,7 +81,7 @@ func TestSmartAggregator_FullRedrawThrottling_IncrementalNotThrottled(t *testing
 	// Wait for flushes
 	time.Sleep(100 * time.Millisecond)
 
-	count := atomic.LoadInt32(&flushCount)
+	count := relay.sendCount()
 
 	// Incremental frames should not be throttled (or minimally affected)
 	// With 30ms between writes and 10ms base delay, we should get ~4-5 flushes
@@ -109,17 +94,15 @@ func TestSmartAggregator_FullRedrawThrottling_IncrementalNotThrottled(t *testing
 
 // TestSmartAggregator_FullRedrawThrottling_Disabled tests behavior without throttling
 func TestSmartAggregator_FullRedrawThrottling_Disabled(t *testing.T) {
-	var flushCount int32
+	relay := newMockRelayWriter(true)
 
 	// Create aggregator WITHOUT throttling
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			atomic.AddInt32(&flushCount, 1)
-		},
 		func() float64 { return 0 },
 		WithSmartBaseDelay(10*time.Millisecond),
 		// No WithFullRedrawThrottling
 	)
+	agg.SetRelayClient(relay)
 	defer agg.Stop()
 
 	// Send full redraw frames rapidly
@@ -132,7 +115,7 @@ func TestSmartAggregator_FullRedrawThrottling_Disabled(t *testing.T) {
 	// Wait for flushes
 	time.Sleep(100 * time.Millisecond)
 
-	count := atomic.LoadInt32(&flushCount)
+	count := relay.sendCount()
 
 	// Without throttling, we should get ~4-5 flushes (one per frame, aggregated by delay)
 	t.Logf("Frames written: 5, actual flushes without throttling: %d", count)

--- a/runner/internal/terminal/aggregator/smart_aggregator_throttle_recovery_test.go
+++ b/runner/internal/terminal/aggregator/smart_aggregator_throttle_recovery_test.go
@@ -2,7 +2,6 @@ package aggregator
 
 import (
 	"bytes"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -11,17 +10,9 @@ import (
 // TestSmartAggregator_FullRedrawThrottling_Recovery tests that throttling delay
 // decreases when frequency drops, and data is still eventually delivered
 func TestSmartAggregator_FullRedrawThrottling_Recovery(t *testing.T) {
-	var mu sync.Mutex
-	var flushedData [][]byte
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			mu.Lock()
-			dataCopy := make([]byte, len(data))
-			copy(dataCopy, data)
-			flushedData = append(flushedData, dataCopy)
-			mu.Unlock()
-		},
 		func() float64 { return 0 },
 		WithSmartBaseDelay(10*time.Millisecond),
 		WithFullRedrawThrottling(
@@ -32,6 +23,7 @@ func TestSmartAggregator_FullRedrawThrottling_Recovery(t *testing.T) {
 			WithThrottlerMinDelay(50*time.Millisecond),
 		),
 	)
+	agg.SetRelayClient(relay)
 	defer agg.Stop()
 
 	// Phase 1: High frequency full redraws
@@ -53,18 +45,10 @@ func TestSmartAggregator_FullRedrawThrottling_Recovery(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// Verify that at least the recovery frame was delivered
-	mu.Lock()
-	defer mu.Unlock()
+	data := relay.getData()
+	foundRecovery := bytes.Contains(data, []byte("recovery_frame"))
 
-	foundRecovery := false
-	for _, data := range flushedData {
-		if bytes.Contains(data, []byte("recovery_frame")) {
-			foundRecovery = true
-			break
-		}
-	}
-
-	t.Logf("Total flushes: %d, found recovery frame: %v", len(flushedData), foundRecovery)
+	t.Logf("Found recovery frame: %v", foundRecovery)
 
 	// The key assertion: data is eventually delivered
 	if !foundRecovery {
@@ -75,17 +59,9 @@ func TestSmartAggregator_FullRedrawThrottling_Recovery(t *testing.T) {
 // TestSmartAggregator_FullRedrawThrottling_ContentPreserved tests that
 // throttling preserves the latest content
 func TestSmartAggregator_FullRedrawThrottling_ContentPreserved(t *testing.T) {
-	var mu sync.Mutex
-	var allFlushed [][]byte
+	relay := newMockRelayWriter(true)
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			mu.Lock()
-			dataCopy := make([]byte, len(data))
-			copy(dataCopy, data)
-			allFlushed = append(allFlushed, dataCopy)
-			mu.Unlock()
-		},
 		func() float64 { return 0 },
 		WithSmartBaseDelay(10*time.Millisecond),
 		WithFullRedrawThrottling(
@@ -96,6 +72,7 @@ func TestSmartAggregator_FullRedrawThrottling_ContentPreserved(t *testing.T) {
 			WithThrottlerMinDelay(100*time.Millisecond),
 		),
 	)
+	agg.SetRelayClient(relay)
 	defer agg.Stop()
 
 	// Write frames with unique identifiers
@@ -110,39 +87,27 @@ func TestSmartAggregator_FullRedrawThrottling_ContentPreserved(t *testing.T) {
 	agg.Flush()
 	time.Sleep(50 * time.Millisecond)
 
-	// Check that we got the latest data in one of the flushes
-	mu.Lock()
-	defer mu.Unlock()
-
-	foundLatest := false
-	for _, data := range allFlushed {
-		if bytes.Contains(data, []byte("MARKER_")) {
-			// Found at least one marker
-			foundLatest = true
-			break
-		}
-	}
-
-	if !foundLatest {
+	// Check that we got the latest data in the relay
+	data := relay.getData()
+	if !bytes.Contains(data, []byte("MARKER_")) {
 		t.Error("Should have flushed at least some frame content")
 	}
 
-	t.Logf("Total flushes: %d", len(allFlushed))
+	t.Logf("Total relay data length: %d", len(data))
 }
 
 // TestSmartAggregator_FullRedrawThrottling_SerializeModeBypassed tests that
 // throttling is bypassed in serialize mode (VirtualTerminal mode)
 func TestSmartAggregator_FullRedrawThrottling_SerializeModeBypassed(t *testing.T) {
 	var flushCount int32
+	relay := newMockRelayWriter(true)
 	serializedOutput := []byte("serialized content")
 
 	agg := NewSmartAggregator(
-		func(data []byte) {
-			atomic.AddInt32(&flushCount, 1)
-		},
 		func() float64 { return 0 },
 		WithSmartBaseDelay(10*time.Millisecond),
 		WithSerializeCallback(func() []byte {
+			atomic.AddInt32(&flushCount, 1)
 			return serializedOutput
 		}),
 		WithFullRedrawThrottling(
@@ -153,6 +118,7 @@ func TestSmartAggregator_FullRedrawThrottling_SerializeModeBypassed(t *testing.T
 			WithThrottlerMinDelay(200*time.Millisecond),
 		),
 	)
+	agg.SetRelayClient(relay)
 	defer agg.Stop()
 
 	// In serialize mode, Write() just marks pending data
@@ -167,7 +133,7 @@ func TestSmartAggregator_FullRedrawThrottling_SerializeModeBypassed(t *testing.T
 
 	// In serialize mode, throttling should be bypassed
 	// We should get normal flush behavior
-	t.Logf("Serialize mode: %d flushes for 5 writes", count)
+	t.Logf("Serialize mode: %d serialize callbacks for 5 writes", count)
 
 	// Should have at least some flushes (not throttled)
 	if count < 2 {


### PR DESCRIPTION
## Summary

Fixes three systemic issues causing Loop/Autopilot pods to be incorrectly marked as `error`:

- **Remove early buffer mechanism**: OutputRouter's 64KB early buffer captured normal ANSI terminal output and sent it as `ErrorMessage` on pod exit, causing Backend to mismark all Loop/Autopilot pods as `error`. Removed entirely along with gRPC fallback dead code (242→69 lines).
- **Runner-owned status decision**: Added `status` field to `PodTerminatedEvent` proto. Runner now explicitly sends `"completed"` or `"error"` based on exit code semantics (1-127=error, 0/≥128=completed) and PTY errors. Backend stores directly, no inference.
- **Per-pod command queue**: Added `PodCommandQueue` that serializes gRPC commands per pod_key, eliminating the race condition where `create_autopilot` executed before `create_pod` finished registering the pod.

## Test plan

- [x] `runner/internal/terminal/aggregator/...` tests pass
- [x] `runner/internal/runner/...` tests pass
- [x] `runner/internal/client/...` tests pass (including 9 new PodCommandQueue tests)
- [x] `backend/internal/service/runner/...` tests pass
- [x] Race detector passes on PodCommandQueue
- [x] Dev environment: Pod create → terminate → status=terminated (not error)
- [x] Dev environment: Loop trigger → Autopilot created successfully (no "pod not found")
- [x] Dev environment: Loop run completes as `completed` (not `failed`)