### PR TITLE
fix: add --verbose flag for Claude Code ACP stream-json mode

### DIFF
--- a/backend/migrations/000100_claude_acp_add_verbose_flag.down.sql
+++ b/backend/migrations/000100_claude_acp_add_verbose_flag.down.sql
@@ -1,0 +1,6 @@
+-- Revert --verbose flag addition
+UPDATE agents SET agentfile_source = REPLACE(
+    agentfile_source,
+    E'MODE acp "-p" "--verbose" "--input-format" "stream-json" "--output-format" "stream-json"',
+    E'MODE acp "-p" "--input-format" "stream-json" "--output-format" "stream-json"'
+) WHERE slug = 'claude-code';

--- a/backend/migrations/000100_claude_acp_add_verbose_flag.up.sql
+++ b/backend/migrations/000100_claude_acp_add_verbose_flag.up.sql
@@ -1,0 +1,8 @@
+-- Claude Code >=2.1.92 requires --verbose when using --output-format stream-json with -p
+-- Without it: "Error: When using --print, --output-format=stream-json requires --verbose"
+
+UPDATE agents SET agentfile_source = REPLACE(
+    agentfile_source,
+    E'MODE acp "-p" "--input-format" "stream-json" "--output-format" "stream-json"',
+    E'MODE acp "-p" "--verbose" "--input-format" "stream-json" "--output-format" "stream-json"'
+) WHERE slug = 'claude-code';


### PR DESCRIPTION
## Summary

- Claude Code >=2.1.92 requires `--verbose` when using `--output-format stream-json` with `-p` flag
- Without it, ACP subprocess exits immediately (exit_code=1): `Error: When using --print, --output-format=stream-json requires --verbose`
- Migration 000100 updates the Claude Code AgentFile `MODE acp` args to include `--verbose`

## Test plan

- [ ] Run migration on staging DB
- [ ] Create a new Claude Code pod and verify it starts successfully
- [ ] Verify ACP stream-json communication works end-to-end