### PR TITLE
fix(web): prevent WASM recursive-borrow on ACP terminal render

### DIFF
--- a/clients/web/e2e-playwright/helpers/console-errors.ts
+++ b/clients/web/e2e-playwright/helpers/console-errors.ts
@@ -1,5 +1,4 @@
-import type { Page } from "@playwright/test";
-import { expect } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 
 export function collectConsoleErrors(page: Page): string[] {
   const errors: string[] = [];
@@ -22,4 +21,23 @@ export function assertNoWasmErrors(errors: string[]) {
       !e.includes("Failed to load resource")
   );
   expect(critical).toHaveLength(0);
+}
+
+/**
+ * wasm-bindgen's RefCell-style borrow check throws this exact string when
+ * `&mut self` and `&self` calls overlap on the same WASM object. The ACP
+ * session manager regression (render-time wasm read racing relay-driven
+ * mutators) surfaced as exactly this message.
+ */
+export function assertNoWasmRecursiveBorrow(errors: string[]) {
+  const offenders = errors.filter((e) =>
+    e.includes("recursive use of an object detected"),
+  );
+  expect(offenders, `wasm borrow conflict regressed:\n${offenders.join("\n")}`).toHaveLength(0);
+}
+
+export function collectPageErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on("pageerror", (err) => errors.push(err.message));
+  return errors;
 }

--- a/clients/web/e2e-playwright/tests/pod/acp-no-wasm-recursive.spec.ts
+++ b/clients/web/e2e-playwright/tests/pod/acp-no-wasm-recursive.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from "../../fixtures/index";
+import { TEST_ORG_SLUG } from "../../helpers/env";
+import { clearAuthRateLimit } from "../../helpers/redis";
+import { terminateAllPods } from "../../helpers/pod-cleanup";
+import {
+  collectConsoleErrors,
+  collectPageErrors,
+  assertNoWasmRecursiveBorrow,
+} from "../../helpers/console-errors";
+
+const PODS_BASE = `/api/v1/orgs/${TEST_ORG_SLUG}/pods`;
+
+/**
+ * Regression: opening a pod terminal triggered
+ *   "recursive use of an object detected which would lead to unsafe aliasing in rust"
+ * because every ACP-aware component synchronously called wasm `get_session_json`
+ * during React render, racing the `&mut self` mutators driven by relay events.
+ *
+ * The fix moved wasm reads inside store mutators (SSOT cache); React render
+ * only touches the cache. This spec asserts the page never surfaces that
+ * exact wasm-bindgen borrow-check error.
+ */
+test.describe("ACP terminal: no wasm recursive borrow", () => {
+  test.beforeEach(async () => { clearAuthRateLimit(); });
+  test.afterEach(async () => { await terminateAllPods(); });
+
+  test("workspace page load does not trigger wasm recursive borrow", async ({ page }) => {
+    const consoleErrors = collectConsoleErrors(page);
+    const pageErrors = collectPageErrors(page);
+
+    await page.goto(`/${TEST_ORG_SLUG}/workspace`);
+    await page.waitForLoadState("networkidle");
+    // Let any deferred ACP/relay subscriptions settle.
+    await page.waitForTimeout(1500);
+
+    assertNoWasmRecursiveBorrow(consoleErrors);
+    assertNoWasmRecursiveBorrow(pageErrors);
+  });
+
+  test("creating a pod and rendering its terminal does not trigger wasm recursive borrow", async ({ page, api }) => {
+    const runnersRes = await api.get(`/api/v1/orgs/${TEST_ORG_SLUG}/runners/available`);
+    const runners = (await runnersRes.json()).runners;
+    if (!runners?.length) { test.skip(); return; }
+
+    const agentsRes = await api.get(`/api/v1/orgs/${TEST_ORG_SLUG}/agents`);
+    const agents = (await agentsRes.json()).builtin_agents;
+    if (!agents?.length) { test.skip(); return; }
+
+    const consoleErrors = collectConsoleErrors(page);
+    const pageErrors = collectPageErrors(page);
+
+    const createRes = await api.post(PODS_BASE, {
+      runner_id: runners[0].id,
+      agent_slug: agents[0].slug,
+      prompt: "E2E ACP recursive-borrow regression",
+    });
+    const data = await createRes.json();
+    const podKey = data.pod_key || data.pod?.pod_key;
+    expect(podKey, "pod creation must return a pod_key").toBeTruthy();
+
+    await page.goto(`/${TEST_ORG_SLUG}/workspace`);
+    await page.waitForLoadState("networkidle");
+
+    // Give the relay time to push an ACP snapshot + at least one event so
+    // the multi-hook AgentPanel render path actually exercises the cache.
+    await page.waitForTimeout(4000);
+
+    assertNoWasmRecursiveBorrow(consoleErrors);
+    assertNoWasmRecursiveBorrow(pageErrors);
+  });
+});

