### PR TITLE
fix(bazel): restore /app + /data ownership to uid 1000 in go_oci_image

### DIFF
--- a/build_defs/docker/go_oci_image.bzl
+++ b/build_defs/docker/go_oci_image.bzl
@@ -29,8 +29,20 @@ Used by backend/runner/relay to produce distroless images.
 """
 
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_mkdirs")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load(":oci_push.bzl", "oci_push_targets")
+
+# uid/gid the container runs as. Pinned to 1000:1000 to match the
+# legacy GoReleaser/Dockerfile-built images (`addgroup -g 1000 -S app
+# && adduser -u 1000 -S app -G app`) so existing prod swarm volumes
+# (e.g. `agentsmesh_backend_data`) — created by the GoReleaser image
+# and already owned by uid 1000 on disk — keep working without a
+# manual chown after the Bazel migration. Distroless's built-in
+# `nonroot` user is uid 65532, which would otherwise force a one-shot
+# `chown -R 65532:65532 …` on every prod node holding stateful volumes.
+APP_UID = "1000"
+APP_GID = "1000"
 
 def go_oci_image(
         name,
@@ -55,16 +67,45 @@ def go_oci_image(
             entry becomes a `:name_push_<key>` target. `bazel run` one
             of them with `--stamp --workspace_status_command=...` to
             push with the CI-provided version tag.
-        repository: Back-compat single-registry form; equivalent to
-            `repositories = {"default": repository}`. Prefer the dict.
+        repository: Back-compat single-registry shorthand; equivalent
+            to `repositories = {"default": repository}`. Prefer the dict.
         visibility: Standard visibility.
     """
     binary_name = binary.split(":")[-1]
 
+    # /app + binary owned by 1000:1000 — same ownership the GoReleaser
+    # Dockerfile produced via `chown -R app:app /app`. Without this the
+    # binary lands as root:root and the runtime user can't mkdir/write
+    # under /app (e.g. logger's `logs/` subdir, ACME staging, etc.).
     pkg_tar(
         name = name + "_layer",
         srcs = [binary],
         package_dir = "/app",
+        owner = APP_UID + "." + APP_GID,
+        mode = "0755",
+    )
+
+    # Pre-create /data/acme (and therefore /data) owned by 1000:1000.
+    # Docker swarm copies the image's view of a mountpoint into a
+    # freshly-created volume — including ownership — so this lets new
+    # `agentsmesh_backend_data` volumes inherit 1000:1000 from day
+    # one. Existing prod volumes are already 1000:1000 (legacy
+    # Dockerfile invariant) so this aligns the two paths.
+    pkg_mkdirs(
+        name = name + "_data_dirs",
+        dirs = [
+            "/data",
+            "/data/acme",
+        ],
+        attributes = pkg_attributes(
+            mode = "0755",
+            user = APP_UID,
+            group = APP_GID,
+        ),
+    )
+    pkg_tar(
+        name = name + "_data_layer",
+        srcs = [":" + name + "_data_dirs"],
     )
 
     oci_image(
@@ -74,8 +115,14 @@ def go_oci_image(
         env = env,
         exposed_ports = exposed_ports,
         labels = labels,
-        tars = [":" + name + "_layer"],
-        user = "nonroot",
+        tars = [
+            ":" + name + "_layer",
+            ":" + name + "_data_layer",
+        ],
+        # Numeric uid (not the distroless `nonroot` alias) so we don't
+        # depend on the base image's /etc/passwd. 1000 matches the
+        # `app` user the legacy GoReleaser image created.
+        user = APP_UID,
         visibility = visibility,
         workdir = "/app",
     )


### PR DESCRIPTION
## Summary

The Bazel migration replaced the legacy GoReleaser Dockerfile's

```dockerfile
RUN addgroup -g 1000 -S app && adduser -u 1000 -S app -G app
RUN mkdir -p /data/acme && chown -R app:app /app /data
USER app
```

with a `pkg_tar` + `user = "nonroot"` setup. Two regressions slipped in:

1. `pkg_tar` defaults to `owner = "0.0"`, so `/app` and the binary land root-owned in the image.
2. distroless's `nonroot` is uid **65532**, not the **1000** the legacy `app` user had.

Result: every place backend writes under workdir or `/data` fails with `EACCES`. PR #318 papered over the `logs/` instance via `LOG_FILE=""`; ACME (`/data/acme/user.json`) hit the same wall on the next deploy and crashed the container.

This PR roots the fix at the image layer:

- Numeric `user = "1000"` (no `/etc/passwd` dependency).
- `pkg_tar` for `/app` sets `owner = "1000.1000"`.
- New `pkg_mkdirs` + `pkg_tar` layer pre-creates `/data` and `/data/acme` owned 1000:1000 — Docker swarm copies image ownership into freshly-provisioned volumes, so new `agentsmesh_backend_data` volumes inherit 1000:1000 from the start.

Same macro powers backend / runner / relay, so all three pick up the fix.

## Why uid 1000 specifically

Existing prod volumes (`/var/lib/docker/volumes/agentsmesh_backend_data/_data`) are already `1000:1000` on disk — the legacy Dockerfile's invariant. Pinning the new image to the same uid means **no per-node chown after this lands**; the prod containers come up against the same ownership the volume already has.

## Test plan

- [x] `bazel build //backend/cmd/server:image --platforms=@rules_go//go/toolchain:linux_amd64` succeeds
- [x] Layer inspection confirms ownership:
  ```
  drwxr-xr-x  0 1000  1000      0  app/
  -rwxr-xr-x  0 1000  1000  ...   app/server
  drwxr-xr-x  0 1000  1000      0  data/
  drwxr-xr-x  0 1000  1000      0  data/acme/
  ```
- [ ] After merge: release pipeline pushes new image; swarm rolls backend/web/web-admin to 1/1; `docker exec agentsmesh_backend.<task> /app/server --version` no longer panics on `mkdir logs` or ACME init.

## Companion fixes

- #317 — pure-on Go binaries + node:20 base
- #318 — LOG_FILE default → "" (orthogonal: belt-and-suspenders for stdout-only logging)