### PR TITLE
ci(macos-notarize): codesign dmg before notarytool + verify by exit code

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -426,6 +426,15 @@ jobs:
       # upload + polling; `xcrun stapler staple` then attaches the
       # ticket to the dmg for offline Gatekeeper verification.
       #
+      # We also codesign the dmg container itself before notarization.
+      # electron-builder 25 should sign dmgs by default, but in our
+      # bazel-sandbox-driven build it often emits unsigned .dmg
+      # containers (the .app inside is signed correctly). spctl rejects
+      # unsigned dmgs with "no usable signature" even when the staple
+      # is attached (v0.30.7 hit this). Signing the dmg here covers
+      # the gap regardless of what electron-builder did inside the
+      # sandbox.
+      #
       # The dmg is staged into $RUNNER_TEMP/installers because bazel-bin
       # outputs are read-only — `stapler staple` modifies the dmg in
       # place. `cp -aR` preserves macOS extended attributes (xattrs)
@@ -457,7 +466,32 @@ jobs:
             echo "::error::no .dmg found under $STAGE after staging." >&2
             exit 1
           fi
+
+          # Resolve the Developer ID Application identity from the temp
+          # keychain set up earlier. `find-identity` prints lines like:
+          #   1) <hash> "Developer ID Application: Co. (TEAMID)"
+          # The quoted name is what `codesign --sign` accepts.
+          SIGN_IDENTITY=$(security find-identity -v -p codesigning \
+            | awk -F'"' '/Developer ID Application/ {print $2; exit}')
+          if [[ -z "$SIGN_IDENTITY" ]]; then
+            echo "::error::no Developer ID Application identity in keychain." >&2
+            exit 1
+          fi
+          echo "Signing identity: $SIGN_IDENTITY"
+
           for dmg in "${dmgs[@]}"; do
+            # codesign the dmg container if it isn't already signed.
+            # `--verify` exits 0 on a valid signature, non-zero
+            # otherwise; we re-sign on any failure rather than
+            # parsing the error string.
+            if codesign --verify "$dmg" >/dev/null 2>&1; then
+              echo "$dmg already signed, skipping codesign."
+            else
+              echo "Signing $dmg with $SIGN_IDENTITY..."
+              codesign --force --sign "$SIGN_IDENTITY" --timestamp "$dmg"
+              codesign --verify --verbose=2 "$dmg"
+            fi
+
             echo "Submitting $dmg to Apple Notary..."
             xcrun notarytool submit "$dmg" \
               --key "$APPLE_API_KEY" \
@@ -489,11 +523,15 @@ jobs:
           fi
           for dmg in "${dmgs[@]}"; do
             echo "Inspecting $dmg"
-            # codesign on the dmg itself proves Developer ID identity
-            # is wired (electron-builder signs the dmg as a separate
-            # bundle from the .app inside).
-            if codesign -dv "$dmg" 2>&1 | grep -q "Signature=adhoc"; then
-              echo "::error::$dmg is ad-hoc-signed; the codesign identity didn't reach electron-builder." >&2
+            # `codesign --verify` exits 0 when there's a valid
+            # signature, non-zero otherwise. The previous `grep
+            # Signature=adhoc` check was a false-pass on an unsigned
+            # dmg (output text doesn't contain "adhoc" so the
+            # negative-match check let it through). v0.30.7 hit this:
+            # dmg was unsigned but my grep let it pass, then spctl
+            # rejected with "no usable signature" downstream.
+            if ! codesign --verify --verbose=2 "$dmg" 2>&1; then
+              echo "::error::$dmg has no valid signature." >&2
               exit 1
             fi
             # Staple ticket present? — proves notarytool ran and


### PR DESCRIPTION
## Summary

- 在 Notarize step 里先用 keychain 里的 Developer ID identity \`codesign\` dmg 容器，再 \`notarytool submit\` + \`stapler staple\`
- Verify step 把 \`codesign -dv | grep Signature=adhoc\` 改成 \`codesign --verify\`（exit code 检查），避免 unsigned dmg 在原 grep 下假阳性放行

## 背景

v0.30.7 release run \`25473940263\` 的 Desktop macOS：
- ✅ Notarize 步骤成功
- ✅ stapler validate 通过
- ❌ spctl 拒绝：\`source=no usable signature\`

根因：electron-builder 25 默认会签 dmg，但走 bazel macro 跑出来的 dmg 容器层没被签。.app 内部被签了，dmg 包装层没。stapler 能 staple ticket，但 spctl 在没有 signature 的 dmg 上找不到 anchor，rejected。

更深的隐患：Verify step 原来用 \`codesign -dv | grep Signature=adhoc\` 探测 dmg 是否签名失效。问题是 unsigned dmg 的 codesign 输出根本不含 \"adhoc\" 字串，反向匹配假阳性放行了。v0.30.7 之前 stapler grep 早 fail 看不到这点；v0.30.7 stapler 通了，spctl 才暴露 dmg 没签。

## 修复

1. **Notarize step** 增加 codesign 子步骤：
   - \`security find-identity -v -p codesigning\` 找出 \"Developer ID Application: ...\" 名字
   - 对每个 dmg：\`codesign --verify\` 已签则跳过；否则 \`codesign --force --sign \"\$IDENTITY\" --timestamp \"\$dmg\"\`
   - 然后 notarytool submit + stapler staple
2. **Verify step** 用 \`codesign --verify --verbose=2\` 退出码替换 grep

## Test Plan

- [ ] PR CI 全绿
- [ ] Merge 后打 v0.30.8
- [ ] release run macOS step 应看到：
  - \"Signing identity: Developer ID Application: ...\"
  - \"Signing AgentsMesh-0.30.8-arm64.dmg with ...\"
  - notarytool \"Accepted\"
  - stapler staple
  - Verify: codesign verify pass + stapler validated + spctl accepted
- [ ] release page 上有 \`AgentsMesh-0.30.8-*.dmg\`
- [ ] 本地下载 dmg，\`spctl -a -t open --context context:primary-signature -v\` → \"accepted\"