### PR TITLE
fix(backend): update last_login_at for OAuth and SSO login paths

### DIFF
--- a/backend/internal/api/rest/router.go
+++ b/backend/internal/api/rest/router.go
@@ -85,7 +85,7 @@ func NewRouter(cfg *config.Config, svc *v1.Services, db *gorm.DB, logger *slog.L
 
 		// SSO authentication routes (public, under /auth/sso)
 		if svc.SSO != nil {
-			ssoAuthHandler := v1.NewSSOAuthHandler(svc.SSO, svc.Auth, svc.User, cfg)
+			ssoAuthHandler := v1.NewSSOAuthHandler(svc.SSO, svc.Auth, cfg)
 			ssoAuthHandler.RegisterRoutes(authGroup.Group("/sso"))
 		}
 

--- a/backend/internal/api/rest/v1/auth_sso.go
+++ b/backend/internal/api/rest/v1/auth_sso.go
@@ -1,20 +1,17 @@
 package v1
 
 import (
-	"fmt"
 	"log/slog"
 	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/anthropics/agentsmesh/backend/internal/config"
 	"github.com/anthropics/agentsmesh/backend/internal/domain/sso"
 	userDomain "github.com/anthropics/agentsmesh/backend/internal/domain/user"
 	"github.com/anthropics/agentsmesh/backend/internal/service/auth"
 	ssoservice "github.com/anthropics/agentsmesh/backend/internal/service/sso"
-	"github.com/anthropics/agentsmesh/backend/internal/service/user"
 	"github.com/anthropics/agentsmesh/backend/pkg/apierr"
 	ssoprovider "github.com/anthropics/agentsmesh/backend/pkg/auth/sso"
 	"github.com/gin-gonic/gin"
@@ -27,16 +24,14 @@ var domainRegexp = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\
 type SSOAuthHandler struct {
 	ssoService  *ssoservice.Service
 	authService *auth.Service
-	userService *user.Service
 	config      *config.Config
 }
 
 // NewSSOAuthHandler creates a new SSO auth handler
-func NewSSOAuthHandler(ssoSvc *ssoservice.Service, authSvc *auth.Service, userSvc *user.Service, cfg *config.Config) *SSOAuthHandler {
+func NewSSOAuthHandler(ssoSvc *ssoservice.Service, authSvc *auth.Service, cfg *config.Config) *SSOAuthHandler {
 	return &SSOAuthHandler{
 		ssoService:  ssoSvc,
 		authService: authSvc,
-		userService: userSvc,
 		config:      cfg,
 	}
 }
@@ -82,30 +77,20 @@ func (h *SSOAuthHandler) Discover(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"configs": result})
 }
 
-// errAccountDisabled is returned by authenticateSSO when the user account is deactivated.
-var errAccountDisabled = fmt.Errorf("account is disabled")
-
 // authenticateSSO creates/gets the user from SSO identity, checks if active, and generates tokens.
 // It does NOT write HTTP responses — callers decide how to handle errors (JSON vs redirect).
 func (h *SSOAuthHandler) authenticateSSO(c *gin.Context, protocol sso.Protocol, configID int64, userInfo *ssoprovider.UserInfo) (*userDomain.User, *auth.TokenPair, error) {
 	providerName := ssoservice.SSOProviderName(protocol, configID)
-	u, _, err := h.userService.GetOrCreateByOAuth(c.Request.Context(), providerName, userInfo.ExternalID, userInfo.Username, userInfo.Email, userInfo.Name, userInfo.AvatarURL)
+	u, tokens, err := h.authService.SSOLogin(c.Request.Context(), &auth.SSOLoginRequest{
+		ProviderName: providerName,
+		ExternalID:   userInfo.ExternalID,
+		Username:     userInfo.Username,
+		Email:        userInfo.Email,
+		Name:         userInfo.Name,
+		AvatarURL:    userInfo.AvatarURL,
+	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create/get user: %w", err)
-	}
-
-	// Reject disabled users — admin may have deactivated them after SSO identity was created
-	if !u.IsActive {
-		return nil, nil, errAccountDisabled
-	}
-
-	// Update last login time
-	now := time.Now()
-	_, _ = h.userService.Update(c.Request.Context(), u.ID, map[string]interface{}{"last_login_at": now})
-
-	tokens, err := h.authService.GenerateTokenPair(u, 0, "")
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to generate tokens: %w", err)
+		return nil, nil, err
 	}
 
 	return u, tokens, nil

--- a/backend/internal/api/rest/v1/auth_sso_ldap.go
+++ b/backend/internal/api/rest/v1/auth_sso_ldap.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/anthropics/agentsmesh/backend/internal/domain/sso"
+	"github.com/anthropics/agentsmesh/backend/internal/service/auth"
 	ssoservice "github.com/anthropics/agentsmesh/backend/internal/service/sso"
 	"github.com/anthropics/agentsmesh/backend/pkg/apierr"
 	"github.com/gin-gonic/gin"
@@ -42,7 +43,7 @@ func (h *SSOAuthHandler) LDAPAuth(c *gin.Context) {
 	// Authenticate, create/get user, and generate tokens
 	u, tokens, err := h.authenticateSSO(c, sso.ProtocolLDAP, configID, userInfo)
 	if err != nil {
-		if errors.Is(err, errAccountDisabled) {
+		if errors.Is(err, auth.ErrUserDisabled) {
 			apierr.Forbidden(c, apierr.ACCOUNT_DISABLED, "Account is disabled")
 		} else {
 			apierr.InternalError(c, "Failed to process authentication")

--- a/backend/internal/api/rest/v1/auth_sso_oidc.go
+++ b/backend/internal/api/rest/v1/auth_sso_oidc.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/anthropics/agentsmesh/backend/internal/domain/sso"
+	"github.com/anthropics/agentsmesh/backend/internal/service/auth"
 	ssoservice "github.com/anthropics/agentsmesh/backend/internal/service/sso"
 	"github.com/anthropics/agentsmesh/backend/pkg/apierr"
 	"github.com/gin-gonic/gin"
@@ -110,7 +111,7 @@ func (h *SSOAuthHandler) OIDCCallback(c *gin.Context) {
 	if err != nil {
 		slog.Error("OIDC user authentication failed", "domain", domain, "error", err)
 		errorCode := "authentication_failed"
-		if errors.Is(err, errAccountDisabled) {
+		if errors.Is(err, auth.ErrUserDisabled) {
 			errorCode = "account_disabled"
 		}
 		h.redirectWithError(c, redirectTo, errorCode)

--- a/backend/internal/api/rest/v1/auth_sso_saml.go
+++ b/backend/internal/api/rest/v1/auth_sso_saml.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/anthropics/agentsmesh/backend/internal/domain/sso"
+	"github.com/anthropics/agentsmesh/backend/internal/service/auth"
 	ssoservice "github.com/anthropics/agentsmesh/backend/internal/service/sso"
 	"github.com/anthropics/agentsmesh/backend/pkg/apierr"
 	"github.com/gin-gonic/gin"
@@ -94,7 +95,7 @@ func (h *SSOAuthHandler) SAMLACS(c *gin.Context) {
 	if err != nil {
 		slog.Error("SAML user authentication failed", "domain", domain, "error", err)
 		errorCode := "authentication_failed"
-		if errors.Is(err, errAccountDisabled) {
+		if errors.Is(err, auth.ErrUserDisabled) {
 			errorCode = "account_disabled"
 		}
 		h.redirectWithError(c, redirectTo, errorCode)

--- a/backend/internal/service/auth/auth_oauth.go
+++ b/backend/internal/service/auth/auth_oauth.go
@@ -93,8 +93,7 @@ func (s *Service) HandleOAuthCallback(ctx context.Context, provider, code, state
 	}
 
 	// Update last login time
-	now := time.Now()
-	_, _ = s.userService.Update(ctx, u.ID, map[string]interface{}{"last_login_at": now})
+	s.userService.RecordLogin(ctx, u.ID)
 
 	// Generate tokens
 	tokens, err := s.GenerateTokenPair(u, 0, "")
@@ -147,8 +146,7 @@ func (s *Service) OAuthLogin(ctx context.Context, req *OAuthLoginRequest) (*Logi
 	}
 
 	// Update last login time
-	now := time.Now()
-	_, _ = s.userService.Update(ctx, u.ID, map[string]interface{}{"last_login_at": now})
+	s.userService.RecordLogin(ctx, u.ID)
 
 	tokens, err := s.GenerateTokenPair(u, 0, "")
 	if err != nil {

--- a/backend/internal/service/auth/auth_sso.go
+++ b/backend/internal/service/auth/auth_sso.go
@@ -1,0 +1,40 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/anthropics/agentsmesh/backend/internal/domain/user"
+)
+
+// SSOLoginRequest represents an SSO login request with user info from the SSO provider.
+type SSOLoginRequest struct {
+	ProviderName string
+	ExternalID   string
+	Username     string
+	Email        string
+	Name         string
+	AvatarURL    string
+}
+
+// SSOLogin authenticates a user via SSO identity, records the login, and returns tokens.
+// It mirrors OAuthLogin but for SSO providers (LDAP, SAML, OIDC).
+func (s *Service) SSOLogin(ctx context.Context, req *SSOLoginRequest) (*user.User, *TokenPair, error) {
+	u, _, err := s.userService.GetOrCreateByOAuth(ctx, req.ProviderName, req.ExternalID, req.Username, req.Email, req.Name, req.AvatarURL)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create/get user: %w", err)
+	}
+
+	if !u.IsActive {
+		return nil, nil, ErrUserDisabled
+	}
+
+	s.userService.RecordLogin(ctx, u.ID)
+
+	tokens, err := s.GenerateTokenPair(u, 0, "")
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate tokens: %w", err)
+	}
+
+	return u, tokens, nil
+}

--- a/backend/internal/service/auth/service_oauth_login_test.go
+++ b/backend/internal/service/auth/service_oauth_login_test.go
@@ -111,6 +111,34 @@ func TestOAuthLoginWithUserService(t *testing.T) {
 			t.Error("User should not be nil")
 		}
 	})
+
+	t.Run("updates last_login_at on oauth login", func(t *testing.T) {
+		req := &OAuthLoginRequest{
+			Provider:       "github",
+			ProviderUserID: "gh_login_time",
+			Email:          "logintime@example.com",
+			Username:       "logintime",
+			Name:           "Login Time User",
+		}
+
+		before := time.Now()
+		result, err := svc.OAuthLogin(ctx, req)
+		if err != nil {
+			t.Fatalf("OAuthLogin failed: %v", err)
+		}
+
+		// Re-fetch user from DB to verify last_login_at
+		u, err := userSvc.GetByID(ctx, result.User.ID)
+		if err != nil {
+			t.Fatalf("GetByID failed: %v", err)
+		}
+		if u.LastLoginAt == nil {
+			t.Fatal("expected LastLoginAt to be set after OAuth login")
+		}
+		if u.LastLoginAt.Before(before) {
+			t.Error("expected LastLoginAt to be >= time before OAuth login")
+		}
+	})
 }
 
 func TestOAuthLoginErrors(t *testing.T) {

--- a/backend/internal/service/auth/service_sso_login_test.go
+++ b/backend/internal/service/auth/service_sso_login_test.go
@@ -1,0 +1,123 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/anthropics/agentsmesh/backend/internal/infra"
+	userService "github.com/anthropics/agentsmesh/backend/internal/service/user"
+)
+
+func TestSSOLoginWithUserService(t *testing.T) {
+	db := setupTestDB(t)
+	userSvc := userService.NewService(infra.NewUserRepository(db))
+	ctx := context.Background()
+
+	cfg := &Config{
+		JWTSecret:         "test-secret-key-at-least-32-bytes",
+		JWTExpiration:     time.Hour,
+		RefreshExpiration: time.Hour * 24 * 7,
+		Issuer:            "test-issuer",
+	}
+	svc := NewService(cfg, userSvc)
+
+	t.Run("creates new user via SSO", func(t *testing.T) {
+		req := &SSOLoginRequest{
+			ProviderName: "sso_oidc_42",
+			ExternalID:   "ext_001",
+			Email:        "ssouser@example.com",
+			Username:     "ssouser",
+			Name:         "SSO User",
+			AvatarURL:    "https://idp.example.com/avatar.png",
+		}
+
+		u, tokens, err := svc.SSOLogin(ctx, req)
+		if err != nil {
+			t.Fatalf("SSOLogin failed: %v", err)
+		}
+		if u == nil {
+			t.Fatal("User should not be nil")
+		}
+		if u.Email != "ssouser@example.com" {
+			t.Errorf("Email = %s, want ssouser@example.com", u.Email)
+		}
+		if tokens.AccessToken == "" {
+			t.Error("AccessToken should not be empty")
+		}
+		if tokens.RefreshToken == "" {
+			t.Error("RefreshToken should not be empty")
+		}
+	})
+
+	t.Run("returns existing user via SSO", func(t *testing.T) {
+		req := &SSOLoginRequest{
+			ProviderName: "sso_ldap_10",
+			ExternalID:   "ext_exist",
+			Email:        "existing-sso@example.com",
+			Username:     "existingsso",
+			Name:         "Existing SSO",
+		}
+		u1, _, _ := svc.SSOLogin(ctx, req)
+
+		// Second SSO login returns same user
+		u2, _, err := svc.SSOLogin(ctx, req)
+		if err != nil {
+			t.Fatalf("Second SSOLogin failed: %v", err)
+		}
+		if u2.ID != u1.ID {
+			t.Errorf("User ID mismatch: %d != %d", u2.ID, u1.ID)
+		}
+	})
+
+	t.Run("rejects disabled user", func(t *testing.T) {
+		req := &SSOLoginRequest{
+			ProviderName: "sso_saml_5",
+			ExternalID:   "ext_disabled",
+			Email:        "disabled-sso@example.com",
+			Username:     "disabledsso",
+			Name:         "Disabled SSO",
+		}
+		// Create user first
+		svc.SSOLogin(ctx, req)
+
+		// Disable the user
+		db.Exec("UPDATE users SET is_active = 0 WHERE email = ?", "disabled-sso@example.com")
+
+		_, _, err := svc.SSOLogin(ctx, req)
+		if err == nil {
+			t.Fatal("expected error for disabled user")
+		}
+		if err != ErrUserDisabled {
+			t.Errorf("expected ErrUserDisabled, got %v", err)
+		}
+	})
+
+	t.Run("updates last_login_at on SSO login", func(t *testing.T) {
+		req := &SSOLoginRequest{
+			ProviderName: "sso_oidc_99",
+			ExternalID:   "ext_login_time",
+			Email:        "ssologintime@example.com",
+			Username:     "ssologintime",
+			Name:         "SSO Login Time",
+		}
+
+		before := time.Now()
+		u, _, err := svc.SSOLogin(ctx, req)
+		if err != nil {
+			t.Fatalf("SSOLogin failed: %v", err)
+		}
+
+		// Re-fetch from DB
+		fetched, err := userSvc.GetByID(ctx, u.ID)
+		if err != nil {
+			t.Fatalf("GetByID failed: %v", err)
+		}
+		if fetched.LastLoginAt == nil {
+			t.Fatal("expected LastLoginAt to be set after SSO login")
+		}
+		if fetched.LastLoginAt.Before(before) {
+			t.Error("expected LastLoginAt to be >= time before SSO login")
+		}
+	})
+}

--- a/backend/internal/service/user/interface.go
+++ b/backend/internal/service/user/interface.go
@@ -21,6 +21,7 @@ type Interface interface {
 	// Authentication
 	Authenticate(ctx context.Context, email, password string) (*user.User, error)
 	UpdatePassword(ctx context.Context, id int64, password string) error
+	RecordLogin(ctx context.Context, userID int64)
 
 	// OAuth
 	GetOrCreateByOAuth(ctx context.Context, provider, providerUserID, providerUsername, email, name, avatarURL string) (*user.User, bool, error)

--- a/backend/internal/service/user/mock_auth_test.go
+++ b/backend/internal/service/user/mock_auth_test.go
@@ -78,6 +78,30 @@ func TestMockServiceGetOrCreateByOAuth(t *testing.T) {
 	})
 }
 
+func TestMockServiceRecordLogin(t *testing.T) {
+	ctx := context.Background()
+	mock := NewMockService()
+
+	u, _ := mock.Create(ctx, &CreateRequest{Email: "test@example.com", Username: "test"})
+
+	t.Run("records login call", func(t *testing.T) {
+		mock.RecordLogin(ctx, u.ID)
+		if len(mock.RecordLoginCalls) != 1 {
+			t.Errorf("RecordLoginCalls count = %d, want 1", len(mock.RecordLoginCalls))
+		}
+		if mock.RecordLoginCalls[0] != u.ID {
+			t.Errorf("RecordLoginCalls[0] = %d, want %d", mock.RecordLoginCalls[0], u.ID)
+		}
+	})
+
+	t.Run("records multiple calls", func(t *testing.T) {
+		mock.RecordLogin(ctx, u.ID)
+		if len(mock.RecordLoginCalls) != 2 {
+			t.Errorf("RecordLoginCalls count = %d, want 2", len(mock.RecordLoginCalls))
+		}
+	})
+}
+
 func TestMockServiceUpdateIdentityTokens(t *testing.T) {
 	ctx := context.Background()
 	mock := NewMockService()

--- a/backend/internal/service/user/mock_service.go
+++ b/backend/internal/service/user/mock_service.go
@@ -38,6 +38,7 @@ type MockService struct {
 	UpdatedUsers     []map[string]interface{}
 	DeletedUserIDs   []int64
 	AuthAttempts     []authAttempt
+	RecordLoginCalls []int64
 	SearchQueries    []string
 }
 
@@ -193,6 +194,14 @@ func (m *MockService) Authenticate(ctx context.Context, email, password string) 
 	return m.GetByEmail(ctx, email)
 }
 
+// RecordLogin implements Interface.
+func (m *MockService) RecordLogin(_ context.Context, userID int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.RecordLoginCalls = append(m.RecordLoginCalls, userID)
+}
+
 // GetOrCreateByOAuth implements Interface.
 func (m *MockService) GetOrCreateByOAuth(ctx context.Context, provider, providerUserID, providerUsername, email, name, avatarURL string) (*user.User, bool, error) {
 	if m.GetOrCreateByOAuthErr != nil {
@@ -344,6 +353,7 @@ func (m *MockService) Reset() {
 	m.UpdatedUsers = nil
 	m.DeletedUserIDs = nil
 	m.AuthAttempts = nil
+	m.RecordLoginCalls = nil
 	m.SearchQueries = nil
 }
 

--- a/backend/internal/service/user/service_auth_test.go
+++ b/backend/internal/service/user/service_auth_test.go
@@ -3,6 +3,7 @@ package user
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/anthropics/agentsmesh/backend/internal/infra"
 )
@@ -96,6 +97,101 @@ func TestAuthenticateInactiveUser(t *testing.T) {
 	if err != ErrUserInactive {
 		t.Errorf("expected ErrUserInactive, got %v", err)
 	}
+}
+
+func TestAuthenticateUpdatesLastLoginAt(t *testing.T) {
+	db := setupTestDB(t)
+	service := NewService(infra.NewUserRepository(db))
+	ctx := context.Background()
+
+	req := &CreateRequest{
+		Email:    "login@example.com",
+		Username: "loginuser",
+		Password: "password123",
+	}
+	created, _ := service.Create(ctx, req)
+
+	// Verify last_login_at is nil before first login
+	u, _ := service.GetByID(ctx, created.ID)
+	if u.LastLoginAt != nil {
+		t.Error("expected LastLoginAt to be nil before first login")
+	}
+
+	before := time.Now()
+	_, err := service.Authenticate(ctx, "login@example.com", "password123")
+	if err != nil {
+		t.Fatalf("failed to authenticate: %v", err)
+	}
+
+	// Re-fetch user to verify last_login_at was updated
+	u, _ = service.GetByID(ctx, created.ID)
+	if u.LastLoginAt == nil {
+		t.Fatal("expected LastLoginAt to be set after login")
+	}
+	if u.LastLoginAt.Before(before) {
+		t.Error("expected LastLoginAt to be >= time before authentication")
+	}
+}
+
+func TestRecordLogin(t *testing.T) {
+	db := setupTestDB(t)
+	service := NewService(infra.NewUserRepository(db))
+	ctx := context.Background()
+
+	created, _ := service.Create(ctx, &CreateRequest{
+		Email:    "record@example.com",
+		Username: "recorduser",
+		Password: "password123",
+	})
+
+	before := time.Now()
+	service.RecordLogin(ctx, created.ID)
+
+	u, _ := service.GetByID(ctx, created.ID)
+	if u.LastLoginAt == nil {
+		t.Fatal("expected LastLoginAt to be set after RecordLogin")
+	}
+	if u.LastLoginAt.Before(before) {
+		t.Error("expected LastLoginAt to be >= time before RecordLogin")
+	}
+}
+
+func TestRecordLoginMultipleCalls(t *testing.T) {
+	db := setupTestDB(t)
+	service := NewService(infra.NewUserRepository(db))
+	ctx := context.Background()
+
+	created, _ := service.Create(ctx, &CreateRequest{
+		Email:    "multi@example.com",
+		Username: "multiuser",
+		Password: "password123",
+	})
+
+	// First login
+	service.RecordLogin(ctx, created.ID)
+	u1, _ := service.GetByID(ctx, created.ID)
+	first := *u1.LastLoginAt
+
+	// Small delay to ensure different timestamp
+	time.Sleep(10 * time.Millisecond)
+
+	// Second login
+	service.RecordLogin(ctx, created.ID)
+	u2, _ := service.GetByID(ctx, created.ID)
+	second := *u2.LastLoginAt
+
+	if !second.After(first) {
+		t.Errorf("expected second login time %v to be after first %v", second, first)
+	}
+}
+
+func TestRecordLoginNonExistentUser(t *testing.T) {
+	db := setupTestDB(t)
+	service := NewService(infra.NewUserRepository(db))
+	ctx := context.Background()
+
+	// Should not panic — errors are logged, not returned
+	service.RecordLogin(ctx, 99999)
 }
 
 func TestUpdatePassword(t *testing.T) {

--- a/backend/internal/service/user/user_auth.go
+++ b/backend/internal/service/user/user_auth.go
@@ -32,12 +32,19 @@ func (s *Service) Authenticate(ctx context.Context, email, password string) (*us
 		return nil, ErrInvalidCredentials
 	}
 
-	// Update last login
-	now := time.Now()
-	_ = s.repo.UpdateUserField(ctx, u.ID, "last_login_at", now)
+	s.RecordLogin(ctx, u.ID)
 
 	slog.Info("user authenticated", "user_id", u.ID, "email", email)
 	return u, nil
+}
+
+// RecordLogin updates the user's last login timestamp.
+// Errors are logged but not returned since login should not fail due to timestamp update.
+func (s *Service) RecordLogin(ctx context.Context, userID int64) {
+	now := time.Now()
+	if err := s.repo.UpdateUserField(ctx, userID, "last_login_at", now); err != nil {
+		slog.Warn("failed to update last_login_at", "user_id", userID, "error", err)
+	}
 }
 
 // SetEmailVerificationToken generates and sets a verification token for the user


### PR DESCRIPTION
The last_login_at field was only updated during password authentication, leaving it stale for users who log in via OAuth (GitHub, Google, GitLab, Gitee) or SSO (OIDC, SAML, LDAP). This caused the admin console to show incorrect or missing last login times.

## Summary

- What changed?
- Why was this change needed?

## Changes

- 

## Validation

- [ ] Backend tests (`cd backend && go test ./...`)
- [ ] Web checks (`cd web && pnpm run lint && pnpm run type-check && pnpm run test:coverage`)
- [ ] Runner checks (`cd runner && go test ./...`)
- [ ] Manual validation performed (if applicable)

## Documentation

- [ ] Docs updated (README/docs/inline comments)
- [ ] No docs changes needed

## Risk and Rollback

- Risk level: Low / Medium / High
- Rollback plan:
