### PR TITLE
fix(backend): update ticket api :slug keyword to :ticket_slug

### DIFF
--- a/backend/internal/api/rest/v1/apikey_routes.go
+++ b/backend/internal/api/rest/v1/apikey_routes.go
@@ -61,15 +61,15 @@ func RegisterExtRoutes(rg *gin.RouterGroup, svc *Services) {
 	{
 		ticketsRead.GET("", ticketHandler.ListTickets)
 		ticketsRead.GET("/board", ticketHandler.GetBoard)
-		ticketsRead.GET("/:slug", ticketHandler.GetTicket)
+		ticketsRead.GET("/:ticket_slug", ticketHandler.GetTicket)
 	}
 	ticketsWrite := rg.Group("/tickets")
 	ticketsWrite.Use(middleware.RequireScope("tickets:write"))
 	{
 		ticketsWrite.POST("", ticketHandler.CreateTicket)
-		ticketsWrite.PUT("/:slug", ticketHandler.UpdateTicket)
-		ticketsWrite.PATCH("/:slug/status", ticketHandler.UpdateTicketStatus)
-		ticketsWrite.DELETE("/:slug", ticketHandler.DeleteTicket)
+		ticketsWrite.PUT("/:ticket_slug", ticketHandler.UpdateTicket)
+		ticketsWrite.PATCH("/:ticket_slug/status", ticketHandler.UpdateTicketStatus)
+		ticketsWrite.DELETE("/:ticket_slug", ticketHandler.DeleteTicket)
 	}
 
 	// Channel routes


### PR DESCRIPTION
## Summary

- **What changed?** Fixed route parameter name mismatch in the external (API Key) ticket routes — `:slug` → `:ticket_slug`.
- **Why was this change needed?** All ticket handlers read `c.Param("ticket_slug")`, which matches the internal route definitions in `routes_tickets.go`. However, `apikey_routes.go` registered the same handlers under `/:slug`. Since Gin binds values to the exact param name in the path pattern, `c.Param("ticket_slug")` always returned an empty string on the ext routes, causing every single-ticket operation (GET, PUT, PATCH /status, DELETE) to return 404 regardless of whether the ticket existed.

## Changes

- `backend/internal/api/rest/v1/apikey_routes.go`: renamed four route path params from `/:slug` / `/:slug/status` to `/:ticket_slug` / `/:ticket_slug/status` in both the `ticketsRead` and `ticketsWrite` groups

## Validation

- [ ] Backend tests (`cd backend && go test ./...`)
- [ ] Web checks (`cd web && pnpm run lint && pnpm run type-check && pnpm run test:coverage`)
- [ ] Runner checks (`cd runner && go test ./...`)
- [x] Manual validation performed — confirmed `PATCH /api/v1/ext/orgs/:slug/tickets/:ticket_slug/status` returns 200 after the fix; previously returned 404 on all requests

## Documentation

- [x] No docs changes needed — this is a pure bug fix aligning route params with existing handler contract

## Risk and Rollback

- **Risk level:** Low — the change only corrects a broken parameter name; no logic, no schema, no migration touched. External callers that were working around the 404 (e.g., using the list endpoint only) are unaffected.
- **Rollback plan:** Revert the four `/:ticket_slug` → `/:slug` renames in `apikey_routes.go`. No database or config changes to undo.