### PR TITLE
fix(web): systematically route mobile to channels on all entry points

### DIFF
--- a/web/src/app/(auth)/auth/callback/page.tsx
+++ b/web/src/app/(auth)/auth/callback/page.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { useAuthStore } from "@/stores/auth";
 import { userApi, organizationApi } from "@/lib/api";
+import { getDefaultRoute } from "@/lib/default-route";
 import { Logo } from "@/components/common";
 
 function OAuthCallbackContent() {
@@ -58,7 +59,7 @@ function OAuthCallbackContent() {
 
             // Redirect to first org's dashboard
             setTimeout(() => {
-              router.push(`/${orgsResponse.organizations[0].slug}/workspace`);
+              router.push(getDefaultRoute(orgsResponse.organizations[0].slug));
             }, 1500);
           } else {
             // No organizations, redirect to onboarding

--- a/web/src/app/(auth)/invite/[token]/page.tsx
+++ b/web/src/app/(auth)/invite/[token]/page.tsx
@@ -8,6 +8,7 @@ import { useAuthStore } from "@/stores/auth";
 import { invitationApi, InvitationInfo } from "@/lib/api/invitation";
 import { organizationApi } from "@/lib/api/organization";
 import { Logo } from "@/components/common";
+import { getDefaultRoute } from "@/lib/default-route";
 
 interface PageParams {
   token: string;
@@ -57,7 +58,7 @@ export default function InvitePage({ params }: { params: Promise<PageParams> }) 
       }
 
       // Redirect to the organization workspace
-      router.push(`/${organization.slug}/workspace`);
+      router.push(getDefaultRoute(organization.slug));
     } catch (err: unknown) {
       if (err && typeof err === "object" && "data" in err) {
         const apiErr = err as { data?: { error?: string } };

--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -13,6 +13,7 @@ import type { SSOConfig } from "@/lib/api/sso";
 import { useTranslations } from "next-intl";
 import { Logo } from "@/components/common";
 import { OAuthButtons } from "./OAuthButtons";
+import { getDefaultRoute } from "@/lib/default-route";
 import { SSOSection } from "./SSOSection";
 import { Divider } from "./Divider";
 
@@ -65,7 +66,7 @@ export default function LoginPage() {
       const orgsResponse = await organizationApi.list();
       if (orgsResponse.organizations && orgsResponse.organizations.length > 0) {
         setOrganizations(orgsResponse.organizations);
-        router.push(`/${orgsResponse.organizations[0].slug}/workspace`);
+        router.push(getDefaultRoute(orgsResponse.organizations[0].slug));
       } else {
         router.push("/onboarding");
       }

--- a/web/src/app/(auth)/onboarding/page.tsx
+++ b/web/src/app/(auth)/onboarding/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useAuthStore } from "@/stores/auth";
+import { getDefaultRoute } from "@/lib/default-route";
 import { organizationApi } from "@/lib/api/organization";
 import { getLocalizedErrorMessage } from "@/lib/api/errors";
 import { toast } from "sonner";
@@ -29,7 +30,7 @@ export default function OnboardingPage() {
         if (organizations && organizations.length > 0) {
           setOrganizations(organizations);
           setCurrentOrg(organizations[0]);
-          router.push(`/${organizations[0].slug}/workspace`);
+          router.push(getDefaultRoute(organizations[0].slug));
         }
       } catch {
         // No organizations, stay on onboarding

--- a/web/src/app/(auth)/verify-email/page.tsx
+++ b/web/src/app/(auth)/verify-email/page.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { authApi, organizationApi } from "@/lib/api";
 import { useTranslations } from "next-intl";
+import { getDefaultRoute } from "@/lib/default-route";
 import { useAuthStore } from "@/stores/auth";
 import { VerifyingScreen, SuccessScreen, LogoHeader } from "./VerifyStateScreens";
 
@@ -41,7 +42,7 @@ function VerifyEmailContent() {
         const orgsResponse = await organizationApi.list();
         if (orgsResponse.organizations && orgsResponse.organizations.length > 0) {
           setOrganizations(orgsResponse.organizations);
-          router.push(`/${orgsResponse.organizations[0].slug}/workspace`);
+          router.push(getDefaultRoute(orgsResponse.organizations[0].slug));
         } else {
           router.push("/onboarding");
         }

--- a/web/src/app/(dashboard)/[org]/layout.tsx
+++ b/web/src/app/(dashboard)/[org]/layout.tsx
@@ -4,6 +4,7 @@ import React, { useEffect } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useAuthStore } from "@/stores/auth";
 import { Spinner } from "@/components/ui/spinner";
+import { getDefaultRoute } from "@/lib/default-route";
 
 /**
  * Organization-scoped layout
@@ -30,7 +31,7 @@ export default function OrgLayout({ children }: { children: React.ReactNode }) {
     } else if (organizations.length > 0) {
       // Organization not found, redirect to first available org
       console.warn(`Organization "${orgSlug}" not found, redirecting...`);
-      router.replace(`/${organizations[0].slug}/workspace`);
+      router.replace(getDefaultRoute(organizations[0].slug));
     }
   }, [orgSlug, organizations, currentOrg, setCurrentOrg, router, _hasHydrated]);
 

--- a/web/src/app/(dashboard)/[org]/page.tsx
+++ b/web/src/app/(dashboard)/[org]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 import { useParams, useRouter } from "next/navigation";
+import { getDefaultRoute } from "@/lib/default-route";
 
 export default function OrganizationPage() {
   const router = useRouter();
@@ -9,9 +10,7 @@ export default function OrganizationPage() {
   const orgSlug = params.org as string;
 
   useEffect(() => {
-    const isMobile = window.innerWidth < 768;
-    const target = isMobile ? "channels" : "workspace";
-    router.replace(`/${orgSlug}/${target}`);
+    router.replace(getDefaultRoute(orgSlug));
   }, [orgSlug, router]);
 
   return null;

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -16,6 +16,7 @@ import {
   FinalCTA,
   Footer,
 } from "@/components/landing";
+import { getDefaultRoute } from "@/lib/default-route";
 
 export default function Home() {
   const router = useRouter();
@@ -39,7 +40,7 @@ export default function Home() {
   // Handle redirect in effect
   useEffect(() => {
     if (shouldRedirect && currentOrg) {
-      router.replace(`/${currentOrg.slug}/workspace`);
+      router.replace(getDefaultRoute(currentOrg.slug));
     }
   }, [shouldRedirect, currentOrg, router]);
 

--- a/web/src/components/mobile/MobileDrawer.tsx
+++ b/web/src/components/mobile/MobileDrawer.tsx
@@ -6,6 +6,7 @@ import { Drawer } from "vaul";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { cn } from "@/lib/utils";
 import { useIDEStore, ACTIVITIES, type ActivityType } from "@/stores/ide";
+import { getDefaultRoute } from "@/lib/default-route";
 import { useAuthStore } from "@/stores/auth";
 import { useTranslations } from "next-intl";
 import {
@@ -80,7 +81,7 @@ export function MobileDrawer({ className }: MobileDrawerProps) {
     if (org) {
       setCurrentOrg(org);
       setMobileDrawerOpen(false);
-      router.push(`/${org.slug}/workspace`);
+      router.push(getDefaultRoute(org.slug));
     }
   };
 

--- a/web/src/lib/default-route.ts
+++ b/web/src/lib/default-route.ts
@@ -1,0 +1,7 @@
+const MOBILE_BREAKPOINT = 768;
+
+export function getDefaultRoute(orgSlug: string): string {
+  const isMobile =
+    typeof window !== "undefined" && window.innerWidth < MOBILE_BREAKPOINT;
+  return `/${orgSlug}/${isMobile ? "channels" : "workspace"}`;
+}


### PR DESCRIPTION
## Summary

- Extract `getDefaultRoute(orgSlug)` in `lib/default-route.ts` — mobile (<768px) → `/channels`, desktop → `/workspace`
- Apply to **all** redirect entry points:
  - Login page
  - OAuth callback
  - Email verification
  - Onboarding
  - Invite acceptance
  - Org root page
  - Org layout fallback
  - Home page (auto-redirect)
  - MobileDrawer org switch
- Revert ineffective MobileShell effect from #287

## Test plan

- [ ] Mobile login → lands on channels
- [ ] Desktop login → lands on workspace (unchanged)
- [ ] Mobile org switch via drawer → channels
- [ ] OAuth login on mobile → channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)