### PR TITLE
ci(macos-notarize): wire mac.notarize teamId for electron-builder 25.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -433,6 +433,23 @@ jobs:
           fi
           echo "OK: app bundle is signed with a real identity."
 
+          # Notarization staple check. Without this the dmg signs but
+          # spctl rejects with "Unnotarized Developer ID" (v0.30.4
+          # exact bug). The check is gated on APPLE_API_KEY being
+          # present — local builds can still ship signed-but-not-
+          # notarized for testing. CI always has the secret, so a
+          # notarize regression turns into a hard CI failure.
+          if [[ -n "${APPLE_API_KEY:-}" ]]; then
+            echo "Verifying notarization staple..."
+            if ! xcrun stapler validate "$APP" 2>&1 | tee /dev/stderr | grep -q "validated"; then
+              echo "::error::AgentsMesh.app has no stapled notarization ticket. electron-builder either skipped notarization or it was rejected by Apple." >&2
+              exit 1
+            fi
+            echo "OK: notarization ticket is stapled."
+          else
+            echo "APPLE_API_KEY unset — skipping notarization check."
+          fi
+
       - name: Build :dist (Windows)
         if: matrix.os.runner == 'windows-latest'
         shell: bash

--- a/clients/desktop/electron-builder.yml
+++ b/clients/desktop/electron-builder.yml
@@ -63,10 +63,26 @@ mac:
         - x64
   hardenedRuntime: true
   gatekeeperAssess: false
+  # `notarize: { teamId: ... }` is required as of electron-builder 25.x
+  # — the older "auto-notarize when APPLE_API_* env is set" behaviour
+  # was removed. Without this block the dmg ships signed but
+  # *un-notarized*, so `spctl --assess` rejects with "Unnotarized
+  # Developer ID" and Gatekeeper shows the "unidentified developer"
+  # prompt on first launch (we hit this in v0.30.4: signing wired
+  # correctly, dmg simply never went through Apple's Notary API).
+  #
+  # `@electron/notarize` reads the API credentials from env:
+  #   APPLE_API_KEY               → file path to the .p8 private key
+  #   APPLE_API_KEY_ID            → key id (10-char alphanumeric)
+  #   APPLE_API_KEY_ISSUER_ID     → issuer uuid
+  # release.yml's "Set up macOS signing keychain" step decodes the .p8
+  # to disk and exposes all three.
+  notarize:
+    teamId: DCK4SSVH2H
   # codesign + notarization are driven by env vars in CI:
   #   CSC_LINK / CSC_KEY_PASSWORD              → Developer ID Application cert
   #   APPLE_API_KEY / APPLE_API_KEY_ID /
-  #   APPLE_API_ISSUER                         → notarytool API key path
+  #   APPLE_API_KEY_ISSUER_ID                  → notarytool API key path
   # Leave `identity` unset so electron-builder auto-discovers from CSC_LINK
   # (an explicit `null` here disables signing entirely — the cert env vars
   # are silently ignored, and the resulting .dmg/.zip won't pass Gatekeeper).


### PR DESCRIPTION
## Summary

- 在 `clients/desktop/electron-builder.yml` 的 `mac:` 段加 `notarize: { teamId: DCK4SSVH2H }`，让 electron-builder 25 真正调用 Apple Notary API
- 在 `release.yml` 的 macOS dmg 验签步骤里加 `xcrun stapler validate`，把"签了但没 notarize"的回归从静默通过变成 CI 硬失败

## 背景

v0.30.4 dmg 签名是对的（`Authority=Developer ID Application: Beijing SginalRender Technology Co., Ltd (DCK4SSVH2H)`、`TeamIdentifier=DCK4SSVH2H`、hardened runtime、signed timestamp），但 Gatekeeper 拒绝：
\`\`\`
spctl -a -t open --context context:primary-signature -v AgentsMesh-0.30.4-arm64.dmg
→ rejected source=Unnotarized Developer ID
\`\`\`
\`xcrun stapler validate AgentsMesh.app\` 报 "no stapled notarization ticket"。

根因：electron-builder 25.x 移除了"`APPLE_API_*` 环境变量齐全就自动 notarize"的隐式行为。25.x 强制要求显式 `mac.notarize` 配置，否则跳过 Notary 上传。我们的 keychain 步骤已经导出 `APPLE_API_KEY` / `APPLE_API_KEY_ID` / `APPLE_API_KEY_ISSUER_ID`，但 yml 里没有 `mac.notarize` 段，所以 `@electron/notarize` 根本没被触发。

## Test Plan

- [ ] PR CI Bazel workflow 全绿（covers napi.bzl + electron-builder yaml 解析）
- [ ] Merge 后打 v0.30.5 tag
- [ ] release run 的 desktop-package macOS step 应看到 \`@electron/notarize\` log（"Submitted notarization request..."）
- [ ] release run 的 "Verify macOS dmg signing" 应打印 \"OK: notarization ticket is stapled.\"
- [ ] 本地下载 v0.30.5 dmg，跑：
  - \`xcrun stapler validate AgentsMesh.app\` → \"validated\"
  - \`spctl -a -t open --context context:primary-signature -v *.dmg\` → \"accepted\"
  - 双击 dmg 打开应用，无 Gatekeeper "unidentified developer" 弹窗