### PR TITLE
fix(web): rename mesh tab to Mesh and default mobile to channels

### DIFF
--- a/web/src/components/mobile/MobileHeader.tsx
+++ b/web/src/components/mobile/MobileHeader.tsx
@@ -42,7 +42,7 @@ export function MobileHeader({ className, title, actions }: MobileHeaderProps) {
       case "settings":
         return t("ide.activities.settings");
       default:
-        return "AgentsMesh";
+        return "Mesh";
     }
   };
 

--- a/web/src/components/mobile/MobileShell.tsx
+++ b/web/src/components/mobile/MobileShell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 import { MobileHeader } from "./MobileHeader";
 import { MobileTabBar } from "./MobileTabBar";
@@ -39,7 +39,17 @@ export function MobileShell({
   hideTabBar = false,
   className,
 }: MobileShellProps) {
-  const { _hasHydrated } = useIDEStore();
+  const { _hasHydrated, activeActivity, setActiveActivity } = useIDEStore();
+  const didSetDefault = useRef(false);
+
+  useEffect(() => {
+    if (_hasHydrated && !didSetDefault.current) {
+      didSetDefault.current = true;
+      if (activeActivity === "workspace") {
+        setActiveActivity("channels");
+      }
+    }
+  }, [_hasHydrated, activeActivity, setActiveActivity]);
 
   // Show loading state while hydrating
   if (!_hasHydrated) {

--- a/web/src/components/mobile/MobileSidebar.tsx
+++ b/web/src/components/mobile/MobileSidebar.tsx
@@ -40,7 +40,7 @@ function getActivityTitle(activity: ActivityType): string {
     case "tickets":
       return "Tickets";
     case "mesh":
-      return "AgentsMesh";
+      return "Mesh";
     case "repositories":
       return "Repositories";
     case "runners":
@@ -48,7 +48,7 @@ function getActivityTitle(activity: ActivityType): string {
     case "settings":
       return "Settings";
     default:
-      return "AgentsMesh";
+      return "Mesh";
   }
 }
 

--- a/web/src/messages/de/common.json
+++ b/web/src/messages/de/common.json
@@ -57,7 +57,7 @@
   },
   "nav": {
     "agentpod": "AgentPod",
-    "mesh": "AgentsMesh",
+    "mesh": "Mesh",
     "tickets": "Tickets",
     "settings": "Einstellungen",
     "billing": "Abrechnung"

--- a/web/src/messages/de/ide.json
+++ b/web/src/messages/de/ide.json
@@ -4,7 +4,7 @@
       "workspace": "Arbeitsbereich",
       "tickets": "Tickets",
       "channels": "Kanäle",
-      "mesh": "AgentsMesh",
+      "mesh": "Mesh",
       "loops": "Loops",
       "repositories": "Repositories",
       "runners": "Runner",

--- a/web/src/messages/en/common.json
+++ b/web/src/messages/en/common.json
@@ -65,7 +65,7 @@
   },
   "nav": {
     "agentpod": "AgentPod",
-    "mesh": "AgentsMesh",
+    "mesh": "Mesh",
     "tickets": "Tickets",
     "settings": "Settings",
     "billing": "Billing"

--- a/web/src/messages/en/ide.json
+++ b/web/src/messages/en/ide.json
@@ -4,7 +4,7 @@
       "workspace": "Workspace",
       "tickets": "Tickets",
       "channels": "Channels",
-      "mesh": "AgentsMesh",
+      "mesh": "Mesh",
       "loops": "Loops",
       "repositories": "Repositories",
       "runners": "Runners",

--- a/web/src/messages/es/common.json
+++ b/web/src/messages/es/common.json
@@ -57,7 +57,7 @@
   },
   "nav": {
     "agentpod": "AgentPod",
-    "mesh": "AgentsMesh",
+    "mesh": "Mesh",
     "tickets": "Tickets",
     "settings": "Configuración",
     "billing": "Facturación"

--- a/web/src/messages/es/ide.json
+++ b/web/src/messages/es/ide.json
@@ -4,7 +4,7 @@
       "workspace": "Espacio de Trabajo",
       "tickets": "Tickets",
       "channels": "Canales",
-      "mesh": "AgentsMesh",
+      "mesh": "Mesh",
       "loops": "Loops",
       "repositories": "Repositorios",
       "runners": "Runner",

--- a/web/src/messages/fr/common.json
+++ b/web/src/messages/fr/common.json
@@ -57,7 +57,7 @@
   },
   "nav": {
     "agentpod": "AgentPod",
-    "mesh": "AgentsMesh",
+    "mesh": "Mesh",
     "tickets": "Tickets",
     "settings": "Paramètres",
     "billing": "Facturation"

--- a/web/src/messages/fr/ide.json
+++ b/web/src/messages/fr/ide.json
@@ -4,7 +4,7 @@
       "workspace": "Espace de Travail",
       "tickets": "Tickets",
       "channels": "Canaux",
-      "mesh": "AgentsMesh",
+      "mesh": "Mesh",
       "loops": "Loops",
       "repositories": "Dépôts",
       "runners": "Runner",

--- a/web/src/messages/ja/common.json
+++ b/web/src/messages/ja/common.json
@@ -57,7 +57,7 @@
   },
   "nav": {
     "agentpod": "AgentPod",
-    "mesh": "AgentsMesh",
+    "mesh": "Mesh",
     "tickets": "チケット",
     "settings": "設定",
     "billing": "請求"

--- a/web/src/messages/ja/ide.json
+++ b/web/src/messages/ja/ide.json
@@ -4,7 +4,7 @@
       "workspace": "ワークスペース",
       "tickets": "チケット",
       "channels": "チャンネル",
-      "mesh": "AgentsMesh",
+      "mesh": "Mesh",
       "loops": "Loops",
       "repositories": "リポジトリ",
       "runners": "Runner",

--- a/web/src/messages/ko/common.json
+++ b/web/src/messages/ko/common.json
@@ -57,7 +57,7 @@
   },
   "nav": {
     "agentpod": "AgentPod",
-    "mesh": "AgentsMesh",
+    "mesh": "Mesh",
     "tickets": "티켓",
     "settings": "설정",
     "billing": "결제"

--- a/web/src/messages/ko/ide.json
+++ b/web/src/messages/ko/ide.json
@@ -4,7 +4,7 @@
       "workspace": "워크스페이스",
       "tickets": "티켓",
       "channels": "채널",
-      "mesh": "AgentsMesh",
+      "mesh": "Mesh",
       "loops": "Loops",
       "repositories": "저장소",
       "runners": "Runner",

--- a/web/src/messages/pt/common.json
+++ b/web/src/messages/pt/common.json
@@ -57,7 +57,7 @@
   },
   "nav": {
     "agentpod": "AgentPod",
-    "mesh": "AgentsMesh",
+    "mesh": "Mesh",
     "tickets": "Tickets",
     "settings": "Configurações",
     "billing": "Faturamento"

--- a/web/src/messages/pt/ide.json
+++ b/web/src/messages/pt/ide.json
@@ -4,7 +4,7 @@
       "workspace": "Área de Trabalho",
       "tickets": "Tickets",
       "channels": "Canais",
-      "mesh": "AgentsMesh",
+      "mesh": "Mesh",
       "loops": "Loops",
       "repositories": "Repositórios",
       "runners": "Runner",

--- a/web/src/messages/zh/ide.json
+++ b/web/src/messages/zh/ide.json
@@ -4,7 +4,7 @@
       "workspace": "工作区",
       "tickets": "任务",
       "channels": "频道",
-      "mesh": "AgentsMesh",
+      "mesh": "Mesh",
       "loops": "Loop",
       "repositories": "仓库",
       "runners": "Runner",


### PR DESCRIPTION
## Summary

- Rename "AgentsMesh" → "Mesh" in all i18n files (8 languages, ide.json + common.json)
- Update fallback labels in MobileSidebar and MobileHeader
- Mobile app defaults to channels tab on first launch (instead of workspace)

## Test plan

- [ ] Mobile tab bar shows "Mesh" not "AgentsMesh"
- [ ] Mobile app opens to channels tab on first visit
- [ ] Desktop sidebar still shows correct labels
- [ ] All languages display "Mesh" for the mesh tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)