### PR TITLE
fix(web): mobile default route to channels

### DIFF
--- a/web/src/app/(dashboard)/[org]/page.tsx
+++ b/web/src/app/(dashboard)/[org]/page.tsx
@@ -3,16 +3,15 @@
 import { useEffect } from "react";
 import { useParams, useRouter } from "next/navigation";
 
-/**
- * Organization root page - redirects to workspace
- */
 export default function OrganizationPage() {
   const router = useRouter();
   const params = useParams();
   const orgSlug = params.org as string;
 
   useEffect(() => {
-    router.replace(`/${orgSlug}/workspace`);
+    const isMobile = window.innerWidth < 768;
+    const target = isMobile ? "channels" : "workspace";
+    router.replace(`/${orgSlug}/${target}`);
   }, [orgSlug, router]);
 
   return null;

--- a/web/src/components/mobile/MobileShell.tsx
+++ b/web/src/components/mobile/MobileShell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useRef } from "react";
+import React from "react";
 import { cn } from "@/lib/utils";
 import { MobileHeader } from "./MobileHeader";
 import { MobileTabBar } from "./MobileTabBar";
@@ -39,17 +39,7 @@ export function MobileShell({
   hideTabBar = false,
   className,
 }: MobileShellProps) {
-  const { _hasHydrated, activeActivity, setActiveActivity } = useIDEStore();
-  const didSetDefault = useRef(false);
-
-  useEffect(() => {
-    if (_hasHydrated && !didSetDefault.current) {
-      didSetDefault.current = true;
-      if (activeActivity === "workspace") {
-        setActiveActivity("channels");
-      }
-    }
-  }, [_hasHydrated, activeActivity, setActiveActivity]);
+  const { _hasHydrated } = useIDEStore();
 
   // Show loading state while hydrating
   if (!_hasHydrated) {


### PR DESCRIPTION
## Summary

- Org root redirect (`/[org]/`) now routes mobile (<768px) to `/channels`, desktop to `/workspace`
- Reverts MobileShell effect approach from #287 (URL routing determines active activity, not store state)

## Test plan

- [ ] Mobile: opening app defaults to channels tab
- [ ] Desktop: opening app defaults to workspace (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)