### PR TITLE
fix(web): mobile rendering across landing, docs, and nav

### DIFF
--- a/web/src/app/docs/page.tsx
+++ b/web/src/app/docs/page.tsx
@@ -24,21 +24,21 @@ export default function DocsPage() {
 
   return (
     <div>
-      <div className="mb-14">
+      <div className="mb-10 sm:mb-14">
         <span className="inline-flex items-center gap-2 rounded-full azure-light-chip px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em]">
           <span className="h-1.5 w-1.5 rounded-full bg-[var(--azure-light-cyan-ink)]" />
           {t("docs.title")}
         </span>
-        <h1 className="mt-4 text-5xl font-semibold leading-tight tracking-tight text-[var(--azure-light-ink)]">
+        <h1 className="mt-4 text-3xl sm:text-4xl md:text-5xl font-semibold leading-tight tracking-tight text-[var(--azure-light-ink)]">
           {t("docs.intro.title")}
         </h1>
-        <p className="mt-4 max-w-2xl text-lg leading-relaxed text-[var(--azure-light-ink-muted)]">
+        <p className="mt-4 max-w-2xl text-base sm:text-lg leading-relaxed text-[var(--azure-light-ink-muted)]">
           {t("docs.intro.description")}
         </p>
       </div>
 
-      <section className="mb-16">
-        <div className="azure-light-card rounded-2xl p-7">
+      <section className="mb-12 sm:mb-16">
+        <div className="azure-light-card rounded-2xl p-5 sm:p-7">
           <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--azure-light-cyan-ink)]">
             {t("docs.intro.supportedAgents")}
           </p>
