### PR TITLE
ci(macos-notarize): fix stapler validate grep + drop dead $APP block

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -497,36 +497,25 @@ jobs:
               exit 1
             fi
             # Staple ticket present? — proves notarytool ran and
-            # Apple accepted.
-            if ! xcrun stapler validate "$dmg" 2>&1 | tee /dev/stderr | grep -q "validated"; then
+            # Apple accepted. `xcrun stapler validate` exits 0 when
+            # the ticket is attached (and prints "The validate action
+            # worked!" — note: NOT "validated", that string never
+            # appears in the success path; v0.30.6 hit this exact
+            # grep mismatch). Use the exit code, not stdout text.
+            if ! xcrun stapler validate "$dmg"; then
               echo "::error::$dmg has no stapled notarization ticket." >&2
               exit 1
             fi
             # spctl is the gold standard: simulates the Gatekeeper
-            # check the user's Mac runs at first launch.
-            if ! spctl -a -t open --context context:primary-signature -v "$dmg" 2>&1 | tee /dev/stderr | grep -q "accepted"; then
+            # check the user's Mac runs at first launch. Exit 0 ⇒
+            # "accepted source=Notarized Developer ID"; non-zero ⇒
+            # rejected.
+            if ! spctl -a -t open --context context:primary-signature -v "$dmg"; then
               echo "::error::spctl --assess rejected $dmg." >&2
               exit 1
             fi
             echo "OK: $dmg is signed + notarized + stapled."
           done
-
-          # Notarization staple check. Without this the dmg signs but
-          # spctl rejects with "Unnotarized Developer ID" (v0.30.4
-          # exact bug). The check is gated on APPLE_API_KEY being
-          # present — local builds can still ship signed-but-not-
-          # notarized for testing. CI always has the secret, so a
-          # notarize regression turns into a hard CI failure.
-          if [[ -n "${APPLE_API_KEY:-}" ]]; then
-            echo "Verifying notarization staple..."
-            if ! xcrun stapler validate "$APP" 2>&1 | tee /dev/stderr | grep -q "validated"; then
-              echo "::error::AgentsMesh.app has no stapled notarization ticket. electron-builder either skipped notarization or it was rejected by Apple." >&2
-              exit 1
-            fi
-            echo "OK: notarization ticket is stapled."
-          else
-            echo "APPLE_API_KEY unset — skipping notarization check."
-          fi
 
       - name: Build :dist (Windows)
         if: matrix.os.runner == 'windows-latest'


### PR DESCRIPTION
## Summary

修两个 v0.30.6 release run 暴露的 bug：

1. **`grep -q "validated"` 永远不匹配**——`xcrun stapler validate` 成功时输出 \"The validate action worked!\"，不是 \"validated\"。`spctl` 的 grep 也同样不可靠。改为 drop grep，直接用 stapler / spctl 的 exit code（\`set -o pipefail\` 已开）。

2. **PR #330 stapler-on-\$APP 残块**——PR #331 重写 Verify 时 \`old_string\` 没把 \$APP 那一段包到，结果残留在 line 514+。这块 references 一个未定义的 \$APP 变量，运行时会 unbound error，但因为前面的 grep 错误已经 exit 1，没机会跑到这里。

## 背景

v0.30.6 release run 25439092099 Desktop macOS：
- ✅ Notarize 步骤成功（\`xcrun notarytool submit ... --wait\` 返回 Accepted，stapler staple 成功）
- ❌ Verify 步骤失败：\`stapler validate\` 实际输出 \"The validate action worked!\" 表示 ticket 已 staple，但我的 grep \"validated\" 不匹配，于是误判为没 staple

直接看 log:
\`\`\`
Inspecting /Users/runner/work/_temp/installers/AgentsMesh-0.30.6-arm64.dmg
Processing: /Users/runner/work/_temp/installers/AgentsMesh-0.30.6-arm64.dmg
The validate action worked!
##[error]/Users/runner/work/_temp/installers/AgentsMesh-0.30.6-arm64.dmg has no stapled notarization ticket.
\`\`\`

## Test Plan

- [ ] PR CI 全绿
- [ ] Merge 后打 v0.30.7 tag
- [ ] release run 的 Verify 步骤打印 \"OK: ... is signed + notarized + stapled.\"
- [ ] release page 上有 \`AgentsMesh-0.30.7-*.dmg\`
- [ ] 本地下载验证：\`xcrun stapler validate <dmg>\` → 0 exit, \`spctl -a -t open --context context:primary-signature -v <dmg>\` → \"accepted\"