### PR TITLE
fix(backend): default LOG_FILE to stdout-only

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -7,19 +7,19 @@ import (
 
 // Config holds all configuration for the application
 type Config struct {
-	Server   ServerConfig
-	Database DatabaseConfig
-	Redis    RedisConfig
-	JWT      JWTConfig
-	OAuth    OAuthConfig
-	Webhook  WebhookConfig
-	Log      LogConfig
-	Email    EmailConfig
-	Storage  StorageConfig
-	Payment  PaymentConfig
-	PKI      PKIConfig
-	GRPC     GRPCConfig
-	Admin    AdminConfig
+	Server      ServerConfig
+	Database    DatabaseConfig
+	Redis       RedisConfig
+	JWT         JWTConfig
+	OAuth       OAuthConfig
+	Webhook     WebhookConfig
+	Log         LogConfig
+	Email       EmailConfig
+	Storage     StorageConfig
+	Payment     PaymentConfig
+	PKI         PKIConfig
+	GRPC        GRPCConfig
+	Admin       AdminConfig
 	Relay       RelayConfig
 	Marketplace MarketplaceConfig
 
@@ -110,9 +110,16 @@ func Load() (*Config, error) {
 
 		// Logging Configuration
 		Log: LogConfig{
-			Level:      getEnv("LOG_LEVEL", "info"),
-			Format:     getEnv("LOG_FORMAT", "text"),
-			FilePath:   getEnv("LOG_FILE", "logs/agentsmesh.log"),
+			Level:  getEnv("LOG_LEVEL", "info"),
+			Format: getEnv("LOG_FORMAT", "text"),
+			// stdout-only by default — container runtimes (docker/swarm/k8s)
+			// already collect stdout via the configured logging driver
+			// (loki/json-file/etc). The previous default `logs/agentsmesh.log`
+			// required the working directory to be writable, which broke
+			// distroless+nonroot images. Set LOG_FILE explicitly when an
+			// on-disk log file is actually wanted (and ensure the path is
+			// writable by the container's user).
+			FilePath:   getEnv("LOG_FILE", ""),
 			MaxSizeMB:  getEnvInt("LOG_MAX_SIZE_MB", 100),
 			MaxBackups: getEnvInt("LOG_MAX_BACKUPS", 5),
 		},
@@ -237,4 +244,3 @@ func (c *Config) WarnInsecureDefaults() {
 		}
 	}
 }
-


### PR DESCRIPTION
## Summary

Default `LOG_FILE = "logs/agentsmesh.log"` was a relative path that
required write access to the container's working directory. The Bazel
image migration moved Go services onto `distroless/static` with
`user = nonroot` and `workdir = /app`, so `os.MkdirAll("logs", …)` now
fails with `permission denied` before the rest of bootstrap can run.

Changing the default to `""` makes stdout the sole sink (which is
already the path the loki driver and our Prometheus pipeline rely on);
anyone who actually wants a rotating on-disk file just sets `LOG_FILE`
explicitly to a writable path.

## Field report

```
2026/05/05 17:00:03 Failed to initialize logger:
  failed to create log directory: mkdir logs: permission denied
```

— observed on `agentsmesh_backend.1.*` after release [25389683573](https://github.com/AgentsMesh/AgentsMesh/actions/runs/25389683573)
deployed `sha-c358c08`. swarm task exit code 1, `service update paused`.

## Test plan

- [x] `bazel build //backend/cmd/server:image --platforms=@rules_go//go/toolchain:linux_amd64` — image still builds
- [x] `gofmt -l backend/internal/config/config.go` clean
- [ ] After merge: release pipeline pushes a new image, swarm picks it up, `docker service ls` shows `agentsmesh_backend 1/1` again

## Companion fixes (already landed)

- [#317](https://github.com/AgentsMesh/AgentsMesh/pull/317) — pure-on Go binaries + node:20 base
- 2026-05-05 — cleared stale `/etc/hosts` mapping `100.102.229.112 registry.agentsmesh.ai` + `insecure-registries` on `aliyun-cn-relay-01` and `aliyun-agentsmesh-us-relay-beijing-002` (left over from the CF-Proxied era; new endpoint is `47.251.166.143` over HTTPS via Caddy/LE)