### PR TITLE
refactor(ci): split deploy into independent parallel jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,58 @@ env:
 
 jobs:
   # ===========================================================================
-  # Build and push Docker images (server-side services)
-  # main push: backend, web, web-admin, relay (short sha tag)
-  # v* tag:    backend, web, web-admin, relay (semver tags)
+  # Detect which services have changed files
+  # ===========================================================================
+
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      web: ${{ steps.filter.outputs.web }}
+      web-admin: ${{ steps.filter.outputs.web-admin }}
+      relay: ${{ steps.filter.outputs.relay }}
+      migrations: ${{ steps.filter.outputs.migrations }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+              - 'proto/**'
+              - 'agentfile/**'
+              - 'ci/backend.Dockerfile'
+            web:
+              - 'web/**'
+              - 'ci/web.Dockerfile'
+            web-admin:
+              - 'web-admin/**'
+              - 'ci/web-admin.Dockerfile'
+            relay:
+              - 'relay/**'
+              - 'ci/relay.Dockerfile'
+            migrations:
+              - 'backend/migrations/**'
+
+  # ===========================================================================
+  # Build and push Docker images (only changed services)
   # ===========================================================================
 
   build-images:
     name: Build ${{ matrix.service }}
     runs-on: ubuntu-latest
+    needs: changes
+    if: |
+      always() && (
+        (matrix.service == 'backend' && needs.changes.outputs.backend == 'true') ||
+        (matrix.service == 'web' && needs.changes.outputs.web == 'true') ||
+        (matrix.service == 'web-admin' && needs.changes.outputs.web-admin == 'true') ||
+        (matrix.service == 'relay' && needs.changes.outputs.relay == 'true') ||
+        startsWith(github.ref, 'refs/tags/v')
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -101,26 +145,24 @@ jobs:
           platforms: linux/amd64,linux/arm64
 
   # ===========================================================================
-  # Deploy to US West production (main branch only, auto after build)
-  # Each service is an independent job for parallel execution and isolation.
+  # Deploy US West production (independent parallel jobs, changes-based)
   # ===========================================================================
 
   deploy-uswest-backend:
     name: Deploy US West Backend
-    needs: build-images
+    needs: [changes, build-images]
+    if: always() && needs.changes.outputs.backend == 'true' && needs.build-images.result != 'failure'
     runs-on: [self-hosted, deploy]
-    if: github.ref == 'refs/heads/main'
     steps:
       - run: |
           VERSION="${{ needs.build-images.outputs.version }}"
-          ssh aliyun-us-west-001 "cd /opt/agentsmesh && git pull origin main"
           ssh aliyun-us-west-001 "cd /opt/agentsmesh && ./deploy.sh uswest-prod --service backend --version ${VERSION}"
 
   deploy-uswest-web:
     name: Deploy US West Web
-    needs: build-images
+    needs: [changes, build-images]
+    if: always() && needs.changes.outputs.web == 'true' && needs.build-images.result != 'failure'
     runs-on: [self-hosted, deploy]
-    if: github.ref == 'refs/heads/main'
     steps:
       - run: |
           VERSION="${{ needs.build-images.outputs.version }}"
@@ -128,9 +170,9 @@ jobs:
 
   deploy-uswest-web-admin:
     name: Deploy US West Web-Admin
-    needs: build-images
+    needs: [changes, build-images]
+    if: always() && needs.changes.outputs.web-admin == 'true' && needs.build-images.result != 'failure'
     runs-on: [self-hosted, deploy]
-    if: github.ref == 'refs/heads/main'
     steps:
       - run: |
           VERSION="${{ needs.build-images.outputs.version }}"
@@ -138,40 +180,40 @@ jobs:
 
   deploy-uswest-relay-01:
     name: Deploy US West Relay 01
-    needs: build-images
+    needs: [changes, build-images]
+    if: always() && needs.changes.outputs.relay == 'true' && needs.build-images.result != 'failure'
     runs-on: [self-hosted, deploy]
-    if: github.ref == 'refs/heads/main'
     steps:
       - run: |
           ssh aliyun-us-west-relay-001 "cd /opt/agentsmesh/relay && ./deploy.sh uswest-relay-01 --pull"
 
   deploy-uswest-relay-beijing-02:
     name: Deploy US West Relay Beijing 02
-    needs: build-images
+    needs: [changes, build-images]
+    if: always() && needs.changes.outputs.relay == 'true' && needs.build-images.result != 'failure'
     runs-on: [self-hosted, deploy]
-    if: github.ref == 'refs/heads/main'
     steps:
       - run: |
           ssh aliyun-agentsmesh-us-relay-beijing-002 "cd /opt/agentsmesh/relay && ./deploy.sh uswest-relay-beijing-02 --pull"
 
   migrate-uswest:
     name: Migrate US West
-    needs: deploy-uswest-backend
+    needs: [changes, deploy-uswest-backend]
+    if: always() && needs.changes.outputs.migrations == 'true' && needs.deploy-uswest-backend.result == 'success'
     runs-on: [self-hosted, deploy]
-    if: github.ref == 'refs/heads/main'
     steps:
       - run: |
           ssh aliyun-us-west-001 "cd /opt/agentsmesh && ./migrate.sh uswest-prod --direction up"
 
   # ===========================================================================
-  # Deploy to China production (main branch only, auto after build)
+  # Deploy China production (independent parallel jobs, changes-based)
   # ===========================================================================
 
   deploy-cn-backend:
     name: Deploy CN Backend
-    needs: build-images
+    needs: [changes, build-images]
+    if: always() && needs.changes.outputs.backend == 'true' && needs.build-images.result != 'failure'
     runs-on: [self-hosted, deploy]
-    if: github.ref == 'refs/heads/main'
     steps:
       - run: |
           VERSION="${{ needs.build-images.outputs.version }}"
@@ -179,9 +221,9 @@ jobs:
 
   deploy-cn-web:
     name: Deploy CN Web
-    needs: build-images
+    needs: [changes, build-images]
+    if: always() && needs.changes.outputs.web == 'true' && needs.build-images.result != 'failure'
     runs-on: [self-hosted, deploy]
-    if: github.ref == 'refs/heads/main'
     steps:
       - run: |
           VERSION="${{ needs.build-images.outputs.version }}"
@@ -189,9 +231,9 @@ jobs:
 
   deploy-cn-web-admin:
     name: Deploy CN Web-Admin
-    needs: build-images
+    needs: [changes, build-images]
+    if: always() && needs.changes.outputs.web-admin == 'true' && needs.build-images.result != 'failure'
     runs-on: [self-hosted, deploy]
-    if: github.ref == 'refs/heads/main'
     steps:
       - run: |
           VERSION="${{ needs.build-images.outputs.version }}"
@@ -199,18 +241,18 @@ jobs:
 
   deploy-cn-relay-01:
     name: Deploy CN Relay 01
-    needs: build-images
+    needs: [changes, build-images]
+    if: always() && needs.changes.outputs.relay == 'true' && needs.build-images.result != 'failure'
     runs-on: [self-hosted, deploy]
-    if: github.ref == 'refs/heads/main'
     steps:
       - run: |
           ssh aliyun-cn-relay-01 "cd /opt/agentsmesh/relay && ./deploy.sh cn-relay-01 --pull"
 
   migrate-cn:
     name: Migrate CN
-    needs: deploy-cn-backend
+    needs: [changes, deploy-cn-backend]
+    if: always() && needs.changes.outputs.migrations == 'true' && needs.deploy-cn-backend.result == 'success'
     runs-on: [self-hosted, deploy]
-    if: github.ref == 'refs/heads/main'
     steps:
       - run: |
           ssh aliyun-s001 "cd /opt/agentsmesh && ./migrate.sh cn-prod --direction up"


### PR DESCRIPTION
## Summary
- Split monolithic deploy-uswest and deploy-cn jobs into 11 independent jobs
- Each service (backend, web, web-admin, relay) deploys as its own job
- Migration jobs depend only on their region's backend deploy (`needs`)
- All other deploy jobs run in parallel after build-images completes
- Registered 5 self-hosted runners (up from 1) to support concurrent execution

## Job dependency graph
```
build-images (4 matrix jobs, parallel)
    │
    ├─► deploy-uswest-backend ──► migrate-uswest
    ├─► deploy-uswest-web
    ├─► deploy-uswest-web-admin
    ├─► deploy-uswest-relay-01
    ├─► deploy-uswest-relay-beijing-02
    ├─► deploy-cn-backend ──► migrate-cn
    ├─► deploy-cn-web
    ├─► deploy-cn-web-admin
    └─► deploy-cn-relay-01
```

## Test plan
- [ ] All deploy jobs run in parallel (not sequentially)
- [ ] One failed deploy does not block other deploys
- [ ] Migration waits for backend deploy to complete