### PR TITLE
ci(macos-notarize): drive notarize via xcrun notarytool outside bazel sandbox

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -433,6 +433,23 @@ jobs:
           fi
           echo "OK: app bundle is signed with a real identity."
 
+          # Notarization staple check. Without this the dmg signs but
+          # spctl rejects with "Unnotarized Developer ID" (v0.30.4
+          # exact bug). The check is gated on APPLE_API_KEY being
+          # present — local builds can still ship signed-but-not-
+          # notarized for testing. CI always has the secret, so a
+          # notarize regression turns into a hard CI failure.
+          if [[ -n "${APPLE_API_KEY:-}" ]]; then
+            echo "Verifying notarization staple..."
+            if ! xcrun stapler validate "$APP" 2>&1 | tee /dev/stderr | grep -q "validated"; then
+              echo "::error::AgentsMesh.app has no stapled notarization ticket. electron-builder either skipped notarization or it was rejected by Apple." >&2
+              exit 1
+            fi
+            echo "OK: notarization ticket is stapled."
+          else
+            echo "APPLE_API_KEY unset — skipping notarization check."
+          fi
+
       - name: Build :dist (Windows)
         if: matrix.os.runner == 'windows-latest'
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,12 +231,14 @@ jobs:
         os:
           - label: macOS
             runner: macos-14
-            # `latest-mac.yml` ships next to the dmg/zip so electron-
-            # updater can poll the release for new versions.
+            # Only the .dmg is shipped today. `.zip` + `latest-mac.yml`
+            # drive electron-updater autoupdate, but the `.app` inside
+            # the zip is NOT yet stapled (notarization re-pack pipeline
+            # is dmg-only). Re-enable once the zip-restaple flow lands
+            # — until then autoupdate stays disabled to avoid shipping
+            # un-notarized .app over the update channel.
             installers: |
               AgentsMesh-*.dmg
-              AgentsMesh-*.zip
-              latest-mac.yml
           - label: Windows
             runner: windows-latest
             installers: |
@@ -289,15 +291,17 @@ jobs:
       # the 100MB electron download.
       #
       # Signing matrix:
-      #   macOS  — CSC_LINK from MACOS_CERTIFICATE; notarization via
-      #            APPLE_API_KEY (path to .p8 decoded below) +
-      #            APPLE_API_KEY_ID + APPLE_API_ISSUER. We use the
-      #            App Store Connect API key path because the .p8 secret
-      #            already exists for the Runner CLI rcodesign flow.
+      #   macOS  — codesign identity from a temp keychain (.p12 import,
+      #            see "Set up macOS signing keychain" step). Notarization
+      #            runs in a separate `xcrun notarytool` step *outside*
+      #            the bazel sandbox; electron-builder's internal notarize
+      #            never reached @electron/notarize when launched through
+      #            the bazel macro pipeline.
       #   Windows — CSC_LINK from WIN_CSC_LINK (Authenticode .pfx) +
       #             WIN_CSC_KEY_PASSWORD. electron-builder reuses the
       #             same env names cross-platform.
-      #   Linux  — unsigned (AppImage GPG + .deb signing not wired).
+      #   Linux  — desktop matrix entry dropped; runner CLI ships the
+      #            Linux story.
       #
       # Bazel's exec sandbox strips arbitrary host env from actions; the
       # `--action_env` flags below allowlist the signing vars so they
@@ -408,47 +412,104 @@ jobs:
           # name silently disabled notarization in v0.30.0–v0.30.2.
           APPLE_API_KEY_ISSUER_ID: ${{ secrets.APPLE_API_KEY_ISSUER_ID }}
 
