### PR TITLE
fix(runner): ACP mode reads deprecated InitialPrompt instead of Prompt

### DIFF
--- a/runner/internal/runner/message_handler_acp.go
+++ b/runner/internal/runner/message_handler_acp.go
@@ -148,12 +148,12 @@ func (h *RunnerMessageHandler) wireAndStartACPPod(pod *Pod, cmd *runnerv1.Create
 	// Claude: sessionID is empty (first message triggers system/init asynchronously).
 	// ACP/Codex: sessionID is already set by NewSession().
 	// ACPClient.SendPrompt checks State() == Idle (guaranteed after Handshake).
-	if cmd.InitialPrompt != "" { //nolint:staticcheck // deprecated but still used until removed from proto
+	if cmd.Prompt != "" {
 		// Echo user message so it appears in chat on all connected devices.
 		sendAcpViaRelay(pod, "contentChunk", "", map[string]string{
-			"text": cmd.InitialPrompt, "role": "user", //nolint:staticcheck
+			"text": cmd.Prompt, "role": "user",
 		})
-		if err := acpClient.SendPrompt(cmd.InitialPrompt); err != nil { //nolint:staticcheck
+		if err := acpClient.SendPrompt(cmd.Prompt); err != nil {
 			log.Error("Failed to send initial prompt", "pod_key", podKey, "error", err)
 		}
 	}


### PR DESCRIPTION
## Summary
ACP mode pods (Claude Code via stream-json) don't receive initial prompts from tickets.

**Root cause:** `message_handler_acp.go` reads `cmd.InitialPrompt` (proto field 7, deprecated) but backend writes to `cmd.Prompt` (proto field 19) since the AgentFile SSOT migration (#200). The deprecated field is always empty.

**Fix:** Change ACP mode to read `cmd.Prompt`, matching PTY mode's behavior in `pod_builder_build.go`.

## Test plan
- [ ] Create pod from ticket with ACP mode (claude-code) → prompt should be received