@@ -60,9 +60,9 @@ export default function DocsPage() {
         </div>
       </section>
 
-      <section className="mb-16">
-        <div className="mb-6">
-          <h2 className="text-3xl font-semibold tracking-tight text-[var(--azure-light-ink)]">
+      <section className="mb-12 sm:mb-16">
+        <div className="mb-5 sm:mb-6">
+          <h2 className="text-2xl sm:text-3xl font-semibold tracking-tight text-[var(--azure-light-ink)]">
             {t("docs.whatYouCanDo.title")}
           </h2>
           <p className="mt-2 text-[var(--azure-light-ink-muted)] leading-relaxed max-w-2xl">
@@ -73,7 +73,7 @@ export default function DocsPage() {
           {CAPABILITIES.map((key) => (
             <div
               key={key}
-              className="azure-light-card azure-light-card-hover rounded-xl p-6"
+              className="azure-light-card azure-light-card-hover rounded-xl p-5 sm:p-6"
             >
               <h3 className="text-base font-semibold text-[var(--azure-light-ink)]">
                 {t(`docs.whatYouCanDo.${key}.title`)}
@@ -86,9 +86,9 @@ export default function DocsPage() {
         </div>
       </section>
 
-      <section className="mb-16">
+      <section className="mb-12 sm:mb-16">
         <div className="mb-2">
-          <h2 className="text-3xl font-semibold tracking-tight text-[var(--azure-light-ink)]">
+          <h2 className="text-2xl sm:text-3xl font-semibold tracking-tight text-[var(--azure-light-ink)]">
             {t("docs.architecture.title")}
           </h2>
           <p className="mt-2 text-[var(--azure-light-ink-muted)] leading-relaxed max-w-2xl">
@@ -99,7 +99,7 @@ export default function DocsPage() {
       </section>
 
       <section className="mb-12">
-        <h2 className="text-3xl font-semibold mb-6 tracking-tight text-[var(--azure-light-ink)]">
+        <h2 className="text-2xl sm:text-3xl font-semibold mb-5 sm:mb-6 tracking-tight text-[var(--azure-light-ink)]">
           {t("docs.quickLinks.title")}
         </h2>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -141,7 +141,7 @@ function QuickLinkCard({
   return (
     <Link
       href={href}
-      className="azure-light-card azure-light-card-hover rounded-xl p-6 block group"
+      className="azure-light-card azure-light-card-hover rounded-xl p-5 sm:p-6 block group"
     >
       <h3 className="text-base font-semibold text-[var(--azure-light-ink)] group-hover:text-[var(--azure-light-cyan-ink)] transition-colors">
         {title}

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -300,9 +300,9 @@ body:has(.app-shell) {
 }
 
 .azure-theme .azure-glass {
-  background-color: rgba(49, 53, 63, 0.4);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
+  background-color: rgba(28, 31, 41, 0.7);
+  backdrop-filter: blur(20px) saturate(140%);
+  -webkit-backdrop-filter: blur(20px) saturate(140%);
 }
 
 .azure-theme .azure-glow-cyan {

--- a/web/src/components/docs/DocsShell.tsx
+++ b/web/src/components/docs/DocsShell.tsx
@@ -106,14 +106,14 @@ export default function DocsShell({
       <BreadcrumbJsonLd breadcrumbs={breadcrumbs} labels={breadcrumbLabels} />
 
       <header className="azure-light-glass sticky top-0 z-10">
-        <div className="container mx-auto px-4 py-4 flex items-center justify-between">
-          <div className="flex items-center gap-3">
+        <div className="container mx-auto px-3 sm:px-4 py-3 sm:py-4 flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2 sm:gap-3 min-w-0">
             <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
               <SheetTrigger asChild>
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="md:hidden"
+                  className="md:hidden flex-shrink-0"
                   aria-label={t("docs.nav.menu")}
                 >
                   <svg
@@ -139,11 +139,11 @@ export default function DocsShell({
               </SheetContent>
             </Sheet>
 
-            <Link href="/" className="flex items-center gap-2">
-              <div className="w-8 h-8 rounded-lg overflow-hidden">
+            <Link href="/" className="flex items-center gap-2 min-w-0">
+              <div className="w-7 h-7 sm:w-8 sm:h-8 rounded-lg overflow-hidden flex-shrink-0">
                 <Logo />
               </div>
-              <span className="text-xl font-semibold text-[var(--azure-light-ink)]">
+              <span className="text-base sm:text-xl font-semibold text-[var(--azure-light-ink)] truncate">
                 AgentsMesh
               </span>
             </Link>
@@ -151,10 +151,10 @@ export default function DocsShell({
               Docs
             </span>
           </div>
-          <div className="flex items-center gap-5">
+          <div className="flex items-center gap-3 sm:gap-5 flex-shrink-0">
             <Link
               href="/docs"
-              className="text-sm font-medium text-[var(--azure-light-ink-muted)] hover:text-[var(--azure-light-ink)] transition-colors"
+              className="hidden sm:block text-sm font-medium text-[var(--azure-light-ink-muted)] hover:text-[var(--azure-light-ink)] transition-colors"
             >
               {t("landing.nav.docs")}
             </Link>
@@ -168,9 +168,9 @@ export default function DocsShell({
           <SidebarNav />
         </aside>
 
-        <main className="flex-1 px-6 md:px-10 py-10 max-w-4xl mx-auto min-w-0">
+        <main className="flex-1 px-4 sm:px-6 md:px-10 py-8 sm:py-10 max-w-4xl mx-auto min-w-0 w-full">
           {breadcrumbs.length > 1 && (
-            <nav className="flex items-center gap-2 text-xs mb-8 text-[var(--azure-light-ink-muted)]">
+            <nav className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs mb-6 sm:mb-8 text-[var(--azure-light-ink-muted)]">
               {breadcrumbs.map((crumb, index) => (
                 <span key={index} className="flex items-center gap-2">
                   {index > 0 && (

--- a/web/src/components/landing/AgentPodDemo.tsx
+++ b/web/src/components/landing/AgentPodDemo.tsx
@@ -138,12 +138,10 @@ export function AgentPodDemo() {
 
   return (
     <div className="space-y-2.5">
-      {/* Top row: 2 terminals */}
-      <div className="grid grid-cols-2 gap-2.5">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
         <Terminal pod={PODS[0]} displayedLines={displayedLines} />
         <Terminal pod={PODS[1]} displayedLines={displayedLines} />
       </div>
-      {/* Bottom row: 1 terminal, full width */}
       <Terminal pod={PODS[2]} displayedLines={displayedLines} />
     </div>
   );

--- a/web/src/components/landing/FeatureVisuals.tsx
+++ b/web/src/components/landing/FeatureVisuals.tsx
@@ -27,35 +27,40 @@ export function FeatureVisuals({ feature, t }: FeatureVisualsProps) {
 
 function MeshDiagram({ t }: { t: TFunc }) {
   return (
-    <div className="bg-[#0f0e2a] rounded-xl border border-[#2a2556] shadow-2xl p-8 relative overflow-hidden">
+    <div className="bg-[#0f0e2a] rounded-xl border border-[#2a2556] shadow-2xl p-4 sm:p-8 relative overflow-hidden">
       <div className="absolute inset-0 opacity-[0.06]"
         style={{ backgroundImage: 'radial-gradient(circle, #818cf8 1px, transparent 1px)', backgroundSize: '20px 20px' }} />
-      <div className="relative h-64">
-        <div className="absolute left-[10%] top-[20%] px-5 py-3 bg-[#1a1745] border border-[#3730a3]/40 rounded-xl shadow-lg shadow-indigo-500/10 z-10">
+      <div className="relative h-56 sm:h-64">
+        <div className="absolute left-[4%] sm:left-[10%] top-[15%] sm:top-[20%] px-3 py-2 sm:px-5 sm:py-3 bg-[#1a1745] border border-[#3730a3]/40 rounded-xl shadow-lg shadow-indigo-500/10 z-10">
           <div className="flex items-center gap-2 mb-1">
             <div className="w-2 h-2 rounded-full bg-[#34d399] animate-pulse" />
-            <div className="text-sm font-bold text-[#e0e7ff]">Claude Code</div>
+            <div className="text-xs sm:text-sm font-bold text-[#e0e7ff]">Claude Code</div>
           </div>
-          <div className="text-xs text-[#a5b4fc] font-mono">{t("landing.coreDemo.podA")}</div>
+          <div className="text-[10px] sm:text-xs text-[#a5b4fc] font-mono">{t("landing.coreDemo.podA")}</div>
         </div>
-        <div className="absolute right-[10%] top-[20%] px-5 py-3 bg-[#1a1745] border border-[#3730a3]/40 rounded-xl shadow-lg shadow-indigo-500/10 z-10">
+        <div className="absolute right-[4%] sm:right-[10%] top-[15%] sm:top-[20%] px-3 py-2 sm:px-5 sm:py-3 bg-[#1a1745] border border-[#3730a3]/40 rounded-xl shadow-lg shadow-indigo-500/10 z-10">
           <div className="flex items-center gap-2 mb-1">
             <div className="w-2 h-2 rounded-full bg-[#34d399] animate-pulse delay-75" />
-            <div className="text-sm font-bold text-[#e0e7ff]">Codex CLI</div>
+            <div className="text-xs sm:text-sm font-bold text-[#e0e7ff]">Codex CLI</div>
           </div>
-          <div className="text-xs text-[#a5b4fc] font-mono">{t("landing.coreDemo.podB")}</div>
+          <div className="text-[10px] sm:text-xs text-[#a5b4fc] font-mono">{t("landing.coreDemo.podB")}</div>
         </div>
-        <div className="absolute left-1/2 -translate-x-1/2 bottom-[20%] px-6 py-3 bg-[#1a1745] border border-[#3730a3]/40 rounded-full shadow-lg shadow-indigo-500/10 z-10 flex items-center gap-3">
-          <div className="w-8 h-8 rounded-full bg-[#818cf8]/15 flex items-center justify-center text-[#818cf8]">#</div>
-          <div>
-            <div className="text-sm font-bold text-[#e0e7ff]">{t("landing.coreDemo.devChannel")}</div>
-            <div className="text-xs text-[#a5b4fc]/70">{t("landing.coreDemo.members", { count: 3 })}</div>
+        <div className="absolute left-1/2 -translate-x-1/2 bottom-[12%] sm:bottom-[20%] px-3 py-2 sm:px-6 sm:py-3 bg-[#1a1745] border border-[#3730a3]/40 rounded-full shadow-lg shadow-indigo-500/10 z-10 flex items-center gap-2 sm:gap-3 max-w-[90%]">
+          <div className="w-7 h-7 sm:w-8 sm:h-8 rounded-full bg-[#818cf8]/15 flex items-center justify-center text-[#818cf8] flex-shrink-0">#</div>
+          <div className="min-w-0">
+            <div className="text-xs sm:text-sm font-bold text-[#e0e7ff] truncate">{t("landing.coreDemo.devChannel")}</div>
+            <div className="text-[10px] sm:text-xs text-[#a5b4fc]/70">{t("landing.coreDemo.members", { count: 3 })}</div>
           </div>
         </div>
-        <svg className="absolute inset-0 w-full h-full pointer-events-none" style={{ zIndex: 0 }}>
-          <path d="M120 80 Q 180 200 250 220" fill="none" stroke="#818cf8" strokeWidth="2" strokeDasharray="4" opacity="0.3" />
-          <path d="M380 80 Q 320 200 250 220" fill="none" stroke="#818cf8" strokeWidth="2" strokeDasharray="4" opacity="0.3" />
-          <path d="M140 60 Q 250 20 360 60" fill="none" stroke="#818cf8" strokeWidth="1.5" strokeDasharray="6 4" opacity="0.2" />
+        <svg
+          className="absolute inset-0 w-full h-full pointer-events-none"
+          viewBox="0 0 500 250"
+          preserveAspectRatio="none"
+          style={{ zIndex: 0 }}
+        >
+          <path d="M120 80 Q 180 200 250 220" fill="none" stroke="#818cf8" strokeWidth="2" strokeDasharray="4" opacity="0.3" vectorEffect="non-scaling-stroke" />
+          <path d="M380 80 Q 320 200 250 220" fill="none" stroke="#818cf8" strokeWidth="2" strokeDasharray="4" opacity="0.3" vectorEffect="non-scaling-stroke" />
+          <path d="M140 60 Q 250 20 360 60" fill="none" stroke="#818cf8" strokeWidth="1.5" strokeDasharray="6 4" opacity="0.2" vectorEffect="non-scaling-stroke" />
           <circle r="3" fill="#818cf8" className="animate-ping" style={{ animationDuration: '3s' }}>
             <animateMotion dur="2s" repeatCount="indefinite" path="M120 80 Q 180 200 250 220" />
           </circle>
@@ -70,22 +75,22 @@ function MeshDiagram({ t }: { t: TFunc }) {
 
 function KanbanBoard({ columns, t }: { columns: Array<{ titleKey: string; cards: string[] }>; t: TFunc }) {
   return (
-    <div className="bg-[#fafbfc] rounded-xl border border-[#d8dee4] shadow-2xl p-6 relative overflow-hidden">
-      <div className="grid grid-cols-4 gap-4">
+    <div className="bg-[#fafbfc] rounded-xl border border-[#d8dee4] shadow-2xl p-3 sm:p-6 relative overflow-hidden">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 sm:gap-4">
         {columns.map((col, i) => (
-          <div key={i} className="bg-[#f0f3f6] rounded-xl p-3 flex flex-col h-48">
-            <div className="flex items-center justify-between mb-3 px-1">
-              <span className="text-[10px] font-bold uppercase tracking-wider text-[#57606a]">{t(col.titleKey)}</span>
-              <span className="text-[10px] bg-[#d8dee4] px-1.5 py-0.5 rounded text-[#57606a]">{col.cards.length}</span>
+          <div key={i} className="bg-[#f0f3f6] rounded-xl p-2 sm:p-3 flex flex-col h-40 sm:h-48 min-w-0">
+            <div className="flex items-center justify-between mb-2 sm:mb-3 px-1 gap-1">
+              <span className="text-[9px] sm:text-[10px] font-bold uppercase tracking-wider text-[#57606a] truncate">{t(col.titleKey)}</span>
+              <span className="text-[10px] bg-[#d8dee4] px-1.5 py-0.5 rounded text-[#57606a] flex-shrink-0">{col.cards.length}</span>
             </div>
             <div className="space-y-2 flex-1 overflow-y-auto custom-scrollbar">
               {col.cards.map((card, j) => (
-                <div key={j} className="bg-white border border-[#d8dee4] rounded-lg p-2.5 shadow-sm hover:shadow-md hover:border-[#0969da]/40 transition-all cursor-default group/card">
-                  <div className="flex items-center justify-between mb-1.5">
-                    <span className="font-mono text-[10px] text-[#0969da] bg-[#ddf4ff] px-1 rounded">{card}</span>
-                    <div className="w-1.5 h-1.5 rounded-full bg-[#1a7f37]" />
+                <div key={j} className="bg-white border border-[#d8dee4] rounded-lg p-2 sm:p-2.5 shadow-sm hover:shadow-md hover:border-[#0969da]/40 transition-all cursor-default group/card">
+                  <div className="flex items-center justify-between mb-1.5 gap-1">
+                    <span className="font-mono text-[9px] sm:text-[10px] text-[#0969da] bg-[#ddf4ff] px-1 rounded truncate">{card}</span>
+                    <div className="w-1.5 h-1.5 rounded-full bg-[#1a7f37] flex-shrink-0" />
                   </div>
-                  <div className="text-[10px] text-[#24292f] font-medium leading-tight">{t("landing.coreDemo.kanban.authFeature")}</div>
+                  <div className="text-[10px] text-[#24292f] font-medium leading-tight line-clamp-2">{t("landing.coreDemo.kanban.authFeature")}</div>
                   <div className="mt-2 flex items-center gap-1 opacity-50 group-hover/card:opacity-100 transition-opacity">
                     <div className="w-3 h-3 rounded-full bg-[#0969da]/15" />
                     <div className="h-1 w-8 bg-[#d8dee4] rounded-full" />
@@ -131,23 +136,23 @@ function SchedulePanel({ t }: { t: TFunc }) {
       </div>
       <div className="divide-y divide-[#1a3a2a]">
         {rows.map((row, i) => (
-          <div key={i} className="flex items-center gap-4 px-5 py-4 hover:bg-[#0c2618] transition-colors group/row">
+          <div key={i} className="flex items-center gap-2 sm:gap-4 px-3 sm:px-5 py-3 sm:py-4 hover:bg-[#0c2618] transition-colors group/row">
             <div className={`w-2.5 h-2.5 rounded-full flex-shrink-0 ${row.status === "passed" ? "bg-[#34d399]" : row.status === "running" ? "bg-[#fbbf24] animate-pulse" : "bg-[#365a48]"}`} />
-            <div className="w-24 flex-shrink-0">
-              <span className="text-[11px] font-mono text-[#6ee7b7] bg-[#0c2618] px-2 py-0.5 rounded">{row.schedule}</span>
+            <div className="w-16 sm:w-24 flex-shrink-0">
+              <span className="text-[10px] sm:text-[11px] font-mono text-[#6ee7b7] bg-[#0c2618] px-1.5 sm:px-2 py-0.5 rounded">{row.schedule}</span>
             </div>
-            <div className="flex-1 text-sm font-medium text-[#a7f3d0]/80 group-hover/row:text-[#d1fae5] transition-colors">{row.task}</div>
-            <div className={`text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full ${row.status === "passed" ? "bg-[#34d399]/10 text-[#34d399] border border-[#34d399]/20" : row.status === "running" ? "bg-[#fbbf24]/10 text-[#fbbf24] border border-[#fbbf24]/20" : "bg-[#1a3a2a] text-[#6ee7b7]/50 border border-[#365a48]"}`}>
+            <div className="flex-1 min-w-0 text-xs sm:text-sm font-medium text-[#a7f3d0]/80 group-hover/row:text-[#d1fae5] transition-colors truncate">{row.task}</div>
+            <div className={`text-[9px] sm:text-[10px] font-bold uppercase tracking-wider px-1.5 sm:px-2 py-0.5 rounded-full flex-shrink-0 ${row.status === "passed" ? "bg-[#34d399]/10 text-[#34d399] border border-[#34d399]/20" : row.status === "running" ? "bg-[#fbbf24]/10 text-[#fbbf24] border border-[#fbbf24]/20" : "bg-[#1a3a2a] text-[#6ee7b7]/50 border border-[#365a48]"}`}>
               {row.status === "passed" ? t("landing.coreDemo.schedule.passed") : row.status === "running" ? t("landing.coreDemo.schedule.running") : t("landing.coreDemo.schedule.pending")}
             </div>
           </div>
         ))}
       </div>
-      <div className="px-5 py-3 bg-[#0c2618] border-t border-[#1a3a2a] flex items-center justify-between">
-        <span className="text-[11px] text-[#6ee7b7]/60">
+      <div className="px-3 sm:px-5 py-3 bg-[#0c2618] border-t border-[#1a3a2a] flex items-center justify-between gap-2">
+        <span className="text-[10px] sm:text-[11px] text-[#6ee7b7]/60 truncate">
           {t("landing.coreDemo.schedule.nextRun")} <span className="font-mono text-[#a7f3d0]/70">12m 34s</span>
         </span>
-        <div className="flex gap-1">
+        <div className="flex gap-1 flex-shrink-0">
           {[1, 2, 3, 4, 5, 6, 7].map((d) => (
             <div key={d} className={`w-1.5 h-4 rounded-sm ${d <= 5 ? "bg-[#34d399]/50" : "bg-[#1a3a2a]"}`} />
           ))}
@@ -159,48 +164,48 @@ function SchedulePanel({ t }: { t: TFunc }) {
 
 function ArchitectureDiagram({ t }: { t: TFunc }) {
   return (
-    <div className="bg-[#1c1917] rounded-xl border border-[#44403c] shadow-2xl p-8 relative overflow-hidden">
+    <div className="bg-[#1c1917] rounded-xl border border-[#44403c] shadow-2xl p-4 sm:p-8 relative overflow-hidden">
       <div className="relative z-10">
-        <div className="border-2 border-dashed border-[#57534e] bg-[#292524] rounded-2xl p-8 relative">
-          <div className="absolute -top-3 left-6 px-2 bg-[#1c1917] text-xs font-bold text-[#fb923c] uppercase tracking-wider border border-[#44403c] rounded">
+        <div className="border-2 border-dashed border-[#57534e] bg-[#292524] rounded-2xl p-4 sm:p-8 relative">
+          <div className="absolute -top-3 left-4 sm:left-6 px-2 bg-[#1c1917] text-[10px] sm:text-xs font-bold text-[#fb923c] uppercase tracking-wider border border-[#44403c] rounded">
             {t("landing.coreDemo.architecture.yourInfrastructure")}
           </div>
-          <div className="flex items-center justify-center gap-12">
-            <div className="text-center group/node">
-              <div className="w-20 h-20 bg-[#1c1917] border-2 border-[#44403c] rounded-2xl flex items-center justify-center mx-auto mb-3 shadow-lg group-hover/node:border-[#fb923c]/50 transition-all">
-                <svg className="w-10 h-10 text-[#fb923c]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <div className="flex items-center justify-center gap-4 sm:gap-12">
+            <div className="text-center group/node flex-shrink-0">
+              <div className="w-16 h-16 sm:w-20 sm:h-20 bg-[#1c1917] border-2 border-[#44403c] rounded-2xl flex items-center justify-center mx-auto mb-2 sm:mb-3 shadow-lg group-hover/node:border-[#fb923c]/50 transition-all">
+                <svg className="w-8 h-8 sm:w-10 sm:h-10 text-[#fb923c]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2" />
                 </svg>
               </div>
-              <div className="text-sm font-bold text-[#e7e5e4]">{t("landing.coreDemo.architecture.runner")}</div>
-              <div className="text-[10px] text-[#a8a29e] mt-1 font-mono">Docker/K8s</div>
+              <div className="text-xs sm:text-sm font-bold text-[#e7e5e4]">{t("landing.coreDemo.architecture.runner")}</div>
+              <div className="text-[9px] sm:text-[10px] text-[#a8a29e] mt-1 font-mono">Docker/K8s</div>
             </div>
-            <div className="flex flex-col items-center gap-1">
-              <div className="w-16 h-0.5 bg-gradient-to-r from-transparent via-[#fb923c]/50 to-transparent" />
-              <div className="text-[10px] text-[#a8a29e] font-mono">gRPC mTLS</div>
-              <div className="w-16 h-0.5 bg-gradient-to-r from-transparent via-[#fb923c]/50 to-transparent" />
+            <div className="flex flex-col items-center gap-1 min-w-0">
+              <div className="w-10 sm:w-16 h-0.5 bg-gradient-to-r from-transparent via-[#fb923c]/50 to-transparent" />
+              <div className="text-[9px] sm:text-[10px] text-[#a8a29e] font-mono whitespace-nowrap">gRPC mTLS</div>
+              <div className="w-10 sm:w-16 h-0.5 bg-gradient-to-r from-transparent via-[#fb923c]/50 to-transparent" />
             </div>
-            <div className="text-center group/node">
-              <div className="w-20 h-20 bg-[#292524] border-2 border-[#44403c] rounded-2xl flex items-center justify-center mx-auto mb-3 shadow-lg group-hover/node:border-[#fb923c]/50 transition-all">
-                <svg className="w-10 h-10 text-[#e7e5e4]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <div className="text-center group/node flex-shrink-0">
+              <div className="w-16 h-16 sm:w-20 sm:h-20 bg-[#292524] border-2 border-[#44403c] rounded-2xl flex items-center justify-center mx-auto mb-2 sm:mb-3 shadow-lg group-hover/node:border-[#fb923c]/50 transition-all">
+                <svg className="w-8 h-8 sm:w-10 sm:h-10 text-[#e7e5e4]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                 </svg>
               </div>
-              <div className="text-sm font-bold text-[#e7e5e4]">{t("landing.coreDemo.architecture.agent")}</div>
-              <div className="text-[10px] text-[#a8a29e] mt-1 font-mono">Isolated Pod</div>
+              <div className="text-xs sm:text-sm font-bold text-[#e7e5e4]">{t("landing.coreDemo.architecture.agent")}</div>
+              <div className="text-[9px] sm:text-[10px] text-[#a8a29e] mt-1 font-mono">Isolated Pod</div>
             </div>
           </div>
         </div>
-        <div className="h-16 w-px bg-gradient-to-b from-[#44403c] to-transparent mx-auto my-2 relative">
-          <div className="absolute top-1/2 left-4 -translate-y-1/2 text-[10px] text-[#a8a29e] whitespace-nowrap font-mono">
+        <div className="h-12 sm:h-16 w-px bg-gradient-to-b from-[#44403c] to-transparent mx-auto my-2 relative">
+          <div className="absolute top-1/2 left-3 sm:left-4 -translate-y-1/2 text-[9px] sm:text-[10px] text-[#a8a29e] whitespace-nowrap font-mono">
             {t("landing.coreDemo.architecture.websocket")} (Encrypted)
           </div>
         </div>
       </div>
       <div className="text-center relative z-10">
-        <div className="inline-flex items-center gap-2 px-6 py-2.5 bg-[#292524] rounded-full border border-[#44403c] shadow-lg">
-          <div className="w-2 h-2 rounded-full bg-[#34d399] animate-pulse" />
-          <span className="text-sm font-medium text-[#e7e5e4]">{t("landing.coreDemo.architecture.agentsmeshCloud")}</span>
+        <div className="inline-flex items-center gap-2 px-4 sm:px-6 py-2 sm:py-2.5 bg-[#292524] rounded-full border border-[#44403c] shadow-lg max-w-full">
+          <div className="w-2 h-2 rounded-full bg-[#34d399] animate-pulse flex-shrink-0" />
+          <span className="text-xs sm:text-sm font-medium text-[#e7e5e4] truncate">{t("landing.coreDemo.architecture.agentsmeshCloud")}</span>
         </div>
       </div>
       <div className="absolute inset-0 bg-gradient-to-b from-transparent via-[#fb923c]/5 to-transparent opacity-50 pointer-events-none" />

--- a/web/src/components/landing/Footer.tsx
+++ b/web/src/components/landing/Footer.tsx
@@ -77,7 +77,7 @@ export function Footer() {
   return (
     <footer className="bg-[var(--azure-bg-deeper)] py-20">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="grid grid-cols-2 md:grid-cols-5 gap-12 mb-16">
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-8 sm:gap-12 mb-12 sm:mb-16">
           <div className="col-span-2 md:col-span-1">
             <Link href="/" className="flex items-center gap-2 mb-5">
               <div className="w-7 h-7 rounded-lg overflow-hidden">

--- a/web/src/components/landing/HeroSection/HeroContent.tsx
+++ b/web/src/components/landing/HeroSection/HeroContent.tsx
@@ -10,7 +10,7 @@ interface HeroContentProps {
 export function HeroContent({ t, onWatchDemo }: HeroContentProps) {
   return (
     <div className="text-center max-w-5xl mx-auto">
-      <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-[var(--azure-bg-high)] border border-[var(--azure-outline-variant)]/40 mb-10">
+      <div className="inline-flex items-center gap-2 px-3 sm:px-4 py-1.5 rounded-full bg-[var(--azure-bg-high)] border border-[var(--azure-outline-variant)]/40 mb-6 sm:mb-10">
         <span className="relative flex h-2 w-2">
           <span className="absolute inline-flex h-full w-full rounded-full bg-[var(--azure-mint)] opacity-75 animate-ping" />
           <span className="relative inline-flex h-2 w-2 rounded-full bg-[var(--azure-mint)]" />
@@ -20,13 +20,13 @@ export function HeroContent({ t, onWatchDemo }: HeroContentProps) {
         </span>
       </div>
 
-      <h1 className="font-headline text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold leading-[0.95] mb-8">
+      <h1 className="font-headline text-[2.25rem] leading-[1.05] sm:text-5xl md:text-6xl lg:text-7xl sm:leading-[0.95] font-bold mb-6 sm:mb-8">
         <span className="text-foreground">{t("landing.hero.slogan1")}</span>
         <br />
         <span className="azure-gradient-text">{t("landing.hero.slogan2")}</span>
       </h1>
 
-      <p className="text-[var(--azure-text-muted)] text-lg md:text-xl max-w-2xl mx-auto mb-12 font-light leading-relaxed">
+      <p className="text-[var(--azure-text-muted)] text-base sm:text-lg md:text-xl max-w-2xl mx-auto mb-8 sm:mb-12 font-light leading-relaxed">
         {t("landing.hero.description")}
       </p>
 

--- a/web/src/components/landing/HeroSection/HeroSection.tsx
+++ b/web/src/components/landing/HeroSection/HeroSection.tsx
@@ -11,14 +11,14 @@ export function HeroSection() {
   const [demoOpen, setDemoOpen] = useState(false);
 
   return (
-    <section className="relative pt-32 pb-24 sm:pt-40 sm:pb-32 px-4 sm:px-6 lg:px-8 azure-mesh-bg overflow-hidden">
-      <div className="absolute -top-20 -right-20 w-[500px] h-[500px] bg-[var(--azure-cyan)]/10 blur-[120px] rounded-full azure-orb pointer-events-none" />
+    <section className="relative pt-24 pb-20 sm:pt-40 sm:pb-32 px-4 sm:px-6 lg:px-8 azure-mesh-bg overflow-hidden">
+      <div className="absolute -top-20 -right-20 w-[300px] h-[300px] sm:w-[500px] sm:h-[500px] bg-[var(--azure-cyan)]/10 blur-[120px] rounded-full azure-orb pointer-events-none" />
       <div
-        className="absolute bottom-10 -left-10 w-[400px] h-[400px] bg-[var(--azure-mint)]/10 blur-[100px] rounded-full azure-orb pointer-events-none"
+        className="absolute bottom-10 -left-10 w-[260px] h-[260px] sm:w-[400px] sm:h-[400px] bg-[var(--azure-mint)]/10 blur-[100px] rounded-full azure-orb pointer-events-none"
         style={{ animationDelay: "1.5s" }}
       />
       <div
-        className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[700px] h-[700px] bg-[var(--azure-cyan)]/[0.04] blur-[140px] rounded-full pointer-events-none"
+        className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[400px] h-[400px] sm:w-[700px] sm:h-[700px] bg-[var(--azure-cyan)]/[0.04] blur-[140px] rounded-full pointer-events-none"
       />
 
       <MeshBackground />

--- a/web/src/components/landing/HowItWorks.tsx
+++ b/web/src/components/landing/HowItWorks.tsx
@@ -83,9 +83,9 @@ agentsmesh-runner run`,
                   </div>
                 </div>
 
-                <div className={`flex-1 w-full ${onLeft ? "md:order-3" : "md:order-1"}`}>
-                  <div className="azure-glass rounded-2xl border border-white/5 p-5 font-mono text-xs leading-relaxed text-[var(--azure-text-muted)] overflow-x-auto">
-                    <pre className="whitespace-pre-wrap">{step.code}</pre>
+                <div className={`flex-1 w-full min-w-0 ${onLeft ? "md:order-3" : "md:order-1"}`}>
+                  <div className="azure-glass rounded-2xl border border-white/5 p-4 sm:p-5 font-mono text-xs leading-relaxed text-[var(--azure-text-muted)] overflow-x-auto">
+                    <pre className="whitespace-pre-wrap break-all sm:break-words">{step.code}</pre>
                   </div>
                 </div>
               </div>

--- a/web/src/components/landing/Navbar.tsx
+++ b/web/src/components/landing/Navbar.tsx
@@ -33,14 +33,17 @@ export function Navbar() {
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
+  const collapsedRadius = isMobileMenuOpen ? "rounded-3xl" : "rounded-full";
+  const containerStyle = isMobileMenuOpen
+    ? "bg-[var(--azure-bg-high)]/95 backdrop-blur-xl border border-white/15 shadow-[0_24px_48px_-12px_rgba(0,0,0,0.6)]"
+    : isScrolled
+      ? "azure-glass border border-white/10 azure-glow-cyan-lg"
+      : "bg-transparent border border-transparent";
+
   return (
     <nav className="fixed top-0 left-0 right-0 z-50 px-4 pt-4 sm:pt-6">
       <div
-        className={`mx-auto max-w-6xl rounded-full px-5 sm:px-7 py-3 transition-all duration-300 ${
-          isScrolled
-            ? "azure-glass border border-white/10 azure-glow-cyan-lg"
-            : "bg-transparent border border-transparent"
-        }`}
+        className={`mx-auto max-w-6xl ${collapsedRadius} px-5 sm:px-7 py-3 transition-all duration-300 ${containerStyle}`}
       >
         <div className="flex items-center justify-between">
           <Link href="/" className="flex items-center gap-2.5">
@@ -121,7 +124,6 @@ export function Navbar() {
               </div>
               <AuthButtons
                 size="sm"
-                showRegister
                 onClick={() => setIsMobileMenuOpen(false)}
                 className="flex flex-col gap-2 [&_button]:w-full"
               />

--- a/web/src/components/landing/ParadigmShift.tsx
+++ b/web/src/components/landing/ParadigmShift.tsx
@@ -62,9 +62,13 @@ export function ParadigmShift() {
         </div>
 
         <div className="text-center">
-          <p className="font-headline text-xl md:text-2xl font-medium italic text-[var(--azure-text-muted)] max-w-3xl mx-auto">
-            {t("landing.paradigmShift.punchline")}
-          </p>
+          <div className="inline-flex items-center gap-3 max-w-3xl mx-auto">
+            <span className="hidden sm:block h-px w-12 bg-gradient-to-r from-transparent to-[var(--azure-cyan)]/40" />
+            <p className="font-headline text-lg sm:text-xl md:text-2xl font-medium text-foreground/90 tracking-tight">
+              {t("landing.paradigmShift.punchline")}
+            </p>
+            <span className="hidden sm:block h-px w-12 bg-gradient-to-l from-transparent to-[var(--azure-cyan)]/40" />
+          </div>
         </div>
       </div>
     </section>

--- a/web/src/components/landing/PricingSection.tsx
+++ b/web/src/components/landing/PricingSection.tsx
@@ -142,23 +142,23 @@ export function PricingSection() {
   const plans = buildPlans();
 
   return (
-    <section className="py-32 relative" id="pricing">
+    <section className="py-20 sm:py-32 relative" id="pricing">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-16">
-          <h2 className="font-headline text-4xl md:text-5xl font-bold mb-6 italic">
+        <div className="text-center mb-12 sm:mb-16">
+          <h2 className="font-headline text-3xl sm:text-4xl md:text-5xl font-bold mb-5 sm:mb-6 leading-tight">
             {t("landing.pricing.title")}{" "}
-            <span className="azure-gradient-text not-italic">{t("landing.pricing.titleHighlight")}</span>
+            <span className="azure-gradient-text">{t("landing.pricing.titleHighlight")}</span>
           </h2>
-          <p className="text-[var(--azure-text-muted)] max-w-2xl mx-auto text-lg font-light">
+          <p className="text-[var(--azure-text-muted)] max-w-2xl mx-auto text-base sm:text-lg font-light">
             {t("landing.pricing.description")}
           </p>
         </div>
 
-        <div className="flex items-center justify-center mb-16">
+        <div className="flex items-center justify-center mb-12 sm:mb-16">
           <div className="inline-flex items-center rounded-full azure-glass p-1 border border-white/10">
             <button
               onClick={() => setBillingCycle("monthly")}
-              className={`px-5 py-2 rounded-full text-sm font-headline font-bold uppercase tracking-wider transition-all ${
+              className={`px-4 sm:px-5 py-2 rounded-full text-xs sm:text-sm font-headline font-bold uppercase tracking-wider transition-all ${
                 billingCycle === "monthly"
                   ? "azure-gradient-bg"
                   : "text-[var(--azure-text-muted)] hover:text-foreground"
@@ -168,14 +168,14 @@ export function PricingSection() {
             </button>
             <button
               onClick={() => setBillingCycle("yearly")}
-              className={`px-5 py-2 rounded-full text-sm font-headline font-bold uppercase tracking-wider transition-all ${
+              className={`px-4 sm:px-5 py-2 rounded-full text-xs sm:text-sm font-headline font-bold uppercase tracking-wider transition-all ${
                 billingCycle === "yearly"
                   ? "azure-gradient-bg"
                   : "text-[var(--azure-text-muted)] hover:text-foreground"
               }`}
             >
               {t("landing.pricing.yearly")}
-              <span className="ml-2 text-[10px] opacity-80">{t("landing.pricing.yearlyDiscount")}</span>
+              <span className="ml-1.5 sm:ml-2 text-[9px] sm:text-[10px] opacity-80">{t("landing.pricing.yearlyDiscount")}</span>
             </button>
           </div>
         </div>
@@ -187,7 +187,7 @@ export function PricingSection() {
             {plans.map((plan) => (
               <div
                 key={plan.key}
-                className={`relative rounded-3xl p-8 flex flex-col transition-all ${
+                className={`relative rounded-3xl p-6 sm:p-8 flex flex-col transition-all ${
                   plan.highlighted
                     ? "azure-glass border-2 border-[var(--azure-cyan)] azure-glow-cyan-lg lg:scale-105 z-10"
                     : "bg-[var(--azure-bg-low)] border border-[var(--azure-outline-variant)]/30"


### PR DESCRIPTION
## Summary
- Fix mobile overflow and oversized typography across landing (Hero, ParadigmShift, Pricing, Footer) and docs pages
- Fix mobile menu: solid background with contrast, single Sign In CTA, no cyan glow halo
- Scale FeatureVisuals (MeshDiagram SVG via viewBox + non-scaling-stroke, Kanban 4→2 cols, ArchitectureDiagram tighter spacing, SchedulePanel truncation)
- Replace italic headings (ParadigmShift punchline, Pricing title) with weight-based emphasis and decorative gradient dividers
- Tighten azure-glass background opacity to prevent text bleed-through on scrolled navbar

## Test plan
- [x] Mobile viewport (~390-500px): Hero, paradigm shift, pricing, mesh, kanban, architecture all render without horizontal overflow
- [x] Mobile menu: solid bg, single CTA, no glow halo, rounded corners
- [x] Desktop (1280px): no regressions on paradigm shift dividers and pricing title
- [x] Lint clean (`pnpm lint` — 0 errors)
- [ ] Verify on real mobile device

🤖 Generated with [Claude Code](https://claude.com/claude-code)