### PR TITLE
fix(runner): send snapshot on subscribe pod

### DIFF
--- a/runner/internal/runner/message_handler_relay.go
+++ b/runner/internal/runner/message_handler_relay.go
@@ -57,11 +57,21 @@ func (h *RunnerMessageHandler) OnSubscribePod(req client.SubscribePodRequest) er
 	if existingClient != nil {
 		if existingClient.IsConnected() && existingClient.GetRelayURL() == relayURL {
 			// Already connected to the same Relay, just update token for future reconnects
-			log.Info("Already connected to same relay, updating token only",
+			log.Info("Already connected to same relay, updating token",
 				"pod_key", req.PodKey,
-				"relay_url", relayURL)
+				"relay_url", relayURL,
+				"include_snapshot", req.IncludeSnapshot)
 			existingClient.UpdateToken(req.RunnerToken)
 			pod.UnlockRelay()
+
+			// Send snapshot if requested (critical for ACP mode: browser refresh doesn't trigger
+			// relay reconnect, so we must send snapshot on every subscribe request).
+			// PTY mode benefits too: reduces latency for multi-device scenarios.
+			if req.IncludeSnapshot && pod.Relay != nil {
+				log.Info("Sending snapshot for existing relay connection",
+					"pod_key", req.PodKey)
+				pod.Relay.SendSnapshot(existingClient)
+			}
 			return nil
 		}
 		// Connected to different Relay or disconnected, need to reconnect


### PR DESCRIPTION
## Summary

- What changed?

Modified runner's relay message handler to send terminal snapshot when subscribing to an already-connected pod with IncludeSnapshot=true.

- Why was this change needed?

Browser refresh in ACP mode doesn't trigger relay reconnection, causing terminal content loss. This fix ensures snapshot is sent on every subscribe request, critical for ACP mode and beneficial for multi-device PTY scenarios.

## Changes

- Added snapshot sending logic in OnSubscribePod when reconnecting to same relay with IncludeSnapshot=true
- Enhanced logging to include include_snapshot flag
- Added inline comment explaining ACP mode behavior and PTY mode benefits

## Validation

- [ ] Backend tests (`cd backend && go test ./...`)
- [ ] Web checks (`cd web && pnpm run lint && pnpm run type-check && pnpm run test:coverage`)
- [ ] Runner checks (`cd runner && go test ./...`)
- [ ] Manual validation performed (if applicable)

## Documentation

- [ ] Docs updated (README/docs/inline comments)
- [ ] No docs changes needed

## Risk and Rollback

- Risk level: Low
- Rollback plan:  Revert commit f40456a. Existing connections won't be affected, only new subscribe requests with IncludeSnapshot=true will miss snapshot data on browser refresh.
