### PR TITLE
fix(acp): handle Resync so browser receives ACP session snapshot

### DIFF
--- a/runner/internal/runner/pod_relay_acp.go
+++ b/runner/internal/runner/pod_relay_acp.go
@@ -26,6 +26,9 @@ func NewACPPodRelay(podKey string, acpClient *acp.ACPClient, onCommand func([]by
 
 func (r *ACPPodRelay) SetupHandlers(rc relay.RelayClient) {
 	rc.SetMessageHandler(relay.MsgTypeAcpCommand, r.onCommand)
+	rc.SetMessageHandler(relay.MsgTypeResync, func(_ []byte) {
+		r.SendSnapshot(rc)
+	})
 }
 
 func (r *ACPPodRelay) SendSnapshot(rc relay.RelayClient) {

--- a/runner/internal/runner/pod_relay_acp_unit_test.go
+++ b/runner/internal/runner/pod_relay_acp_unit_test.go
@@ -41,6 +41,24 @@ func TestACPPodRelay_SendSnapshot_NilClient(t *testing.T) {
 	}
 }
 
+func TestACPPodRelay_SetupHandlers_Resync(t *testing.T) {
+	mc := relay.NewMockClient("wss://relay.example.com")
+	mc.SetConnected(true)
+
+	// Create a minimal ACPClient-less relay to verify Resync triggers SendSnapshot.
+	// With nil acpClient, SendSnapshot is a no-op (no panic, no message).
+	r := NewACPPodRelay("pod-1", nil, nil)
+	r.SetupHandlers(mc)
+
+	// Simulate browser sending Resync.
+	mc.SimulateMessage(relay.MsgTypeResync, nil)
+
+	// nil acpClient → SendSnapshot returns early, 0 snapshots sent.
+	if mc.CountSentByType(relay.MsgTypeAcpSnapshot) != 0 {
+		t.Error("should not send snapshot when ACP client is nil")
+	}
+}
+
 func TestACPPodRelay_OnRelayConnected_NoPanic(t *testing.T) {
 	mc := relay.NewMockClient("wss://relay.example.com")
 	r := NewACPPodRelay("pod-1", nil, nil)

--- a/web/src/stores/relayConnectionHandlers.ts
+++ b/web/src/stores/relayConnectionHandlers.ts
@@ -51,6 +51,11 @@ export function dispatchRelayMessage(
     case MsgType.AcpCommand: {
       const parsed = decodeJsonPayload(payload);
       if (parsed !== null) {
+        // AcpSnapshot serves the same role as terminal Snapshot for ACP pods:
+        // mark received so scheduleSnapshotRetry stops sending redundant Resyncs.
+        if (type === MsgType.AcpSnapshot) {
+          conn.snapshotReceived = true;
+        }
         callbacks.onAcpMessage(conn.podKey, type, parsed);
       }
       break;


### PR DESCRIPTION
The ACP panel gets stuck on "Waiting for ACP session..." because the runner sends the ACP snapshot before the browser subscribes to the relay. ACP snapshots are ephemeral (not buffered), so they are lost. When the browser later sends Resync, the runner has no handler for it in ACP mode — the request is silently ignored.

Register a MsgTypeResync handler in ACPPodRelay.SetupHandlers that responds with a fresh ACP snapshot. Also mark snapshotReceived on the browser side when an AcpSnapshot arrives, so the retry timer stops sending redundant Resyncs.

## Summary

- What changed?
- Why was this change needed?

## Changes

- 

## Validation

- [ ] Backend tests (`cd backend && go test ./...`)
- [ ] Web checks (`cd web && pnpm run lint && pnpm run type-check && pnpm run test:coverage`)
- [ ] Runner checks (`cd runner && go test ./...`)
- [ ] Manual validation performed (if applicable)

## Documentation

- [ ] Docs updated (README/docs/inline comments)
- [ ] No docs changes needed

## Risk and Rollback

- Risk level: Low / Medium / High
- Rollback plan:
