### PR TITLE
fix(runner): add relay reconnect circuit breaker and pod process reconciler

### DIFF
--- a/runner/internal/relay/client.go
+++ b/runner/internal/relay/client.go
@@ -53,6 +53,7 @@ type Client struct {
 	stopped        atomic.Bool   // Indicates client has been permanently stopped
 	stopCh         chan struct{} // Signals client shutdown (permanent)
 	connDoneCh     chan struct{} // Signals current connection is done (closed on disconnect)
+	writeExitCh    chan struct{} // Closed when writeLoop exits; used by reconnectLoop
 	stopOnce       sync.Once
 	closeOnce      sync.Once // Ensures onClose callback fires at most once
 	sendCh         chan []byte
@@ -78,6 +79,7 @@ func NewClient(relayURL, podKey, token string, logger *slog.Logger) *Client {
 		token:      token,
 		stopCh:     make(chan struct{}),
 		connDoneCh: make(chan struct{}),
+		writeExitCh: make(chan struct{}),
 		sendCh:     make(chan []byte, 256), // Buffered send channel
 		handlers:   make(map[byte]func([]byte)),
 		logger: logger.With(

--- a/runner/internal/relay/client_connection.go
+++ b/runner/internal/relay/client_connection.go
@@ -134,8 +134,9 @@ func (c *Client) Stop() {
 		}
 		c.connMu.Unlock()
 
-		// Wait for read/write loops to exit with timeout
-		// Since stopped=true and wgMu was held, no new loops can be started
+		// Wait for read/write loops and reconnectLoop to exit with timeout.
+		// All goroutines are tracked in the same wg.
+		// Since stopped=true and wgMu was held, no new goroutines can be started.
 		done := make(chan struct{})
 		go func() {
 			c.wg.Wait()

--- a/runner/internal/relay/client_loops.go
+++ b/runner/internal/relay/client_loops.go
@@ -51,10 +51,20 @@ func (c *Client) readLoop() {
 				c.reconnectCount.Store(0)
 			}
 
-			// Unexpected disconnect - attempt reconnection
-			// Use atomic.Swap to prevent concurrent reconnect attempts
+			// Atomically check stopped and add reconnectLoop to wg under lock.
+			// This ensures Stop() will wait for reconnectLoop to exit.
+			c.wgMu.Lock()
+			if c.stopped.Load() {
+				c.wgMu.Unlock()
+				c.fireOnClose()
+				return
+			}
 			if !c.reconnecting.Swap(true) {
+				c.wg.Add(1)
+				c.wgMu.Unlock()
 				go c.reconnectLoop()
+			} else {
+				c.wgMu.Unlock()
 			}
 		}
 	}()
@@ -99,6 +109,16 @@ func (c *Client) writeLoop() {
 	c.logger.Debug("Write loop starting")
 	defer c.wg.Done()
 	defer c.logger.Info("Write loop exited")
+
+	// Signal reconnectLoop that writeLoop has fully exited.
+	exitCh := c.writeExitCh
+	defer func() {
+		select {
+		case <-exitCh:
+		default:
+			close(exitCh)
+		}
+	}()
 
 	// Capture connDoneCh at loop start — matches readLoop pattern.
 	// If reconnectLoop replaces c.connDoneCh, we only listen to the one

--- a/runner/internal/relay/client_reconnect.go
+++ b/runner/internal/relay/client_reconnect.go
@@ -20,8 +20,18 @@ func isHandshakeError(err error) bool {
 		strings.Contains(errStr, "403")
 }
 
-// reconnectLoop attempts to reconnect to the relay server with exponential backoff
+const (
+	// maxConsecutiveAuthFailures is the circuit-breaker threshold for permanent
+	// authentication errors. After this many consecutive handshake failures
+	// (where token refresh also fails), the reconnect loop gives up.
+	// This prevents zombie connections for dead/expired pods.
+	maxConsecutiveAuthFailures = 5
+)
+
+// reconnectLoop attempts to reconnect to the relay server with exponential backoff.
+// It is tracked by wg so that Stop() reliably waits for it to exit.
 func (c *Client) reconnectLoop() {
+	defer c.wg.Done()
 	defer c.reconnecting.Store(false)
 
 	// Check if client is already stopped - no point in reconnecting
@@ -40,23 +50,20 @@ func (c *Client) reconnectLoop() {
 	}
 	c.connMu.Unlock()
 
-	// Wait for the writeLoop to exit (readLoop already exited since we're in reconnectLoop)
-	// writeLoop should exit quickly since connDoneCh is closed
-	done := make(chan struct{})
-	go func() {
-		c.wg.Wait()
-		close(done)
-	}()
-
+	// Wait for writeLoop to exit. readLoop already exited (we're spawned from its defer).
+	// connDoneCh was closed by readLoop, which tells writeLoop to return.
+	// writeExitCh is closed by writeLoop on exit — we wait on it directly,
+	// avoiding wg.Wait() which would deadlock (reconnectLoop is in the same wg).
+	writeExit := c.writeExitCh
 	select {
-	case <-done:
-		// Loops exited
-	case <-time.After(2 * time.Second):
-		c.logger.Warn("Timeout waiting for loops to exit before reconnect, aborting")
-		c.fireOnClose()
-		return
+	case <-writeExit:
+		// writeLoop has fully exited
 	case <-c.stopCh:
 		c.logger.Info("Reconnect cancelled while waiting for loops, client stopped")
+		c.fireOnClose()
+		return
+	case <-time.After(2 * time.Second):
+		c.logger.Warn("Timeout waiting for writeLoop to exit before reconnect, aborting")
 		c.fireOnClose()
 		return
 	}
@@ -74,6 +81,7 @@ func (c *Client) reconnectLoop() {
 			"flap_count", flapCount, "initial_backoff", backoff)
 	}
 	tokenRefreshAttempted := false
+	consecutiveAuthFailures := 0
 
 	for attempt := 1; ; attempt++ {
 		// Check if Stop() was called during reconnection
@@ -104,22 +112,35 @@ func (c *Client) reconnectLoop() {
 				"attempt", attempt,
 				"next_backoff", min(backoff*2, maxReconnectDelay))
 
-			// Check if this is a handshake error (likely token expired)
-			// Try to refresh token once
-			if isHandshakeError(err) && !tokenRefreshAttempted && c.onTokenExpired != nil {
-				tokenRefreshAttempted = true
-				c.logger.Info("Handshake failed, requesting new token from Backend")
+			if isHandshakeError(err) {
+				consecutiveAuthFailures++
 
-				// Request new token from Backend
-				// This is a blocking call that waits for Backend to respond
-				newToken := c.onTokenExpired()
-				if newToken != "" {
-					c.logger.Info("Received new token, retrying connection")
-					c.UpdateToken(newToken)
-					// Don't increment backoff, retry immediately with new token
-					continue
+				// Try to refresh token once on first auth failure
+				if !tokenRefreshAttempted && c.onTokenExpired != nil {
+					tokenRefreshAttempted = true
+					c.logger.Info("Handshake failed, requesting new token from Backend")
+
+					newToken := c.onTokenExpired()
+					if newToken != "" {
+						c.logger.Info("Received new token, retrying connection")
+						c.UpdateToken(newToken)
+						consecutiveAuthFailures = 0
+						continue
+					}
+					c.logger.Warn("Failed to get new token, continuing with exponential backoff")
 				}
-				c.logger.Warn("Failed to get new token, continuing with exponential backoff")
+
+				// Circuit breaker: give up after too many consecutive auth failures.
+				// This prevents zombie reconnect loops for dead/expired pods.
+				if consecutiveAuthFailures >= maxConsecutiveAuthFailures {
+					c.logger.Error("Giving up reconnect: too many consecutive auth failures",
+						"count", consecutiveAuthFailures, "last_error", err)
+					c.fireOnClose()
+					return
+				}
+			} else {
+				// Transient error (network, timeout) — reset auth failure counter
+				consecutiveAuthFailures = 0
 			}
 
 			// Exponential backoff with jitter (±20%) to prevent thundering herd
@@ -154,8 +175,9 @@ func (c *Client) reconnectLoop() {
 		c.connected.Store(true)
 		c.connectedAt.Store(time.Now().UnixMilli())
 
-		// Create a new connDoneCh for the new connection
+		// Create new per-connection channels for the new connection
 		c.connDoneCh = make(chan struct{})
+		c.writeExitCh = make(chan struct{})
 
 		// Restart read/write loops
 		c.wg.Add(2)

--- a/runner/internal/relay/client_reconnect_test.go
+++ b/runner/internal/relay/client_reconnect_test.go
@@ -277,6 +277,160 @@ func TestStartAfterStop(t *testing.T) {
 	}
 }
 
+// TestAuthFailureCircuitBreaker verifies that the reconnect loop gives up
+// after maxConsecutiveAuthFailures handshake errors.
+func TestAuthFailureCircuitBreaker(t *testing.T) {
+	var connectionAttempts atomic.Int32
+	var closeCalled atomic.Bool
+
+	// Server always rejects with 401
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		connectionAttempts.Add(1)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	url := "ws" + strings.TrimPrefix(srv.URL, "http")
+	c := NewClient(url, "pod-1", "test-token", nil)
+	c.SetCloseHandler(func() { closeCalled.Store(true) })
+
+	// Token refresh always fails (returns empty)
+	c.SetTokenExpiredHandler(func() string { return "" })
+
+	// Simulate that read/write loops have already exited (no prior connection).
+	close(c.writeExitCh)
+
+	// Manually trigger reconnectLoop as if readLoop spawned it.
+	c.wg.Add(1)
+	c.reconnecting.Store(true)
+	go c.reconnectLoop()
+
+	// Wait for circuit breaker to trigger
+	deadline := time.After(30 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("timeout: reconnect loop did not stop after auth failures")
+		default:
+			if closeCalled.Load() {
+				// Circuit breaker triggered onClose
+				attempts := connectionAttempts.Load()
+				if attempts > int32(maxConsecutiveAuthFailures)+1 {
+					t.Errorf("too many attempts: got %d, want <= %d",
+						attempts, maxConsecutiveAuthFailures+1)
+				}
+				return
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+}
+
+// TestAuthFailureResetsOnTransientError verifies that transient errors
+// reset the consecutive auth failure counter.
+func TestAuthFailureResetsOnTransientError(t *testing.T) {
+	var connectionAttempts atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempt := connectionAttempts.Add(1)
+		if attempt <= 3 {
+			// First 3: auth failures
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if attempt == 4 {
+			// 4th: network-level rejection (transient) - just close connection
+			w.Header().Set("Connection", "close")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		// 5th+: accept connection
+		conn, err := testUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	url := "ws" + strings.TrimPrefix(srv.URL, "http")
+	c := NewClient(url, "pod-1", "test-token", nil)
+	c.SetTokenExpiredHandler(func() string { return "" })
+
+	reconnected := make(chan struct{})
+	c.SetReconnectHandler(func() { close(reconnected) })
+
+	close(c.writeExitCh)
+	c.wg.Add(1)
+	c.reconnecting.Store(true)
+	go c.reconnectLoop()
+	defer c.Stop()
+
+	select {
+	case <-reconnected:
+		// After 3 auth + 1 transient + 1 success = reconnected
+		if connectionAttempts.Load() < 5 {
+			t.Errorf("expected at least 5 attempts, got %d", connectionAttempts.Load())
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("timeout: should have reconnected after transient error reset counter")
+	}
+}
+
+// TestAuthFailure_TokenRefreshSuccessThenFailAgain verifies that after a
+// successful token refresh, the auth failure counter resets and a fresh
+// sequence of failures is needed to trigger the circuit breaker.
+func TestAuthFailure_TokenRefreshSuccessThenFailAgain(t *testing.T) {
+	var connectionAttempts atomic.Int32
+	var closeCalled atomic.Bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		connectionAttempts.Add(1)
+		// Always reject — even refreshed tokens don't help
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	url := "ws" + strings.TrimPrefix(srv.URL, "http")
+	c := NewClient(url, "pod-1", "test-token", nil)
+	c.SetCloseHandler(func() { closeCalled.Store(true) })
+
+	// Token refresh succeeds (returns a new token), but the new token also fails
+	c.SetTokenExpiredHandler(func() string { return "refreshed-token" })
+
+	close(c.writeExitCh)
+	c.wg.Add(1)
+	c.reconnecting.Store(true)
+	go c.reconnectLoop()
+
+	deadline := time.After(30 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("timeout: circuit breaker should have triggered")
+		default:
+			if closeCalled.Load() {
+				// Circuit breaker triggered. After token refresh success (resets counter),
+				// need maxConsecutiveAuthFailures more failures.
+				// Attempt 1: auth fail → refresh → success → counter=0, retry immediately
+				// Attempts 2-6: auth fail × 5 → circuit break
+				// Total: 1 (refresh attempt) + 1 (retry with new token) + 5 = 7 max
+				attempts := connectionAttempts.Load()
+				if attempts > int32(maxConsecutiveAuthFailures)+2 {
+					t.Errorf("too many attempts after refresh: got %d", attempts)
+				}
+				return
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+}
+
 // TestStopIdempotent verifies that calling Stop() multiple times is safe.
 func TestStopIdempotent(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/runner/internal/runner/message_handler_relay.go
+++ b/runner/internal/runner/message_handler_relay.go
@@ -39,6 +39,14 @@ func (h *RunnerMessageHandler) OnSubscribePod(req client.SubscribePodRequest) er
 		return fmt.Errorf("pod not found: %s", req.PodKey)
 	}
 
+	// Reject subscribe for pods in terminal states. Initializing pods are
+	// allowed — backend may send subscribe_pod before the process starts.
+	if status := pod.GetStatus(); status == PodStatusStopped || status == PodStatusFailed {
+		log.Info("Pod is not active, ignoring subscribe",
+			"pod_key", req.PodKey, "status", status)
+		return nil
+	}
+
 	log.Debug("Pod interaction mode", "pod_key", req.PodKey, "mode", pod.InteractionMode)
 
 	// Phase 1: Under lock — check existing client and extract/clear if needed.

--- a/runner/internal/runner/message_handler_relay_test.go
+++ b/runner/internal/runner/message_handler_relay_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"log/slog"
 	"testing"
 
 	"github.com/anthropics/agentsmesh/runner/internal/client"
@@ -367,5 +368,62 @@ func TestOnSubscribePod_ReconnectAfterDisconnect(t *testing.T) {
 	// Stop should be called to clean up the disconnected client
 	if !firstClient.StopCalled {
 		t.Error("Stop() should be called to clean up disconnected client")
+	}
+}
+
+// TestOnSubscribePod_RejectsStoppedPod verifies that subscribe is silently ignored
+// for pods in terminal states.
+func TestOnSubscribePod_RejectsStoppedPod(t *testing.T) {
+	for _, status := range []string{PodStatusStopped, PodStatusFailed} {
+		t.Run(status, func(t *testing.T) {
+			store := NewInMemoryPodStore()
+			mockConn := client.NewMockConnection()
+			runner := &Runner{cfg: &config.Config{}}
+			handler := NewRunnerMessageHandler(runner, store, mockConn)
+
+			pod := &Pod{PodKey: "pod-terminal", Status: status}
+			store.Put(pod.PodKey, pod)
+
+			err := handler.OnSubscribePod(client.SubscribePodRequest{
+				PodKey:      pod.PodKey,
+				RelayURL:    "wss://relay.example.com",
+				RunnerToken: "token-123",
+			})
+
+			if err != nil {
+				t.Errorf("expected nil error for %s pod, got: %v", status, err)
+			}
+			if pod.GetRelayClient() != nil {
+				t.Errorf("no relay client should be set for %s pod", status)
+			}
+		})
+	}
+}
+
+// TestOnSubscribePod_AllowsInitializingPod verifies that subscribe is accepted
+// for pods still in initializing state (backend may send subscribe before process starts).
+func TestOnSubscribePod_AllowsInitializingPod(t *testing.T) {
+	store := NewInMemoryPodStore()
+	mockConn := client.NewMockConnection()
+	runner := &Runner{cfg: &config.Config{}}
+	handler := NewRunnerMessageHandler(runner, store, mockConn)
+
+	handler.relayClientFactory = func(url, podKey, token string, logger *slog.Logger) relay.RelayClient {
+		mc := relay.NewMockClient(url)
+		return mc
+	}
+
+	pod := &Pod{PodKey: "pod-init", Status: PodStatusInitializing}
+	store.Put(pod.PodKey, pod)
+
+	err := handler.OnSubscribePod(client.SubscribePodRequest{
+		PodKey:      pod.PodKey,
+		RelayURL:    "wss://relay.example.com",
+		RunnerToken: "token-123",
+	})
+
+	// Should proceed (Connect will succeed with mock), not be rejected
+	if err != nil {
+		t.Errorf("initializing pod should accept subscribe, got: %v", err)
 	}
 }

--- a/runner/internal/runner/pod_reconciler.go
+++ b/runner/internal/runner/pod_reconciler.go
@@ -1,0 +1,84 @@
+package runner
+
+import (
+	"context"
+	"time"
+
+	"github.com/anthropics/agentsmesh/runner/internal/logger"
+	"github.com/anthropics/agentsmesh/runner/internal/process"
+)
+
+// PodReconciler periodically verifies that each pod's underlying process is
+// still alive. If a pod's process has exited but the exit handler never fired
+// (race condition, unexpected crash), the reconciler cleans it up. This
+// prevents zombie relay connections from accumulating in long-running Runners.
+type PodReconciler struct {
+	podStore PodStore
+	cleanup  func(podKey string, exitCode int, stopIO bool)
+	interval time.Duration
+}
+
+// NewPodReconciler creates a PodReconciler.
+// cleanup should be RunnerMessageHandler.cleanupPodExit.
+func NewPodReconciler(
+	store PodStore,
+	cleanup func(podKey string, exitCode int, stopIO bool),
+	interval time.Duration,
+) *PodReconciler {
+	if interval == 0 {
+		interval = 60 * time.Second
+	}
+	return &PodReconciler{
+		podStore: store,
+		cleanup:  cleanup,
+		interval: interval,
+	}
+}
+
+// Serve implements suture.Service.
+func (r *PodReconciler) Serve(ctx context.Context) error {
+	log := logger.Runner()
+	log.Info("PodReconciler starting", "interval", r.interval)
+
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			r.reconcile()
+		}
+	}
+}
+
+func (r *PodReconciler) String() string { return "PodReconciler" }
+
+func (r *PodReconciler) reconcile() {
+	log := logger.Runner()
+
+	for _, pod := range r.podStore.All() {
+		// Skip pods in intermediate states: initializing pods haven't started
+		// their process yet, and stopped pods are already being cleaned up.
+		status := pod.GetStatus()
+		if status != PodStatusRunning {
+			continue
+		}
+
+		if pod.IO == nil {
+			continue
+		}
+
+		pid := pod.IO.GetPID()
+		if pid <= 0 {
+			continue // ACP mode or not yet started
+		}
+
+		if err := process.IsAlive(pid); err != nil {
+			log.Warn("Reconciler detected dead pod process, cleaning up",
+				"pod_key", pod.PodKey, "pid", pid, "reason", err)
+			r.cleanup(pod.PodKey, -1, true)
+		}
+	}
+}

--- a/runner/internal/runner/pod_reconciler_test.go
+++ b/runner/internal/runner/pod_reconciler_test.go
@@ -1,0 +1,159 @@
+package runner
+
+import (
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// reconcilerMockPodIO implements PodIO with a configurable PID for reconciler tests.
+type reconcilerMockPodIO struct {
+	pid int
+}
+
+func (m *reconcilerMockPodIO) Mode() string                              { return "pty" }
+func (m *reconcilerMockPodIO) SendInput(string) error                    { return nil }
+func (m *reconcilerMockPodIO) GetSnapshot(int) (string, error)           { return "", nil }
+func (m *reconcilerMockPodIO) GetAgentStatus() string                    { return "idle" }
+func (m *reconcilerMockPodIO) SubscribeStateChange(string, func(string)) {}
+func (m *reconcilerMockPodIO) UnsubscribeStateChange(string)             {}
+func (m *reconcilerMockPodIO) GetPID() int                               { return m.pid }
+func (m *reconcilerMockPodIO) Stop()                                     {}
+func (m *reconcilerMockPodIO) Teardown() string                          { return "" }
+func (m *reconcilerMockPodIO) SetExitHandler(func(int))                  {}
+func (m *reconcilerMockPodIO) SetIOErrorHandler(func(error))             {}
+func (m *reconcilerMockPodIO) Detach()                                   {}
+func (m *reconcilerMockPodIO) Start() error                              { return nil }
+
+func TestPodReconciler_CleansUpDeadProcess(t *testing.T) {
+	store := NewInMemoryPodStore()
+	pod := &Pod{
+		PodKey: "dead-pod",
+		Status: PodStatusRunning,
+		IO:     &reconcilerMockPodIO{pid: 999999},
+	}
+	store.Put(pod.PodKey, pod)
+
+	var cleaned atomic.Bool
+	reconciler := NewPodReconciler(store, func(podKey string, exitCode int, stopIO bool) {
+		if podKey == "dead-pod" && exitCode == -1 && stopIO {
+			cleaned.Store(true)
+		}
+	}, 50*time.Millisecond)
+
+	reconciler.reconcile()
+
+	if !cleaned.Load() {
+		t.Error("expected dead pod to be cleaned up")
+	}
+}
+
+func TestPodReconciler_SkipsLiveProcess(t *testing.T) {
+	store := NewInMemoryPodStore()
+	pod := &Pod{
+		PodKey: "live-pod",
+		Status: PodStatusRunning,
+		IO:     &reconcilerMockPodIO{pid: os.Getpid()},
+	}
+	store.Put(pod.PodKey, pod)
+
+	var cleaned atomic.Bool
+	reconciler := NewPodReconciler(store, func(_ string, _ int, _ bool) {
+		cleaned.Store(true)
+	}, 50*time.Millisecond)
+
+	reconciler.reconcile()
+
+	if cleaned.Load() {
+		t.Error("live pod should not be cleaned up")
+	}
+}
+
+func TestPodReconciler_SkipsNonRunningStatus(t *testing.T) {
+	store := NewInMemoryPodStore()
+	for _, status := range []string{PodStatusInitializing, PodStatusStopped, PodStatusFailed} {
+		pod := &Pod{
+			PodKey: "pod-" + status,
+			Status: status,
+			IO:     &reconcilerMockPodIO{pid: 999999},
+		}
+		store.Put(pod.PodKey, pod)
+	}
+
+	var cleaned atomic.Bool
+	reconciler := NewPodReconciler(store, func(_ string, _ int, _ bool) {
+		cleaned.Store(true)
+	}, 50*time.Millisecond)
+
+	reconciler.reconcile()
+
+	if cleaned.Load() {
+		t.Error("non-running pods should not be cleaned up")
+	}
+}
+
+func TestPodReconciler_SkipsZeroPID(t *testing.T) {
+	store := NewInMemoryPodStore()
+	pod := &Pod{
+		PodKey: "acp-pod",
+		Status: PodStatusRunning,
+		IO:     &reconcilerMockPodIO{pid: 0},
+	}
+	store.Put(pod.PodKey, pod)
+
+	var cleaned atomic.Bool
+	reconciler := NewPodReconciler(store, func(_ string, _ int, _ bool) {
+		cleaned.Store(true)
+	}, 50*time.Millisecond)
+
+	reconciler.reconcile()
+
+	if cleaned.Load() {
+		t.Error("zero-PID pod should not be cleaned up")
+	}
+}
+
+func TestPodReconciler_SkipsNilIO(t *testing.T) {
+	store := NewInMemoryPodStore()
+	pod := &Pod{
+		PodKey: "no-io-pod",
+		Status: PodStatusRunning,
+		IO:     nil,
+	}
+	store.Put(pod.PodKey, pod)
+
+	var cleaned atomic.Bool
+	reconciler := NewPodReconciler(store, func(_ string, _ int, _ bool) {
+		cleaned.Store(true)
+	}, 50*time.Millisecond)
+
+	reconciler.reconcile()
+
+	if cleaned.Load() {
+		t.Error("nil-IO pod should not be cleaned up")
+	}
+}
+
+func TestPodReconciler_IdempotentCleanup(t *testing.T) {
+	store := NewInMemoryPodStore()
+	pod := &Pod{
+		PodKey: "dead-pod",
+		Status: PodStatusRunning,
+		IO:     &reconcilerMockPodIO{pid: 999999},
+	}
+	store.Put(pod.PodKey, pod)
+
+	var cleanupCount atomic.Int32
+	reconciler := NewPodReconciler(store, func(podKey string, _ int, _ bool) {
+		cleanupCount.Add(1)
+		store.Delete(podKey)
+	}, 50*time.Millisecond)
+
+	reconciler.reconcile()
+	reconciler.reconcile()
+
+	if got := cleanupCount.Load(); got != 1 {
+		t.Errorf("cleanup called %d times, want 1", got)
+	}
+}

--- a/runner/internal/runner/runner_lifecycle.go
+++ b/runner/internal/runner/runner_lifecycle.go
@@ -66,6 +66,14 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 	supervisor.Add(lifecycle.NewWatchdogService(watchdogCfg))
 
+	// Register Pod Reconciler: periodically detects dead pod processes
+	// whose exit handlers never fired, preventing zombie relay connections.
+	supervisor.Add(NewPodReconciler(
+		r.podStore,
+		r.messageHandler.cleanupPodExit,
+		60*time.Second,
+	))
+
 	// Register additional services (Console, etc.)
 	for _, svc := range r.additionalServices {
 		supervisor.Add(svc)


### PR DESCRIPTION
## Summary

- Runner relay 连接在长时间运行的实例上泄漏 TCP 连接（22k+ TIME_WAIT），耗尽临时端口导致所有 TCP 出站失败
- 根因：Pod `1-26-4b53ae19` 进程已死但 relay client 无限重连（7214 次 `bad handshake`），无熔断机制
- 架构缺陷：Runner 作为服务型进程缺少 relay 连接生命周期的兜底管控

## Changes

### Fix 1: Auth 熔断 (`client_reconnect.go`)
- 新增 `maxConsecutiveAuthFailures = 5` 熔断阈值
- 连续 auth 失败达到上限后终止重连并触发 `onClose`
- 瞬态错误（网络超时）重置计数器，token 刷新成功也重置

### Fix 2: Pod 进程存活性 Reconciler (新建 `pod_reconciler.go`)
- `PodReconcilerService` 每 60s 遍历所有 Running 状态 pod
- 使用已有的跨平台 `process.IsAlive(pid)` 检测僵尸进程
- 进程已死的 pod 走标准 `cleanupPodExit` 清理路径

### Fix 3: reconnectLoop 生命周期管理 (`client_loops.go`, `client_connection.go`)
- 引入 `writeExitCh` 信号通道，writeLoop 退出时显式关闭
- reconnectLoop 等待 `writeExitCh` 而非 `wg.Wait()`，避免同一 wg 自锁
- 所有 goroutine (readLoop/writeLoop/reconnectLoop) 统一在单个 wg 中

### Fix 4: OnSubscribePod 防御性检查 (`message_handler_relay.go`)
- 拒绝 stopped/failed 终止态 pod 的 subscribe 请求
- 允许 initializing 状态（backend 可能提前发送 subscribe）

## Test plan

- [x] `TestAuthFailureCircuitBreaker` — 连续 auth 失败后熔断
- [x] `TestAuthFailureResetsOnTransientError` — 瞬态错误重置计数器
- [x] `TestAuthFailure_TokenRefreshSuccessThenFailAgain` — refresh 后再失败需重新累积
- [x] `TestPodReconciler_CleansUpDeadProcess` — 死进程被清理
- [x] `TestPodReconciler_SkipsLiveProcess` — 活进程不被误杀
- [x] `TestPodReconciler_SkipsNonRunningStatus` — 非 Running 状态跳过
- [x] `TestPodReconciler_SkipsZeroPID` / `SkipsNilIO` — 边界条件
- [x] `TestPodReconciler_IdempotentCleanup` — 两轮 reconcile 只清理一次
- [x] `TestOnSubscribePod_RejectsStoppedPod` — stopped/failed 被拒绝
- [x] `TestOnSubscribePod_AllowsInitializingPod` — initializing 被放行
- [x] 全量 relay + runner 测试通过（含 race detector）