### PR TITLE
chore(ci): prune old docker images on deploy hosts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,6 +179,7 @@ jobs:
       - run: |
           VERSION="${{ needs.build-images.outputs.version }}"
           ssh aliyun-us-west-001 "cd /opt/agentsmesh && ./deploy.sh uswest-prod --service backend --version ${VERSION}"
+          ssh aliyun-us-west-001 'docker image prune -af --filter "until=168h"' || true
 
   deploy-uswest-web:
     name: Deploy US West Web
@@ -189,6 +190,7 @@ jobs:
       - run: |
           VERSION="${{ needs.build-images.outputs.version }}"
           ssh aliyun-us-west-001 "cd /opt/agentsmesh && ./deploy.sh uswest-prod --service web --version ${VERSION}"
+          ssh aliyun-us-west-001 'docker image prune -af --filter "until=168h"' || true
 
   deploy-uswest-web-admin:
     name: Deploy US West Web-Admin
@@ -199,6 +201,7 @@ jobs:
       - run: |
           VERSION="${{ needs.build-images.outputs.version }}"
           ssh aliyun-us-west-001 "cd /opt/agentsmesh && ./deploy.sh uswest-prod --service web-admin --version ${VERSION}"
+          ssh aliyun-us-west-001 'docker image prune -af --filter "until=168h"' || true
 
   deploy-uswest-relay-01:
     name: Deploy US West Relay 01
@@ -208,6 +211,7 @@ jobs:
     steps:
       - run: |
           ssh aliyun-us-west-relay-001 "cd /opt/agentsmesh/relay && ./deploy.sh uswest-relay-01 --pull"
+          ssh aliyun-us-west-relay-001 'docker image prune -af --filter "until=168h"' || true
 
   deploy-uswest-relay-beijing-02:
     name: Deploy US West Relay Beijing 02
@@ -217,6 +221,7 @@ jobs:
     steps:
       - run: |
           ssh aliyun-agentsmesh-us-relay-beijing-002 "cd /opt/agentsmesh/relay && ./deploy.sh uswest-relay-beijing-02 --pull"
+          ssh aliyun-agentsmesh-us-relay-beijing-002 'docker image prune -af --filter "until=168h"' || true
 
   migrate-uswest:
     name: Migrate US West
@@ -240,6 +245,7 @@ jobs:
       - run: |
           VERSION="${{ needs.build-images.outputs.version }}"
           ssh aliyun-s001 "cd /opt/agentsmesh && ./deploy.sh cn-prod --service backend --version ${VERSION}"
+          ssh aliyun-s001 'docker image prune -af --filter "until=168h"' || true
 
   deploy-cn-web:
     name: Deploy CN Web
@@ -250,6 +256,7 @@ jobs:
       - run: |
           VERSION="${{ needs.build-images.outputs.version }}"
           ssh aliyun-s001 "cd /opt/agentsmesh && ./deploy.sh cn-prod --service web --version ${VERSION}"
+          ssh aliyun-s001 'docker image prune -af --filter "until=168h"' || true
 
   deploy-cn-web-admin:
     name: Deploy CN Web-Admin
@@ -260,6 +267,7 @@ jobs:
       - run: |
           VERSION="${{ needs.build-images.outputs.version }}"
           ssh aliyun-s001 "cd /opt/agentsmesh && ./deploy.sh cn-prod --service web-admin --version ${VERSION}"
+          ssh aliyun-s001 'docker image prune -af --filter "until=168h"' || true
 
   deploy-cn-relay-01:
     name: Deploy CN Relay 01
@@ -269,6 +277,7 @@ jobs:
     steps:
       - run: |
           ssh aliyun-cn-relay-01 "cd /opt/agentsmesh/relay && ./deploy.sh cn-relay-01 --pull"
+          ssh aliyun-cn-relay-01 'docker image prune -af --filter "until=168h"' || true
 
   migrate-cn:
     name: Migrate CN


### PR DESCRIPTION
## Summary

Follow-up to #321 — the release workflow had no image cleanup, which is how `aliyun-us-west-001` and `aliyun-s001` each accumulated 270–460 stale docker images (85–90 GB) until us-west hit \`no space left on device\` mid-deploy. Both hosts have been manually cleaned (release.yml run 25404942677 succeeded after that). This PR prevents recurrence.

## Change

After each successful service or relay deploy, prune images older than 7 days that no container references:

\`\`\`yaml
ssh <host> 'docker image prune -af --filter "until=168h"' || true
\`\`\`

- **`-a`**: includes tagged-but-unused images (the actual problem — old `sha-xxxxxxx` tags). `docker image prune -a` will not delete images that any container — running or stopped — references, so the currently-deployed version is always safe.
- **`--filter "until=168h"`**: keeps the past week's images for emergency rollback.
- **`|| true`**: a prune failure (network blip, daemon restart) shouldn't turn a successful deploy red.

9 deploy jobs touched: us-west `{backend, web, web-admin, relay-01, relay-beijing-02}`, cn `{backend, web, web-admin, relay-01}`.

## Test plan

- [x] \`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"\` passes
- [x] 9 \`docker image prune\` lines present (one per deploy job)
- [ ] CI: workflow parser must accept the new steps
- [ ] After merge, observe the next prod deploy run — each deploy job should show 2 ssh invocations and \`docker system df\` on hosts should stay flat over time