+      # electron-builder 25.x's `mac.notarize` config never reached
+      # @electron/notarize when invoked through the Bazel macro pipeline:
+      # v0.30.5 dmg shipped signed-but-not-notarized despite explicit
+      # `mac.notarize: { teamId: ... }` in electron-builder.yml. Likely
+      # the .p8 file path leaks across the bazel exec sandbox boundary
+      # (the file lives in $RUNNER_TEMP, outside the sandbox closure).
+      #
+      # Rather than chase electron-builder + bazel-sandbox interactions,
+      # we drive notarization ourselves via `xcrun notarytool` from the
+      # host shell — outside the sandbox, with the .p8 fully readable.
+      # Apple's `notarytool` binary handles the App Store Connect API
+      # upload + polling; `xcrun stapler staple` then attaches the
+      # ticket to the dmg for offline Gatekeeper verification.
+      #
+      # The dmg is staged into $RUNNER_TEMP/installers because bazel-bin
+      # outputs are read-only — `stapler staple` modifies the dmg in
+      # place. `cp -aR` preserves macOS extended attributes (xattrs)
+      # which carry the codesign signature; using a plain `cp` would
+      # invalidate the signature and notarization would reject.
+      - name: Notarize macOS dmg via notarytool
+        if: matrix.os.runner == 'macos-14'
+        shell: bash
+        env:
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_KEY_ISSUER_ID: ${{ secrets.APPLE_API_KEY_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${APPLE_API_KEY:-}" ]]; then
+            echo "::error::APPLE_API_KEY unset — refuse to ship un-notarized dmg." >&2
+            exit 1
+          fi
+
+          DIST="bazel-bin/clients/desktop/dist"
+          STAGE="$RUNNER_TEMP/installers"
+          mkdir -p "$STAGE"
+
+          cp -aR "$DIST"/. "$STAGE"/
+          chmod -R u+w "$STAGE"
+
+          shopt -s nullglob
+          dmgs=("$STAGE"/*.dmg)
+          if (( ${#dmgs[@]} == 0 )); then
+            echo "::error::no .dmg found under $STAGE after staging." >&2
+            exit 1
+          fi
+          for dmg in "${dmgs[@]}"; do
+            echo "Submitting $dmg to Apple Notary..."
+            xcrun notarytool submit "$dmg" \
+              --key "$APPLE_API_KEY" \
+              --key-id "$APPLE_API_KEY_ID" \
+              --issuer "$APPLE_API_KEY_ISSUER_ID" \
+              --wait \
+              --timeout 30m
+            echo "Stapling ticket to $dmg..."
+            xcrun stapler staple "$dmg"
+          done
+
       # Fail-fast assertion: every prior release silently shipped
       # ad-hoc-signed dmgs because electron-builder's logs are
       # captured by bazel and we couldn't see signing fall back to
-      # ad-hoc. Verify the produced .app on the runner before the
-      # upload step so a sign regression turns into a CI failure
+      # ad-hoc. Verify the staged + stapled dmg before the upload
+      # step so a sign/notarize regression turns into a CI failure
       # instead of a Gatekeeper-rejected user install.
-      - name: Verify macOS dmg signing
+      - name: Verify macOS dmg signing + notarization
         if: matrix.os.runner == 'macos-14'
         shell: bash
         run: |
           set -euo pipefail
-          DIST="bazel-bin/clients/desktop/dist"
-          APP="$(find "$DIST" -maxdepth 4 -name 'AgentsMesh.app' | head -1 || true)"
-          if [[ -z "$APP" ]]; then
-            echo "ERROR: AgentsMesh.app not found under $DIST." >&2
+          STAGE="$RUNNER_TEMP/installers"
+          shopt -s nullglob
+          dmgs=("$STAGE"/*.dmg)
+          if (( ${#dmgs[@]} == 0 )); then
+            echo "::error::no .dmg found under $STAGE." >&2
             exit 1
           fi
-          echo "Inspecting $APP"
-          codesign -dv --verbose=2 "$APP" 2>&1 | head -15
-          if codesign -dv "$APP" 2>&1 | grep -q "Signature=adhoc"; then
-            echo "::error::AgentsMesh.app is ad-hoc-signed; the codesign identity didn't reach electron-builder." >&2
-            exit 1
-          fi
-          echo "OK: app bundle is signed with a real identity."
-
-          # Notarization staple check. Without this the dmg signs but
-          # spctl rejects with "Unnotarized Developer ID" (v0.30.4
-          # exact bug). The check is gated on APPLE_API_KEY being
-          # present — local builds can still ship signed-but-not-
-          # notarized for testing. CI always has the secret, so a
-          # notarize regression turns into a hard CI failure.
-          if [[ -n "${APPLE_API_KEY:-}" ]]; then
-            echo "Verifying notarization staple..."
-            if ! xcrun stapler validate "$APP" 2>&1 | tee /dev/stderr | grep -q "validated"; then
-              echo "::error::AgentsMesh.app has no stapled notarization ticket. electron-builder either skipped notarization or it was rejected by Apple." >&2
+          for dmg in "${dmgs[@]}"; do
+            echo "Inspecting $dmg"
+            # codesign on the dmg itself proves Developer ID identity
+            # is wired (electron-builder signs the dmg as a separate
+            # bundle from the .app inside).
+            if codesign -dv "$dmg" 2>&1 | grep -q "Signature=adhoc"; then
+              echo "::error::$dmg is ad-hoc-signed; the codesign identity didn't reach electron-builder." >&2
               exit 1
             fi
-            echo "OK: notarization ticket is stapled."
-          else
-            echo "APPLE_API_KEY unset — skipping notarization check."
-          fi
+            # Staple ticket present? — proves notarytool ran and
+            # Apple accepted.
+            if ! xcrun stapler validate "$dmg" 2>&1 | tee /dev/stderr | grep -q "validated"; then
+              echo "::error::$dmg has no stapled notarization ticket." >&2
+              exit 1
+            fi
+            # spctl is the gold standard: simulates the Gatekeeper
+            # check the user's Mac runs at first launch.
+            if ! spctl -a -t open --context context:primary-signature -v "$dmg" 2>&1 | tee /dev/stderr | grep -q "accepted"; then
+              echo "::error::spctl --assess rejected $dmg." >&2
+              exit 1
+            fi
+            echo "OK: $dmg is signed + notarized + stapled."
+          done
 
       - name: Build :dist (Windows)
         if: matrix.os.runner == 'windows-latest'
@@ -471,6 +532,12 @@ jobs:
       # Release the `release` job created. Single matrix shard's worth
       # per call; `--clobber` lets reruns overwrite without erroring.
       #
+      # macOS reads from `$RUNNER_TEMP/installers` because the Notarize
+      # step staged + stapled the dmg there (bazel-bin is read-only,
+      # so `stapler staple` couldn't modify the dmg in-place). Windows
+      # reads straight from bazel-bin since there's no post-build step
+      # mutating the .exe.
+      #
       # `GH_REPO` short-circuits gh CLI's git-remote inference. Without
       # it, gh runs `git config --get remote.origin.url` from the
       # `working-directory` (a bazel-out subdir, not a git checkout) and
@@ -481,7 +548,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-        working-directory: bazel-bin/clients/desktop/dist
+        working-directory: ${{ matrix.os.runner == 'macos-14' && format('{0}/installers', runner.temp) || 'bazel-bin/clients/desktop/dist' }}
         run: |
           set -euo pipefail
           ls -la

--- a/clients/desktop/electron-builder.yml
+++ b/clients/desktop/electron-builder.yml
@@ -63,10 +63,26 @@ mac:
         - x64
   hardenedRuntime: true
   gatekeeperAssess: false
+  # `notarize: { teamId: ... }` is required as of electron-builder 25.x
+  # — the older "auto-notarize when APPLE_API_* env is set" behaviour
+  # was removed. Without this block the dmg ships signed but
+  # *un-notarized*, so `spctl --assess` rejects with "Unnotarized
+  # Developer ID" and Gatekeeper shows the "unidentified developer"
+  # prompt on first launch (we hit this in v0.30.4: signing wired
+  # correctly, dmg simply never went through Apple's Notary API).
+  #
+  # `@electron/notarize` reads the API credentials from env:
+  #   APPLE_API_KEY               → file path to the .p8 private key
+  #   APPLE_API_KEY_ID            → key id (10-char alphanumeric)
+  #   APPLE_API_KEY_ISSUER_ID     → issuer uuid
+  # release.yml's "Set up macOS signing keychain" step decodes the .p8
+  # to disk and exposes all three.
+  notarize:
+    teamId: DCK4SSVH2H
   # codesign + notarization are driven by env vars in CI:
   #   CSC_LINK / CSC_KEY_PASSWORD              → Developer ID Application cert
   #   APPLE_API_KEY / APPLE_API_KEY_ID /
-  #   APPLE_API_ISSUER                         → notarytool API key path
+  #   APPLE_API_KEY_ISSUER_ID                  → notarytool API key path
   # Leave `identity` unset so electron-builder auto-discovers from CSC_LINK
   # (an explicit `null` here disables signing entirely — the cert env vars
   # are silently ignored, and the resulting .dmg/.zip won't pass Gatekeeper).


### PR DESCRIPTION
## Summary

- 把 macOS dmg notarization 从 electron-builder 内置流程切换为 `xcrun notarytool` + `xcrun stapler` 在 bazel sandbox 外的独立 CI step
- 暂时去掉 `.zip` + `latest-mac.yml` 不发，避免 autoupdate 走未 staple 的 .app
- Verify step 改为检查 staged dmg（codesign + stapler validate + spctl --assess 三重校验）
- Upload step 用条件 `working-directory`：macOS 从 \`\$RUNNER_TEMP/installers\` 读取，Windows 仍走 bazel-bin

## 背景

v0.30.5 mac dmg 签名是对的（`Authority=Developer ID Application: Beijing SginalRender Technology Co., Ltd (DCK4SSVH2H)`），但即使 electron-builder.yml 加了 \`mac.notarize: { teamId: ... }\`，stapler validate 仍报 "no ticket"。CI run \`25435513968\` Desktop macOS 失败在新加的 stapler 校验步骤（PR #330 加的），fail-fast 起作用了。

## 根因假设

@electron/notarize 在 electron-builder 内部跑，而 electron-builder 又跑在 bazel exec sandbox 里。\`.p8\` 文件位于 \`\$RUNNER_TEMP/apple/AuthKey.p8\`——sandbox closure 之外。可能：
1. electron-builder 25 的 \`mac.notarize\` handler 经 bazel macro 路径根本不触发
2. 触发了但 @electron/notarize 跨 sandbox boundary 打开 .p8 失败

bazel 把 action stdout 吃了，看不到 @electron/notarize 的 log，无法定论。

## 解决方案

不再依赖 electron-builder 的 internal notarize（无可见的 black-box），直接用 \`xcrun notarytool\`：
1. \`Build :dist (macOS)\` 完成后，cp dmg/zip 到 \`\$RUNNER_TEMP/installers\`（bazel-bin 是只读的，stapler staple 会写不进）
2. \`xcrun notarytool submit "\$dmg" --wait\` 上传 + 等待 Apple 处理
3. \`xcrun stapler staple "\$dmg"\` 把 ticket 写到 dmg
4. Verify step 跑 codesign / stapler validate / spctl --assess 三重校验
5. Upload 从 staged dir 上传

## 暂时弃用 zip + autoupdate

zip 里的 .app 未 staple → autoupdate 流程会装一个 Gatekeeper 拒绝的 app。要修正需要 unzip → staple .app → ditto re-zip → regen latest-mac.yml 的 sha512+size。本 PR 先把 zip + latest-mac.yml 从 installers 列表里删掉（不发布），避免破坏体验。Autoupdate 完整链路在下个 PR 补上。

## Test Plan

- [ ] PR CI 全绿（buildifier + lint + tests + iOS + smoke + e2e）
- [ ] Merge 后打 v0.30.6 tag
- [ ] release run desktop-package macOS step 应看到：
  - \`Submitting AgentsMesh-0.30.6-arm64.dmg to Apple Notary...\`
  - notarytool 输出 \`status: Accepted\`
  - \`Stapling ticket to ...\`
  - Verify 步骤打印 \`OK: ... is signed + notarized + stapled.\`
- [ ] release page 上有 mac dmg（\`AgentsMesh-0.30.6-arm64.dmg\`、\`AgentsMesh-0.30.6-x64.dmg\`），无 zip / latest-mac.yml
- [ ] 本地下载 v0.30.6 dmg：
  - \`xcrun stapler validate\` → \"validated\"
  - \`spctl -a -t open --context context:primary-signature -v\` → \"accepted\"
  - 双击 dmg 装，无 Gatekeeper unidentified-developer 弹窗