### PR TITLE
fix(relay): buffer output when message type is ACP snapshot

### DIFF
--- a/relay/internal/channel/terminal_channel_io.go
+++ b/relay/internal/channel/terminal_channel_io.go
@@ -157,7 +157,8 @@ func (c *TerminalChannel) forwardPublisherToSubscribers(epoch uint64) {
 		// Snapshot supersedes all buffered output — clear buffer and replace with
 		// the snapshot itself, so new subscribers joining after this point receive
 		// the complete terminal state instead of an empty buffer.
-		if msg != nil && msg.Type == protocol.MsgTypeSnapshot {
+		// Support both PTY Snapshot (0x01) and ACP Snapshot (0x0D).
+		if msg != nil && (msg.Type == protocol.MsgTypeSnapshot || msg.Type == protocol.MsgTypeAcpSnapshot) {
 			c.clearOutputBuffer()
 			c.bufferOutput(data)
 		}


### PR DESCRIPTION
## Summary

- What changed?

Modified terminal_channel_io.go to buffer ACP snapshot messages in addition to PTY snapshot messages.

- Why was this change needed?

Previously, only PTY snapshots (type 0x01) were buffered for new subscribers, but ACP snapshots (type 0x0D) were not. This meant new subscribers joining an ACP terminal session would not receive the complete terminal state, leading to incomplete or missing output in their view.

## Changes

- Updated forwardPublisherToSubscribers to detect both MsgTypeSnapshot (PTY) and MsgTypeAcpSnapshot (ACP) message types
- When either snapshot type is received, the output buffer is cleared and replaced with the snapshot data
- Added inline comment clarifying support for both snapshot types (0x01 PTY and 0x0D ACP)

## Validation

- [ ] Backend tests (`cd backend && go test ./...`)
- [ ] Web checks (`cd web && pnpm run lint && pnpm run type-check && pnpm run test:coverage`)
- [ ] Runner checks (`cd runner && go test ./...`)
- [ ] Manual validation performed (if applicable)

## Documentation

- [ ] Docs updated (README/docs/inline comments)
- [ ] No docs changes needed

## Risk and Rollback

- Risk level: Low
- Rollback plan: Rollback plan: Revert commit 380c290 - only affects new subscriber behavior for ACP sessions; existing PTY sessions unaffected