--- a/clients/web/src/stores/__tests__/acpSession-cache.test.tsx
+++ b/clients/web/src/stores/__tests__/acpSession-cache.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { getAcpManager } from "@/lib/wasm-core";
+import {
+  useAcpSessionStore,
+  readAcpSession,
+  useAcpSession,
+  useAcpSessionField,
+  __resetAcpSessionsForTests,
+} from "../acpSession";
+
+const POD_A = "pod-cache-a";
+const POD_B = "pod-cache-b";
+
+describe("acpSession cache invariants (regression: WASM recursive borrow)", () => {
+  beforeEach(() => {
+    __resetAcpSessionsForTests();
+    vi.restoreAllMocks();
+  });
+
+  describe("cache writes are immediately readable", () => {
+    it("populates cache after a mutator runs", () => {
+      const store = useAcpSessionStore.getState();
+      store.addContentChunk(POD_A, "sid", "hello", "assistant");
+
+      const cache = useAcpSessionStore.getState().cache;
+      expect(cache[POD_A]).toBeDefined();
+      expect(cache[POD_A].messages[0].text).toBe("hello");
+    });
+
+    it("readAcpSession serves from cache without touching wasm", () => {
+      const store = useAcpSessionStore.getState();
+      store.addContentChunk(POD_A, "sid", "x", "assistant");
+
+      const mgr = getAcpManager();
+      const spy = vi.spyOn(mgr, "get_session_json");
+
+      const session = readAcpSession(POD_A);
+      expect(session?.messages[0].text).toBe("x");
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it("returns null for a pod that has never been mutated", () => {
+      expect(readAcpSession("never-touched")).toBeNull();
+    });
+  });
+
+  describe("per-podKey isolation", () => {
+    it("mutating one pod does not touch another pod's cache", () => {
+      const store = useAcpSessionStore.getState();
+      store.addContentChunk(POD_A, "sa", "a-msg", "assistant");
+      store.addContentChunk(POD_B, "sb", "b-msg", "assistant");
+
+      expect(readAcpSession(POD_A)?.messages[0].text).toBe("a-msg");
+      expect(readAcpSession(POD_B)?.messages[0].text).toBe("b-msg");
+    });
+
+    it("clearSession only drops the targeted pod", () => {
+      const store = useAcpSessionStore.getState();
+      store.addContentChunk(POD_A, "sa", "a", "assistant");
+      store.addContentChunk(POD_B, "sb", "b", "assistant");
+
+      store.clearSession(POD_A);
+      expect(readAcpSession(POD_A)).toBeNull();
+      expect(readAcpSession(POD_B)?.messages[0].text).toBe("b");
+    });
+  });
+
+  describe("render-time isolation — the actual fix for `recursive use of an object`", () => {
+    it("useAcpSession hook does not call wasm during render", () => {
+      const store = useAcpSessionStore.getState();
+      store.addContentChunk(POD_A, "sid", "rendered", "assistant");
+
+      const mgr = getAcpManager();
+      const spy = vi.spyOn(mgr, "get_session_json");
+
+      function Probe() {
+        const s = useAcpSession(POD_A);
+        return <div>{s?.messages[0]?.text ?? ""}</div>;
+      }
+      render(<Probe />);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it("useAcpSessionField hook does not call wasm during render", () => {
+      const store = useAcpSessionStore.getState();
+      store.addContentChunk(POD_A, "sid", "x", "assistant");
+
+      const mgr = getAcpManager();
+      const spy = vi.spyOn(mgr, "get_session_json");
+
+      function Probe() {
+        const state = useAcpSessionField(POD_A, (s) => s.state);
+        return <div>{state}</div>;
+      }
+      render(<Probe />);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it("six concurrent hooks (the production AgentPanel pattern) → zero wasm reads at render", () => {
+      const store = useAcpSessionStore.getState();
+      store.addContentChunk(POD_A, "sid", "x", "assistant");
+
+      const mgr = getAcpManager();
+      const spy = vi.spyOn(mgr, "get_session_json");
+
+      function Probe() {
+        const s = useAcpSession(POD_A);
+        const msgs = useAcpSessionField(POD_A, (s) => s.messages);
+        const plan = useAcpSessionField(POD_A, (s) => s.plan);
+        const tools = useAcpSessionField(POD_A, (s) => s.toolCalls);
+        const state = useAcpSessionField(POD_A, (s) => s.state);
+        const perms = useAcpSessionField(POD_A, (s) => s.pendingPermissions);
+        return (
+          <div>
+            {s?.state}-{msgs.length}-{plan.length}-{Object.keys(tools).length}-{state}-{perms.length}
+          </div>
+        );
+      }
+      render(<Probe />);
+      // Pre-fix: this rendered 6 synchronous wasm `get_session_json` calls
+      // per render pass, which is exactly what made the wasm-bindgen borrow
+      // checker race with the `&mut self` writes triggered by relay events.
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("wasm error containment", () => {
+    it("swallows a get_session_json failure during refresh; cache stays absent and writers don't throw", () => {
+      const mgr = getAcpManager();
+      vi.spyOn(mgr, "get_session_json").mockImplementationOnce(() => {
+        throw new Error("recursive use of an object detected which would lead to unsafe aliasing in rust");
+      });
+      const consoleErr = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const store = useAcpSessionStore.getState();
+      expect(() =>
+        store.addContentChunk(POD_A, "sid", "x", "assistant"),
+      ).not.toThrow();
+      expect(readAcpSession(POD_A)).toBeNull();
+      expect(consoleErr).toHaveBeenCalled();
+    });
+  });
+});

--- a/clients/web/src/stores/acpSession.ts
+++ b/clients/web/src/stores/acpSession.ts
@@ -10,6 +10,7 @@ export type { AcpToolCall, AcpPlanStep, AcpPermissionRequest, AcpSessionState, A
 
 interface AcpSessionStore {
   _tick: number;
+  cache: Record<string, AcpSessionState>;
   addContentChunk: (podKey: string, sessionId: string, text: string, role: string) => void;
   markLastMessageComplete: (podKey: string) => void;
   updateToolCall: (podKey: string, sessionId: string, toolCall: AcpToolCall) => void;
@@ -24,24 +25,57 @@ interface AcpSessionStore {
 }
 
 const mgr = () => getAcpManager();
-const bump = () => useAcpSessionStore.setState((s) => ({ _tick: s._tick + 1 }));
+
+// WASM reads happen only inside mutators (same sync call stack as the
+// preceding &mut self write). Reads from React render only see this cache, so
+// wasm-bindgen's per-instance borrow flag never sees concurrent borrowers.
+function readSessionFromWasm(podKey: string): AcpSessionState | null {
+  try {
+    const raw = mgr().get_session_json(podKey);
+    if (!raw) return null;
+    return sessionFromWasm(typeof raw === "string" ? JSON.parse(raw) : raw);
+  } catch (err) {
+    console.error("[acpSession] wasm read failed", { podKey, err });
+    return null;
+  }
+}
+
+function refreshCache(podKey: string): void {
+  const session = readSessionFromWasm(podKey);
+  useAcpSessionStore.setState((s) => {
+    const next = { ...s.cache };
+    if (session) next[podKey] = session;
+    else delete next[podKey];
+    return { _tick: s._tick + 1, cache: next };
+  });
+}
+
+function dropFromCache(podKey: string): void {
+  useAcpSessionStore.setState((s) => {
+    if (!(podKey in s.cache)) return { _tick: s._tick + 1 };
+    const next = { ...s.cache };
+    delete next[podKey];
+    return { _tick: s._tick + 1, cache: next };
+  });
+}
 
 export const useAcpSessionStore = create<AcpSessionStore>(() => ({
   _tick: 0,
+  cache: {},
 
   addContentChunk: (podKey, _sid, text, role) => {
     mgr().add_content_chunk(podKey, text, role);
-    bump();
+    refreshCache(podKey);
   },
 
   markLastMessageComplete: (podKey) => {
     mgr().mark_last_message_complete(podKey);
-    bump();
+    refreshCache(podKey);
   },
 
   updateToolCall: (podKey, _sid, tc) => {
     mgr().update_tool_call(podKey, toolCallToWasm(tc));
-    bump();
+    refreshCache(podKey);
   },
 
   setToolCallResult: (podKey, _sid, id, success, resultText, errorMessage) => {
@@ -50,56 +84,54 @@ export const useAcpSessionStore = create<AcpSessionStore>(() => ({
       resultText || undefined,
       errorMessage || undefined,
     );
-    bump();
+    refreshCache(podKey);
   },
 
   updatePlan: (podKey, _sid, steps) => {
     mgr().update_plan(podKey, JSON.stringify(steps));
-    bump();
+    refreshCache(podKey);
   },
 
   addThinking: (podKey, _sid, text) => {
     mgr().add_thinking(podKey, text);
-    bump();
+    refreshCache(podKey);
   },
 
   addPermissionRequest: (podKey, req) => {
     mgr().add_permission_request(podKey, permReqToWasm(req));
-    bump();
+    refreshCache(podKey);
   },
 
   removePermissionRequest: (podKey, requestId) => {
     mgr().remove_permission_request(podKey, requestId);
-    bump();
+    refreshCache(podKey);
   },
 
   updateSessionState: (podKey, _sid, state) => {
     mgr().update_session_state(podKey, state);
-    bump();
+    refreshCache(podKey);
   },
 
   addLog: (podKey, level, message) => {
     mgr().add_log(podKey, level, message);
-    bump();
+    refreshCache(podKey);
   },
 
   clearSession: (podKey) => {
     mgr().clear_session(podKey);
-    bump();
+    dropFromCache(podKey);
   },
 }));
 
 export function readAcpSession(podKey: string): AcpSessionState | null {
-  const raw = mgr().get_session_json(podKey);
-  if (!raw) return null;
-  return sessionFromWasm(typeof raw === "string" ? JSON.parse(raw) : raw);
+  return useAcpSessionStore.getState().cache[podKey] ?? null;
 }
 
 export function useAcpSession(podKey: string | null | undefined): AcpSessionState | null {
   const tick = useAcpSessionStore((s) => s._tick);
   return useMemo(() => {
     if (!podKey) return null;
-    return readAcpSession(podKey);
+    return useAcpSessionStore.getState().cache[podKey] ?? null;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tick, podKey]);
 }
@@ -111,29 +143,26 @@ export function useAcpSessionField<T>(
   const tick = useAcpSessionStore((s) => s._tick);
   return useMemo(() => {
     if (!podKey) return pick(EMPTY_SESSION);
-    const s = readAcpSession(podKey);
-    return pick(s ?? EMPTY_SESSION);
+    const session = useAcpSessionStore.getState().cache[podKey];
+    return pick(session ?? EMPTY_SESSION);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tick, podKey]);
 }
 
-/** Test-only helper: seed the WASM-backed session directly, bumping tick so
- *  subscribed components re-render. Use inside beforeEach/each test setup. */
 export function __seedAcpSessionForTests(podKey: string, session: AcpSessionState): void {
   const mock = mgr() as unknown as { _seed: (k: string, s: unknown) => void };
   if (typeof mock._seed !== "function") {
     throw new Error("AcpManager mock does not support _seed — test-only API");
   }
   mock._seed(podKey, wasmFromSession(session));
-  useAcpSessionStore.setState((s) => ({ _tick: s._tick + 1 }));
+  refreshCache(podKey);
 }
 
-/** Test-only helper: reset the WASM-backed session store and tick. */
 export function __resetAcpSessionsForTests(): void {
   const mock = mgr() as unknown as { _reset: () => void };
   if (typeof mock._reset !== "function") {
     throw new Error("AcpManager mock does not support _reset — test-only API");
   }
   mock._reset();
-  useAcpSessionStore.setState({ _tick: 0 });
+  useAcpSessionStore.setState({ _tick: 0, cache: {} });
 }


### PR DESCRIPTION
## Summary

Opening a Pod terminal threw `Uncaught Error: recursive use of an object detected which would lead to unsafe aliasing in rust` from `WasmAcpSessionManager.get_session_json`.

### Root cause

`WasmAcpSessionManager` is a global singleton. WebSocket-driven `&mut self` mutators (`add_content_chunk`, etc.) and React render-phase `&self` reads — six concurrent hooks per pod (`useAcpSession` × 2, `useAcpSessionField` × 4) — shared one wasm-bindgen RefCell-style borrow flag. Any `&mut self` panic permanently poisoned the flag because WASM doesn't unwind, and even without panics the two paths can race.

### Fix

Zustand cache as the SSOT for reads:
- Mutator now does wasm `&mut self` → wasm `&self` → cache update inside one JS call stack.
- React hooks read **only** the cache; render never touches WASM.
- `try/catch` containment so any wasm error stays inside the mutator.

### Tests

- **Unit** (`acpSession-cache.test.tsx`, 9 cases): asserts render-phase `get_session_json` invocations = 0 even with the 6-hook AgentPanel pattern; asserts a thrown wasm error is contained in the mutator and does not poison the React tree.
- **E2E** (`acp-no-wasm-recursive.spec.ts`): asserts `console.error` and `pageerror` never contain `recursive use of an object detected` when opening the workspace, with and without an active pod.
- New helper: `assertNoWasmRecursiveBorrow` / `collectPageErrors` in `helpers/console-errors.ts`.

## Test plan

- [x] `bazel test //clients/web:unit` — 1634 / 1634
- [x] `bazel test //clients/web:lint`
- [x] `bazel build //clients/web:src` (tsc --noEmit)
- [ ] CI green