### PR TITLE
fix: systematic close-out for Bazel→prod regressions (alpine base + web-admin port + path-filter)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,12 +47,24 @@ jobs:
               - 'backend/**'
               - 'proto/**'
               - 'agentfile/**'
+              - 'build_defs/docker/**'
+              - 'MODULE.bazel'
+              - 'MODULE.bazel.lock'
             web:
               - 'clients/web/**'
+              - 'build_defs/web/**'
+              - 'MODULE.bazel'
+              - 'MODULE.bazel.lock'
             web-admin:
               - 'clients/web-admin/**'
+              - 'build_defs/web/**'
+              - 'MODULE.bazel'
+              - 'MODULE.bazel.lock'
             relay:
               - 'relay/**'
+              - 'build_defs/docker/**'
+              - 'MODULE.bazel'
+              - 'MODULE.bazel.lock'
             migrations:
               - 'backend/migrations/**'
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -60,18 +60,27 @@ bazel_dep(name = "rules_oci", version = "2.0.0")
 bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "aspect_bazel_lib", version = "2.19.2")
 
-# Base image for all Go services. distroless/static gives us a ~2 MB image
-# (zero shell/libc, nonroot user baked in). Multi-arch to support amd64 +
-# arm64 deployment without per-target overrides.
+# Base image for all Go services. We use Alpine 3.19 (not distroless)
+# because the swarm stack's healthcheck spec is `wget --spider …`, and
+# distroless/static ships neither wget nor curl. Switching to Alpine
+# restores parity with the legacy GoReleaser/Dockerfile setup
+# (`FROM alpine:3.19`) — `addgroup -g 1000 -S app …` user invariants
+# are now reproduced by `go_oci_image.bzl` (uid 1000 + chown /app
+# /data). Image size is ~7MB heavier than distroless/static but layer
+# sharing absorbs most of it. Multi-arch (amd64 + arm64).
+#
+# The repo is still named `distroless_static` for backward
+# compatibility with `base = "@distroless_static"` callers — only the
+# upstream image identity changed.
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 oci.pull(
     name = "distroless_static",
-    image = "gcr.io/distroless/static-debian12",
+    image = "docker.io/library/alpine",
     platforms = [
         "linux/amd64",
         "linux/arm64/v8",
     ],
-    tag = "latest",
+    tag = "3.19",
 )
 use_repo(
     oci,

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -945,7 +945,7 @@
     "@@rules_oci+//oci:extensions.bzl%oci": {
       "general": {
         "bzlTransitiveDigest": "m5CaKTCnSQra32tL1Wy7xwRpB8nsAE7OSh4++9xURBg=",
-        "usagesDigest": "R1eGXxq72fBZx7wrDVUKYR2IRaTVzB5rGbDwz9H41l0=",
+        "usagesDigest": "D545NRuKwngtgsqPuv0ISZnpoGlmUHn8CUHjlMshT3w=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -954,9 +954,9 @@
             "repoRuleId": "@@rules_oci+//oci/private:pull.bzl%oci_pull",
             "attributes": {
               "scheme": "https",
-              "registry": "gcr.io",
-              "repository": "distroless/static-debian12",
-              "identifier": "latest",
+              "registry": "index.docker.io",
+              "repository": "library/alpine",
+              "identifier": "3.19",
               "platform": "linux/amd64",
               "target_name": "distroless_static_linux_amd64",
               "bazel_tags": []
@@ -966,9 +966,9 @@
             "repoRuleId": "@@rules_oci+//oci/private:pull.bzl%oci_pull",
             "attributes": {
               "scheme": "https",
-              "registry": "gcr.io",
-              "repository": "distroless/static-debian12",
-              "identifier": "latest",
+              "registry": "index.docker.io",
+              "repository": "library/alpine",
+              "identifier": "3.19",
               "platform": "linux/arm64/v8",
               "target_name": "distroless_static_linux_arm64_v8",
               "bazel_tags": []
@@ -979,9 +979,9 @@
             "attributes": {
               "target_name": "distroless_static",
               "scheme": "https",
-              "registry": "gcr.io",
-              "repository": "distroless/static-debian12",
-              "identifier": "latest",
+              "registry": "index.docker.io",
+              "repository": "library/alpine",
+              "identifier": "3.19",
               "platforms": {
                 "@@platforms//cpu:x86_64": "@distroless_static_linux_amd64",
                 "@@platforms//cpu:arm64": "@distroless_static_linux_arm64_v8"

--- a/clients/web-admin/BUILD.bazel
+++ b/clients/web-admin/BUILD.bazel
@@ -75,7 +75,13 @@ next_app(
 
 next_oci_image(
     name = "image",
-    exposed_ports = ["3000/tcp"],
+    # Prod swarm stack defines a `curl -f http://localhost:3001/`
+    # healthcheck for web-admin. Next.js defaults to PORT=3000, which
+    # would mismatch the probe → unhealthy → SIGTERM loop. Pin
+    # PORT=3001 in the image so the runtime listener and the
+    # healthcheck address match without a per-deployment env override.
+    env = {"PORT": "3001"},
+    exposed_ports = ["3001/tcp"],
     repositories = {
         "agentsmesh": "registry.agentsmesh.ai/agentsmesh/web-admin",
         "dockerhub": "agentsmesh/web-admin",


### PR DESCRIPTION
## Summary

Three orthogonal regressions surfaced by the post-Bazel-migration release pipeline, each fixed at the source so prod is self-contained and future Bazel-image changes can flow through CI without manual ops.

### 1. Go services healthcheck → switch base to alpine:3.19

`build_defs/docker/go_oci_image.bzl` builds on `distroless/static-debian12`, which carries no `wget`/`curl`. The prod swarm stack's healthcheck is `["CMD","wget","--spider","http://localhost:8080/health"]`, so every Bazel-built backend container started clean, every probe failed, swarm SIGTERM'd → 0/1 replicas.

Switch the upstream image to **`docker.io/library/alpine:3.19`** — exactly the same base the legacy GoReleaser Dockerfile used (`FROM alpine:3.19`). Wget/curl/sh/cacerts come back without a custom tar layer. Repo name `distroless_static` kept for back-compat; only the upstream identity changed.

### 2. web-admin image port 3001

Next.js defaults to `PORT=3000`. The prod stack healthcheck is `curl -f http://localhost:3001/`, so the listener and the probe didn't match → unhealthy loop. Pin `env = {"PORT": "3001"}` and `exposed_ports = ["3001/tcp"]` in the `next_oci_image` call so the image carries the right port out of the box.

### 3. release.yml path-filter

`dorny/paths-filter` had service filters scoped to `backend/**` / `clients/*/**` / `relay/**` only. PR #319 changed `build_defs/docker/go_oci_image.bzl` (i.e. the macro every Go image is built from) but every `Deploy *` job evaluated `needs.changes.outputs.<svc> == 'true'` to false → Build + push happened, swarm kept running the previous (broken) sha.

Add `build_defs/{docker,web}/**` and `MODULE.bazel{,.lock}` to every service filter so any image-layer-relevant change re-triggers the matching deploy.

## Field report

```
✓ backend     1/1 Running  (sha-e0f6d04, manually --no-healthcheck'd)
✓ web         1/1 Running  (sha-e0f6d04)
✓ web-admin   1/1 Running  (sha-e0f6d04, manually --env-add PORT=3001'd)
```

After this PR's release pipeline rolls, the three manual ops above can be reverted (image config supplies PORT; alpine base supplies wget; healthcheck restored).

## Test plan

- [x] `bazel build //backend/cmd/server:image` — alpine base resolves clean
- [x] `bazel build //clients/web-admin:image` — image config reports `Env=[…PORT=3001]`, `ExposedPorts={3001/tcp:{}}`
- [ ] After merge: release pipeline re-deploys all four jobs (backend / web / web-admin / relay) without manual `service update` overrides

## Companion PRs

- #317 — pure-on Go binaries + node:20 base
- #318 — `LOG_FILE` default → ""
- #319 — `/app` & `/data` ownership uid 1000