### PR TITLE
refactor(web): optimize Mesh topology layout and visual styling

### DIFF
--- a/web/src/components/mesh/MeshTopology.tsx
+++ b/web/src/components/mesh/MeshTopology.tsx
@@ -45,7 +45,7 @@ export default function MeshTopology() {
   }, [selectNode]);
 
   const onNodeDragStop: OnNodeDrag = useCallback((_event, node) => {
-    if (node.type === "runnerGroup") updateNodePosition(node.id, node.position);
+    if (node.type === "runnerGroup" || node.type === "pod") updateNodePosition(node.id, node.position);
   }, [updateNodePosition]);
 
   const onPaneClick = useCallback(() => { selectNode(null); }, [selectNode]);

--- a/web/src/components/mesh/PodNode.tsx
+++ b/web/src/components/mesh/PodNode.tsx
@@ -22,7 +22,6 @@ function PodNode({ data }: PodNodeProps) {
   const router = useRouter();
   const orgSlug = params.org as string;
 
-  // Adapt MeshNode to PodDisplayInfo interface for getPodDisplayName
   const displayName = getPodDisplayName(
     {
       pod_key: node.pod_key,
@@ -42,16 +41,20 @@ function PodNode({ data }: PodNodeProps) {
     }
   };
 
+  const startedTitle = node.started_at
+    ? new Date(node.started_at).toLocaleString()
+    : undefined;
+
   return (
     <PodContextMenu node={node}>
       <div
+        title={startedTitle}
         className={`px-4 py-3 rounded-lg border-2 bg-background shadow-md min-w-[180px] transition-all ${
           isSelected
             ? "border-primary ring-2 ring-primary/20"
             : "border-border hover:border-primary/50"
         }`}
       >
-        {/* Handles for edges */}
         <Handle
           type="target"
           position={Position.Left}
@@ -63,50 +66,43 @@ function PodNode({ data }: PodNodeProps) {
           className="w-3 h-3 !bg-primary"
         />
 
-        {/* Pod Header */}
         <div className="flex items-center justify-between mb-2">
-          <code className="text-xs font-mono text-muted-foreground">
+          <code className="text-xs font-mono text-muted-foreground truncate mr-2">
             {displayName}
           </code>
           <span
-            className={`px-2 py-0.5 text-xs rounded-full ${statusInfo.bgColor} ${statusInfo.color}`}
-          >
-            {statusInfo.label}
-          </span>
+            className={`w-2.5 h-2.5 rounded-full shrink-0 ${statusInfo.bgColor.replace("bg-", "bg-").replace("/30", "")} ${
+              node.status === "running" ? "bg-green-500" :
+              node.status === "initializing" ? "bg-blue-500" :
+              node.status === "failed" ? "bg-red-500" : "bg-gray-400"
+            }`}
+            title={statusInfo.label}
+          />
         </div>
 
-        {/* Agent Status */}
         <AgentStatusBadge
           agentStatus={node.agent_status}
           podStatus={node.status}
           variant="badge"
         />
 
-        {/* Model */}
-        {node.model && (
-          <div className="text-xs text-muted-foreground mb-1">
-            Model: <span className="font-medium">{node.model}</span>
-          </div>
-        )}
-
-        {/* Ticket - clickable */}
-        {node.ticket_slug && (
-          <div className="text-xs text-muted-foreground">
-            Ticket:{" "}
-            <button
-              type="button"
-              onClick={handleTicketClick}
-              className="nodrag nopan font-medium text-primary hover:underline cursor-pointer"
-            >
-              {node.ticket_slug}
-            </button>
-          </div>
-        )}
-
-        {/* Started At */}
-        {node.started_at && (
-          <div className="text-xs text-muted-foreground mt-1">
-            {new Date(node.started_at).toLocaleTimeString()}
+        {(node.model || node.ticket_slug) && (
+          <div className="flex items-center gap-2 text-xs text-muted-foreground mt-1">
+            {node.model && (
+              <span className="truncate">{node.model}</span>
+            )}
+            {node.model && node.ticket_slug && (
+              <span className="text-border">|</span>
+            )}
+            {node.ticket_slug && (
+              <button
+                type="button"
+                onClick={handleTicketClick}
+                className="nodrag nopan font-medium text-primary hover:underline cursor-pointer truncate"
+              >
+                {node.ticket_slug}
+              </button>
+            )}
           </div>
         )}
       </div>

--- a/web/src/components/mesh/RunnerGroupNode.tsx
+++ b/web/src/components/mesh/RunnerGroupNode.tsx
@@ -16,9 +16,8 @@ function RunnerGroupNode({ data }: NodeProps) {
   const isOnline = runnerStatus === "online";
 
   return (
-    <div className="rounded-lg border-2 border-dashed border-muted-foreground/30 bg-muted/20 min-w-[440px]">
-      {/* Header */}
-      <div className="flex items-center gap-2 px-4 py-2 border-b border-dashed border-muted-foreground/20">
+    <div className="rounded-xl border border-border bg-muted/30 shadow-sm w-full h-full">
+      <div className="flex items-center gap-2 px-4 py-2 border-b border-border/60">
         <div
           className={`w-2 h-2 rounded-full ${
             isOnline ? "bg-green-500" : "bg-gray-400"
@@ -27,15 +26,18 @@ function RunnerGroupNode({ data }: NodeProps) {
         <span className="text-sm font-medium text-foreground truncate">
           {runnerNodeId}
         </span>
-        <span className="text-xs text-muted-foreground">
+        <span className={`text-xs px-1.5 py-0.5 rounded ${
+          isOnline
+            ? "bg-green-500/10 text-green-600 dark:text-green-400"
+            : "bg-gray-500/10 text-gray-500"
+        }`}>
           {isOnline ? t("runnerGroup.online") : t("runnerGroup.offline")}
         </span>
         <span className="ml-auto text-xs text-muted-foreground bg-muted px-2 py-0.5 rounded-full">
           {t("runnerGroup.podCount", { count: podCount })}
         </span>
       </div>
-      {/* Content area - pods are placed here via parentId mechanism */}
-      <div className="p-4 min-h-[160px]" />
+      <div className="p-4" />
     </div>
   );
 }

--- a/web/src/components/mesh/mesh-layout.ts
+++ b/web/src/components/mesh/mesh-layout.ts
@@ -2,9 +2,8 @@ import type { Node, Edge } from "@xyflow/react";
 import type { MeshNode, MeshEdge } from "@/stores/mesh";
 import type { RunnerInfoData } from "@/lib/api";
 
-// Layout constants
 const POD_WIDTH = 200;
-const POD_HEIGHT = 140;
+const POD_HEIGHT = 160;
 const POD_GAP_X = 20;
 const POD_GAP_Y = 20;
 const PODS_PER_ROW = 2;
@@ -12,10 +11,8 @@ const GROUP_PADDING_X = 20;
 const GROUP_PADDING_TOP = 50;
 const GROUP_PADDING_BOTTOM = 20;
 const GROUP_GAP = 40;
+const CANVAS_WIDTH = 1200;
 
-/**
- * Grouped layout algorithm: arranges pods into Runner "workstation" groups.
- */
 export function calculateGroupedLayout(
   pods: MeshNode[],
   edges: MeshEdge[],
@@ -27,15 +24,16 @@ export function calculateGroupedLayout(
 
   const podsByRunner = groupPodsByRunner(pods);
   const runnerInfoMap = buildRunnerInfoMap(runners);
-
-  let autoGroupX = computeAutoGroupX(podsByRunner, savedPositions);
+  const cursor = computeGridStart(podsByRunner, savedPositions);
 
   for (const [runnerId, runnerPods] of podsByRunner) {
-    const { groupNode, podNodes, nextAutoX } = layoutRunnerGroup(
-      runnerId, runnerPods, runnerInfoMap, savedPositions, autoGroupX
+    const { groupNode, podNodes, nextCursor } = layoutRunnerGroup(
+      runnerId, runnerPods, runnerInfoMap, savedPositions, cursor
     );
     nodes.push(groupNode, ...podNodes);
-    autoGroupX = nextAutoX;
+    cursor.x = nextCursor.x;
+    cursor.y = nextCursor.y;
+    cursor.rowMaxH = nextCursor.rowMaxH;
   }
 
   for (const edge of edges) {
@@ -50,6 +48,8 @@ export function calculateGroupedLayout(
 
   return { nodes, edges: flowEdges };
 }
+
+interface GridCursor { x: number; y: number; rowMaxH: number }
 
 function groupPodsByRunner(pods: MeshNode[]): Map<number, MeshNode[]> {
   const map = new Map<number, MeshNode[]>();
@@ -66,21 +66,29 @@ function buildRunnerInfoMap(runners?: RunnerInfoData[]): Map<number, RunnerInfoD
   return map;
 }
 
-function computeAutoGroupX(
+function computeGridStart(
   podsByRunner: Map<number, MeshNode[]>,
   savedPositions?: Record<string, { x: number; y: number }>
-): number {
-  let autoGroupX = 0;
-  if (!savedPositions) return autoGroupX;
+): GridCursor {
+  if (!savedPositions) return { x: 0, y: 0, rowMaxH: 0 };
+  let maxBottom = 0;
   for (const [runnerId, runnerPods] of podsByRunner) {
     const saved = savedPositions[`runner-group-${runnerId}`];
     if (saved) {
-      const cols = Math.min(runnerPods.length, PODS_PER_ROW);
-      const gw = GROUP_PADDING_X * 2 + cols * POD_WIDTH + (cols - 1) * POD_GAP_X;
-      autoGroupX = Math.max(autoGroupX, saved.x + gw + GROUP_GAP);
+      const rows = Math.ceil(runnerPods.length / PODS_PER_ROW);
+      const gh = GROUP_PADDING_TOP + GROUP_PADDING_BOTTOM + rows * POD_HEIGHT + (rows - 1) * POD_GAP_Y;
+      maxBottom = Math.max(maxBottom, saved.y + gh + GROUP_GAP);
     }
   }
-  return autoGroupX;
+  return { x: 0, y: maxBottom, rowMaxH: 0 };
+}
+
+function calcGroupSize(podCount: number) {
+  const rows = Math.ceil(podCount / PODS_PER_ROW);
+  const cols = Math.min(podCount, PODS_PER_ROW);
+  const width = GROUP_PADDING_X * 2 + cols * POD_WIDTH + (cols - 1) * POD_GAP_X;
+  const height = GROUP_PADDING_TOP + GROUP_PADDING_BOTTOM + rows * POD_HEIGHT + (rows - 1) * POD_GAP_Y;
+  return { width, height };
 }
 
 function layoutRunnerGroup(
@@ -88,20 +96,28 @@ function layoutRunnerGroup(
   runnerPods: MeshNode[],
   runnerInfoMap: Map<number, RunnerInfoData>,
   savedPositions: Record<string, { x: number; y: number }> | undefined,
-  autoGroupX: number,
+  cursor: GridCursor,
 ) {
   const runnerInfo = runnerInfoMap.get(runnerId);
   const runnerNodeId = runnerPods[0]?.runner_node_id || `runner-${runnerId}`;
   const runnerStatus = runnerPods[0]?.runner_status || runnerInfo?.status || "offline";
   const groupId = `runner-group-${runnerId}`;
-
-  const rows = Math.ceil(runnerPods.length / PODS_PER_ROW);
-  const cols = Math.min(runnerPods.length, PODS_PER_ROW);
-  const groupWidth = GROUP_PADDING_X * 2 + cols * POD_WIDTH + (cols - 1) * POD_GAP_X;
-  const groupHeight = GROUP_PADDING_TOP + GROUP_PADDING_BOTTOM + rows * POD_HEIGHT + (rows - 1) * POD_GAP_Y;
+  const { width: groupWidth, height: groupHeight } = calcGroupSize(runnerPods.length);
 
   const savedPos = savedPositions?.[groupId];
-  const position = savedPos ?? { x: autoGroupX, y: 0 };
+  let nextCursor = { ...cursor };
+
+  let position: { x: number; y: number };
+  if (savedPos) {
+    position = savedPos;
+  } else {
+    if (cursor.x + groupWidth > CANVAS_WIDTH && cursor.x > 0) {
+      nextCursor = { x: 0, y: cursor.y + cursor.rowMaxH + GROUP_GAP, rowMaxH: 0 };
+    }
+    position = { x: nextCursor.x, y: nextCursor.y };
+    nextCursor.x += groupWidth + GROUP_GAP;
+    nextCursor.rowMaxH = Math.max(nextCursor.rowMaxH, groupHeight);
+  }
 
   const groupNode: Node = {
     id: groupId,
@@ -112,18 +128,23 @@ function layoutRunnerGroup(
   };
 
   const podNodes: Node[] = runnerPods.map((pod, index) => {
+    const podSaved = savedPositions?.[pod.pod_key];
     const col = index % PODS_PER_ROW;
     const row = Math.floor(index / PODS_PER_ROW);
+    const defaultPos = {
+      x: GROUP_PADDING_X + col * (POD_WIDTH + POD_GAP_X),
+      y: GROUP_PADDING_TOP + row * (POD_HEIGHT + POD_GAP_Y),
+    };
     return {
       id: pod.pod_key,
       type: "pod",
-      position: { x: GROUP_PADDING_X + col * (POD_WIDTH + POD_GAP_X), y: GROUP_PADDING_TOP + row * (POD_HEIGHT + POD_GAP_Y) },
+      position: podSaved ?? defaultPos,
       parentId: groupId,
       extent: "parent" as const,
-      draggable: false,
+      draggable: true,
       data: { node: pod },
     };
   });
 
-  return { groupNode, podNodes, nextAutoX: savedPos ? autoGroupX : autoGroupX + groupWidth + GROUP_GAP };
+  return { groupNode, podNodes, nextCursor };
 }


### PR DESCRIPTION
## Summary

- Grid-based auto-layout for runner groups — wraps at `CANVAS_WIDTH=1200` instead of single horizontal row
- Pods now draggable within their runner container (`extent: "parent"`) with position persistence
- Runner container visual overhaul: solid border, rounded-xl corners, shadow-sm, `w-full h-full` sizing (fixes pod overflow)
- Pod card compact layout: status dot replaces text badge, model+ticket merged into one row, `started_at` moved to hover title
- `POD_HEIGHT` increased 140→160 to prevent content overflow

## Test plan

- [ ] Open Mesh page with multiple pods — Runner container fully covers all pods
- [ ] Drag Runner group on canvas — position persists across refreshes
- [ ] Drag Pod within Runner — constrained to parent bounds, position persists
- [ ] Multiple Runners auto-arrange in grid pattern utilizing canvas space
- [ ] Pod card shows status dot, agent badge, model+ticket compactly
- [ ] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)