### PR TITLE
fix(bazel): unblock prod deploy — Go binaries static, Next.js base full

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -81,11 +81,18 @@ use_repo(
 )
 
 # Base image for Node.js services (Next.js web + web-admin). We pull
-# Debian-based `node:20-slim` instead of a distroless image here
-# because `js_image_layer` wraps the `js_binary` in a bash launcher
-# (to set BAZEL_BINDIR and resolve runfiles), and Google's
-# `distroless/nodejs20` ships neither bash nor sh. Multi-arch so the
-# Next.js images still release to both amd64 and arm64 hosts.
+# Debian-based `node:20` (full bookworm, not -slim) instead of a
+# distroless image here because:
+#  1. `js_image_layer` wraps the `js_binary` in a bash launcher (to set
+#     BAZEL_BINDIR and resolve runfiles), and Google's `distroless/nodejs20`
+#     ships neither bash nor sh.
+#  2. The prod swarm stack defines a `curl -f http://localhost:3000/`
+#     healthcheck. `node:20-slim` strips curl/wget; `node:20` (default
+#     bookworm) ships both. Keeping the full image lets the healthcheck
+#     work without taking a runtime dependency on the deploy repo's
+#     compose yml.
+# Multi-arch so the Next.js images still release to both amd64 and arm64
+# hosts.
 oci.pull(
     name = "distroless_nodejs",
     image = "docker.io/library/node",
@@ -93,7 +100,7 @@ oci.pull(
         "linux/amd64",
         "linux/arm64/v8",
     ],
-    tag = "20-slim",
+    tag = "20",
 )
 use_repo(
     oci,

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -945,7 +945,7 @@
     "@@rules_oci+//oci:extensions.bzl%oci": {
       "general": {
         "bzlTransitiveDigest": "m5CaKTCnSQra32tL1Wy7xwRpB8nsAE7OSh4++9xURBg=",
-        "usagesDigest": "/Rz9XyNyk1lYVwNJuSxgfqRN2a3vA/3lYBJZ2uotpTU=",
+        "usagesDigest": "R1eGXxq72fBZx7wrDVUKYR2IRaTVzB5rGbDwz9H41l0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -996,7 +996,7 @@
               "scheme": "https",
               "registry": "index.docker.io",
               "repository": "library/node",
-              "identifier": "20-slim",
+              "identifier": "20",
               "platform": "linux/amd64",
               "target_name": "distroless_nodejs_linux_amd64",
               "bazel_tags": []
@@ -1008,7 +1008,7 @@
               "scheme": "https",
               "registry": "index.docker.io",
               "repository": "library/node",
-              "identifier": "20-slim",
+              "identifier": "20",
               "platform": "linux/arm64/v8",
               "target_name": "distroless_nodejs_linux_arm64_v8",
               "bazel_tags": []
@@ -1021,7 +1021,7 @@
               "scheme": "https",
               "registry": "index.docker.io",
               "repository": "library/node",
-              "identifier": "20-slim",
+              "identifier": "20",
               "platforms": {
                 "@@platforms//cpu:x86_64": "@distroless_nodejs_linux_amd64",
                 "@@platforms//cpu:arm64": "@distroless_nodejs_linux_arm64_v8"

--- a/backend/cmd/server/BUILD.bazel
+++ b/backend/cmd/server/BUILD.bazel
@@ -86,6 +86,13 @@ go_library(
 go_binary(
     name = "server",
     embed = [":server_lib"],
+    # CGO_ENABLED=0 — produce a statically-linked binary so the image can
+    # stay on `distroless/static` (no glibc / ld-linux loader). Without
+    # this, the binary is dynamically linked against
+    # /lib64/ld-linux-x86-64.so.2 and the container exec fails with
+    # `no such file or directory` on startup (kernel reporting the
+    # missing ELF interpreter, not the binary itself).
+    pure = "on",
     visibility = ["//visibility:public"],
 )
 

--- a/relay/cmd/relay/BUILD.bazel
+++ b/relay/cmd/relay/BUILD.bazel
@@ -16,6 +16,10 @@ go_library(
 go_binary(
     name = "relay",
     embed = [":relay_lib"],
+    # CGO_ENABLED=0 — keep the binary statically linked so it can run on
+    # the distroless/static base (no glibc). See
+    # //backend/cmd/server:BUILD.bazel for the full rationale.
+    pure = "on",
     visibility = ["//visibility:public"],
 )
 

--- a/runner/cmd/runner/BUILD.bazel
+++ b/runner/cmd/runner/BUILD.bazel
@@ -41,6 +41,10 @@ go_library(
 go_binary(
     name = "runner",
     embed = [":runner_lib"],
+    # CGO_ENABLED=0 — keep the binary statically linked so it can run on
+    # the distroless/static base (no glibc). See
+    # //backend/cmd/server:BUILD.bazel for the full rationale.
+    pure = "on",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
## Summary

- **Backend / runner / relay**: pin `pure = "on"` (CGO_ENABLED=0) on the three `go_binary` targets. Distroless/static base has no glibc/ELF loader; the dynamically-linked binaries that the previous Bazel migration emitted made the kernel report `exec /app/server: no such file or directory` (the missing thing was the *interpreter*, not the binary).
- **Web / web-admin**: bump `distroless_nodejs` base from `node:20-slim` → `node:20`. Slim strips `curl/wget`, but the prod swarm stack (`/opt/agentsmesh/base/docker-compose.yml`) defines `["CMD","curl","-f","http://localhost:3000/"]` as the healthcheck. Container started clean (Next.js `Ready in 700ms`) but every probe failed → swarm `SIGTERM` → exit 143.

## Why this surfaced now

The first post-migration release (run [25369427973](https://github.com/AgentsMesh/AgentsMesh/actions/runs/25369427973)) successfully built and pushed all three images to the new `registry.agentsmesh.ai` (Caddy + LE direct origin, post Cloudflare 100 MB body-limit migration), but every prod swarm task crashed on startup. `Deploy US West Relay 01` succeeded only because relay-001 is plain docker-compose, not swarm — it never exercised the broken paths.

## Test plan

- [x] `bazel build //backend/cmd/server:image --platforms=@rules_go//go/toolchain:linux_amd64` → extracted `/app/server` reports `ELF 64-bit LSB executable, x86-64, statically linked`
- [x] `bazel build //clients/web:image` succeeds; `node:20` base verified to ship `/usr/bin/curl` + `/usr/bin/wget`
- [ ] After merge: re-run [Release pipeline](https://github.com/AgentsMesh/AgentsMesh/actions/runs/25369427973) → Deploy US West Web/Web-Admin/Backend should reach `Running` and serve healthchecks