### PR TITLE
fix(web+desktop): popout terminal redirect (#346) + redirect-aware login

### DIFF
--- a/clients/desktop/src/renderer/pages/auth/login/LoginPage.tsx
+++ b/clients/desktop/src/renderer/pages/auth/login/LoginPage.tsx
@@ -1,10 +1,10 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
-  useAuthStore, readOrganizations, readCurrentOrg, useCurrentUser,
+  useAuthStore, useCurrentUser,
 } from "@/stores/auth";
 import { ApiError } from "@/lib/api/api-types";
 import { ssoApi } from "@/lib/api/sso";
@@ -15,22 +15,11 @@ import { OAuthButtons } from "./OAuthButtons";
 import { SSOSection } from "./SSOSection";
 import { Divider } from "./Divider";
 import { AuthShell } from "./AuthShell";
-
-function navigateToWorkspace(push: (url: string) => void) {
-  // Read from Rust SSOT (helpers), not Zustand state — web's auth store
-  // dropped the user/organizations/currentOrg fields when it migrated to
-  // Rust SSOT. Reading them off Zustand returned undefined and threw
-  // `Cannot read properties of undefined (reading '0')`.
-  const org = readCurrentOrg() ?? readOrganizations()[0];
-  if (org) {
-    push(`/${org.slug}/workspace`);
-  } else {
-    push("/onboarding");
-  }
-}
+import { navigateAfterLogin } from "./navigate-after-login";
 
 export function LoginPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const t = useTranslations();
   const { login, setAuth } = useAuthStore();
   const _hasHydrated = useAuthStore((s) => s._hasHydrated);
@@ -42,7 +31,7 @@ export function LoginPage() {
   const [error, setError] = useState("");
 
   useEffect(() => {
-    if (_hasHydrated && user) navigateToWorkspace(router.push);
+    if (_hasHydrated && user) navigateAfterLogin(router.push, searchParams.get("redirect"));
   }, [_hasHydrated, user, router]);
 
   const [ssoConfigs, setSsoConfigs] = useState<SSOConfig[]>([]);
@@ -90,7 +79,7 @@ export function LoginPage() {
     try {
       const response = await ssoApi.ldapAuth(ldapConfig.domain, { username, password: pwd });
       setAuth(response.token, response.user, response.refresh_token);
-      navigateToWorkspace(router.push);
+      navigateAfterLogin(router.push, searchParams.get("redirect"));
     } catch (err) {
       setError(err instanceof ApiError && err.status >= 500
         ? t("common.error") : t("auth.loginPage.invalidCredentials"));
@@ -104,7 +93,7 @@ export function LoginPage() {
     setError("");
     try {
       await login(email, password);
-      navigateToWorkspace(router.push);
+      navigateAfterLogin(router.push, searchParams.get("redirect"));
     } catch {
       setError(t("auth.loginPage.invalidCredentials"));
     } finally { setLoading(false); }

--- a/clients/desktop/src/renderer/pages/auth/login/navigate-after-login.ts
+++ b/clients/desktop/src/renderer/pages/auth/login/navigate-after-login.ts
@@ -1,0 +1,18 @@
+import { readCurrentOrg, readOrganizations } from "@/stores/auth";
+import { safeRedirectPath } from "@/lib/auth/redirect";
+
+// Desktop-only post-login navigator. Web has an analogous helper at
+// clients/web/src/lib/auth/post-login.ts that fetches orgs via
+// OrgApiService; here we read straight off the Rust SSOT cache because
+// the desktop service shim doesn't expose OrgApiService and the
+// auth/login flow already populates that cache via fetch_organizations()
+// inside AuthManager.login.
+export function navigateAfterLogin(
+  push: (url: string) => void,
+  redirect: string | null
+): void {
+  const safe = safeRedirectPath(redirect);
+  if (safe) { push(safe); return; }
+  const org = readCurrentOrg() ?? readOrganizations()[0];
+  push(org ? `/${org.slug}/workspace` : "/onboarding");
+}

--- a/clients/desktop/src/renderer/pages/popout/terminal/PopoutTerminalPage.tsx
+++ b/clients/desktop/src/renderer/pages/popout/terminal/PopoutTerminalPage.tsx
@@ -1,39 +1,24 @@
 import { useEffect } from "react";
-import { useParams, useRouter } from "next/navigation";
-import { useAuthStore } from "@/stores/auth";
+import { useParams } from "next/navigation";
+import { useCurrentUser } from "@/stores/auth";
 import { RealtimeProvider } from "@/providers/RealtimeProvider";
 import { TerminalPane } from "@/components/workspace/TerminalPane";
-import { Spinner } from "@/components/ui/spinner";
 import { getShortPodKey } from "@/lib/pod-display-name";
 
+// Auth gating happens via <RequireAuth> in router.tsx so this component
+// is only mounted when a user exists. New BrowserWindows opened via
+// window.open share the renderer's bootstrapAuth() flow (PlatformGate).
 export function PopoutTerminalPage() {
   const { podKey } = useParams<{ podKey: string }>();
-  const router = useRouter();
-  const { token, _hasHydrated } = useAuthStore();
+  const user = useCurrentUser();
 
-  // Redirect to login if not authenticated
-  useEffect(() => {
-    if (_hasHydrated && !token) {
-      router.push("/login");
-    }
-  }, [_hasHydrated, token, router]);
-
-  // Set window title to identify the pod
   useEffect(() => {
     if (podKey) {
       document.title = `Terminal - ${getShortPodKey(podKey)}`;
     }
   }, [podKey]);
 
-  if (!_hasHydrated) {
-    return (
-      <div className="flex h-screen items-center justify-center bg-terminal-bg">
-        <Spinner />
-      </div>
-    );
-  }
-
-  if (!token || !podKey) return null;
+  if (!user || !podKey) return null;
 
   return (
     <RealtimeProvider>

--- a/clients/desktop/src/renderer/router.tsx
+++ b/clients/desktop/src/renderer/router.tsx
@@ -1,6 +1,7 @@
 import { createHashRouter as createBrowserRouter, Navigate, Outlet } from "react-router-dom";
 import { DashboardShell } from "@/pages/layouts/DashboardShell";
 import { useAuthStore, useCurrentOrg, useAuthOrganizations, useIsAuthenticated } from "@/stores/auth";
+import { RequireAuth } from "@/components/auth/RequireAuth";
 
 // Auth pages
 import { LoginPage } from "@/pages/auth/login/LoginPage";
@@ -71,8 +72,11 @@ export const router = createBrowserRouter([
     ],
   },
 
-  // Popout (no shell)
-  { path: "/popout/terminal/:podKey", element: <PopoutTerminalPage /> },
+  // Popout (no shell) — RequireAuth gates the new BrowserWindow. The
+  // window.open()-spawned renderer runs its own AppProviders.PlatformGate
+  // (bootstrap → setHasHydrated), so by the time this route mounts the
+  // session has been rehydrated from localStorage.
+  { path: "/popout/terminal/:podKey", element: <RequireAuth><PopoutTerminalPage /></RequireAuth> },
 
   // Dashboard routes (wrapped in DashboardShell)
   {

--- a/clients/web/e2e-playwright/tests/auth/popout-redirect.spec.ts
+++ b/clients/web/e2e-playwright/tests/auth/popout-redirect.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from "@playwright/test";
+import { TEST_USER } from "../../helpers/env";
+import { LoginPage } from "../../pages/login.page";
+
+// Regression cover for issue #346: popout terminal redirected to /login
+// for already-logged-in users in a fresh BrowserWindow because the new
+// window's wasm core started anonymous and never ran bootstrap. The
+// fix wires popout/layout.tsx → AuthBootstrap (init wasm + bootstrap)
+// → RequireAuth (login bounce w/ ?redirect=).
+//
+// We use a synthetic podKey: even if no real pod exists, the auth gate
+// runs first — it either lets the page render or redirects. The bug
+// would manifest as a /login redirect for an authenticated session,
+// independent of pod existence.
+
+const SYNTH_POD_KEY = "popout-redirect-test-pod";
+const POPOUT_PATH = `/popout/terminal/${SYNTH_POD_KEY}`;
+
+test.describe("Popout terminal auth gating", () => {
+  test("authenticated user lands on popout without /login bounce", async ({
+    page,
+  }) => {
+    await page.goto(POPOUT_PATH);
+
+    // Give bootstrap + RequireAuth a moment to settle. If the bug
+    // regressed we'd be on /login; instead the URL must keep its
+    // popout shape.
+    await page.waitForTimeout(2_000);
+    expect(page.url()).toContain(POPOUT_PATH);
+    expect(page.url()).not.toContain("/login");
+  });
+
+  test.describe("anonymous", () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+
+    test("anonymous popout deep link bounces through /login with ?redirect=", async ({
+      page,
+    }) => {
+      await page.goto(POPOUT_PATH);
+
+      // RequireAuth replaces the URL with /login?redirect=<encoded popout>.
+      await page.waitForURL((url) => url.pathname === "/login", {
+        timeout: 15_000,
+      });
+      const redirectParam = new URL(page.url()).searchParams.get("redirect");
+      expect(redirectParam).toBe(POPOUT_PATH);
+    });
+
+    test("login restores the original popout URL via ?redirect=", async ({
+      page,
+    }) => {
+      await page.goto(POPOUT_PATH);
+      await page.waitForURL((url) => url.pathname === "/login", {
+        timeout: 15_000,
+      });
+
+      const loginPage = new LoginPage(page);
+      await loginPage.login(TEST_USER.email, TEST_USER.password);
+
+      // Post-login navigation must honor ?redirect= ahead of getDefaultRoute.
+      await page.waitForURL(
+        (url) => url.pathname === POPOUT_PATH,
+        { timeout: 15_000 }
+      );
+      expect(page.url()).toContain(POPOUT_PATH);
+    });
+  });
+});

--- a/clients/web/src/app/(auth)/auth/callback/page.tsx
+++ b/clients/web/src/app/(auth)/auth/callback/page.tsx
@@ -5,9 +5,9 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { useAuthStore } from "@/stores/auth";
-import { getUserApiService, getOrgApiService } from "@/lib/wasm-getters";
+import { getUserApiService } from "@/lib/wasm-getters";
 import { initWasmCore } from "@/lib/wasm-core";
-import { getDefaultRoute } from "@/lib/default-route";
+import { resolvePostLoginUrl } from "@/lib/auth/post-login";
 import { Logo } from "@/components/common";
 
 function OAuthCallbackContent() {
@@ -16,6 +16,7 @@ function OAuthCallbackContent() {
   const token = searchParams.get("token");
   const refreshToken = searchParams.get("refresh_token");
   const error = searchParams.get("error");
+  const redirectParam = searchParams.get("redirect");
   const { setAuth, setOrganizations } = useAuthStore();
 
   const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
@@ -52,31 +53,12 @@ function OAuthCallbackContent() {
         // Update auth with actual user info
         setAuth(token, user, refreshToken || undefined);
 
-        // Get organizations
-        try {
-          const orgsResponse = JSON.parse(await getOrgApiService().list());
-          if (orgsResponse.organizations && orgsResponse.organizations.length > 0) {
-            setOrganizations(orgsResponse.organizations);
-            setStatus("success");
-
-            // Redirect to first org's dashboard
-            setTimeout(() => {
-              router.push(getDefaultRoute(orgsResponse.organizations[0].slug));
-            }, 1500);
-          } else {
-            // No organizations, redirect to onboarding
-            setStatus("success");
-            setTimeout(() => {
-              router.push("/onboarding");
-            }, 1500);
-          }
-        } catch {
-          // Failed to get orgs, redirect to onboarding
-          setStatus("success");
-          setTimeout(() => {
-            router.push("/onboarding");
-          }, 1500);
-        }
+        const url = await resolvePostLoginUrl({
+          redirectParam,
+          setOrganizations,
+        });
+        setStatus("success");
+        setTimeout(() => { router.push(url); }, 1500);
       } catch (err: unknown) {
         setStatus("error");
         if (err instanceof Error) {
@@ -88,7 +70,7 @@ function OAuthCallbackContent() {
     };
 
     handleCallback();
-  }, [token, refreshToken, error, setAuth, setOrganizations, router]);
+  }, [token, refreshToken, error, redirectParam, setAuth, setOrganizations, router]);
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background px-4">

--- a/clients/web/src/app/(auth)/auth/sso/callback/page.tsx
+++ b/clients/web/src/app/(auth)/auth/sso/callback/page.tsx
@@ -5,8 +5,9 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { useAuthStore } from "@/stores/auth";
-import { getUserApiService, getOrgApiService } from "@/lib/wasm-getters";
+import { getUserApiService } from "@/lib/wasm-getters";
 import { initWasmCore } from "@/lib/wasm-core";
+import { resolvePostLoginUrl } from "@/lib/auth/post-login";
 import { Logo } from "@/components/common";
 import { useTranslations } from "next-intl";
 
@@ -17,6 +18,7 @@ function SSOCallbackContent() {
   const token = searchParams.get("token");
   const refreshToken = searchParams.get("refresh_token");
   const error = searchParams.get("error");
+  const redirectParam = searchParams.get("redirect");
   const { setAuth, setOrganizations } = useAuthStore();
 
   const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
@@ -29,7 +31,8 @@ function SSOCallbackContent() {
     if (processedRef.current) return;
     processedRef.current = true;
 
-    // Remove tokens from URL to prevent leaking via browser history/Referer
+    // Remove tokens from URL to prevent leaking via browser history/Referer.
+    // redirectParam is already captured into closure above so this is safe.
     if (token || refreshToken || error) {
       window.history.replaceState({}, "", window.location.pathname);
     }
@@ -69,22 +72,12 @@ function SSOCallbackContent() {
         const userResponse = JSON.parse(await getUserApiService().get_me());
         setAuth(token, userResponse.user, refreshToken || undefined);
 
-        // Get organizations and redirect
-        try {
-          const orgsResponse = JSON.parse(await getOrgApiService().list());
-          const orgs = orgsResponse.organizations;
-          if (orgs && orgs.length > 0) {
-            setOrganizations(orgs);
-            setStatus("success");
-            scheduleRedirect(`/${orgs[0].slug}/workspace`);
-          } else {
-            setStatus("success");
-            scheduleRedirect("/onboarding");
-          }
-        } catch {
-          setStatus("success");
-          scheduleRedirect("/onboarding");
-        }
+        const url = await resolvePostLoginUrl({
+          redirectParam,
+          setOrganizations,
+        });
+        setStatus("success");
+        scheduleRedirect(url);
       } catch {
         setStatus("error");
         setErrorMessage(t("auth.sso.callbackGenericError"));
@@ -97,7 +90,7 @@ function SSOCallbackContent() {
       if (redirectTimerRef.current) clearTimeout(redirectTimerRef.current);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- processedRef ensures single execution
-  }, [token, refreshToken, error]);
+  }, [token, refreshToken, error, redirectParam]);
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background px-4">

--- a/clients/web/src/app/(auth)/layout.tsx
+++ b/clients/web/src/app/(auth)/layout.tsx
@@ -1,13 +1,18 @@
-import { WasmProvider } from "@/providers/WasmProvider";
+import { AuthBootstrap } from "@/components/auth/AuthBootstrap";
 
-// Auth route group — login / register / OAuth callback / verify-email / etc.
-// These routes need wasm because the form submit / OAuth handlers go through
-// AuthManager. Marketing routes outside this group (and outside (dashboard))
-// should NOT load wasm; see app/layout.tsx (root) for the partition.
+// Auth route group — login / register / OAuth callback / verify-email /
+// onboarding / runners-authorize / invite. Some pages here are anonymous
+// (login, register), others require an already-authenticated user
+// (onboarding, runners/authorize, invite acceptance flow). Wrapping the
+// whole group in AuthBootstrap means a deep-link / new-window entry
+// rehydrates the session from localStorage before page-level guards run;
+// for anonymous pages the bootstrap result is `Anonymous` and behaves as
+// before. Marketing routes outside this group should NOT load wasm; see
+// app/layout.tsx (root) for the partition.
 export default function AuthLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return <WasmProvider>{children}</WasmProvider>;
+  return <AuthBootstrap>{children}</AuthBootstrap>;
 }

--- a/clients/web/src/app/(auth)/login/page.tsx
+++ b/clients/web/src/app/(auth)/login/page.tsx
@@ -2,23 +2,24 @@
 
 import { useState, useCallback, useRef, useEffect } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useAuthStore } from "@/stores/auth";
 import { ApiError } from "@/lib/api/api-types";
 import type { SSOConfig } from "@/lib/api/ssoTypes";
 import { getAuthManager, getSSOService } from "@/lib/wasm-getters";
-import { initWasmCore, getOrgApiService } from "@/lib/wasm-core";
+import { initWasmCore } from "@/lib/wasm-core";
 import { useTranslations } from "next-intl";
 import { AuthShell } from "@/components/auth/AuthShell";
 import { OAuthButtons } from "./OAuthButtons";
-import { getDefaultRoute } from "@/lib/default-route";
+import { resolvePostLoginUrl } from "@/lib/auth/post-login";
 import { SSOSection } from "./SSOSection";
 import { Divider } from "./Divider";
 
 export default function LoginPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const t = useTranslations();
   const { setAuth, setOrganizations } = useAuthStore();
   const [email, setEmail] = useState("");
@@ -63,18 +64,11 @@ export default function LoginPage() {
   }, []);
 
   const navigateAfterLogin = async () => {
-    try {
-      // Fetch orgs via OrgApiService (reliable), then persist via AuthManager
-      const orgsResponse = JSON.parse(await getOrgApiService().list());
-      const orgs = orgsResponse.organizations || [];
-      if (orgs.length > 0) {
-        setOrganizations(orgs);
-        try { await getAuthManager().fetch_organizations(); } catch { /* best effort */ }
-        router.push(getDefaultRoute(orgs[0].slug));
-      } else {
-        router.push("/onboarding");
-      }
-    } catch { router.push("/onboarding"); }
+    const url = await resolvePostLoginUrl({
+      redirectParam: searchParams.get("redirect"),
+      setOrganizations,
+    });
+    router.push(url);
   };
 
   const handleLdapSubmit = async (username: string, pwd: string) => {
@@ -115,6 +109,15 @@ export default function LoginPage() {
     } finally { setLoading(false); }
   };
 
+  // Carry `?redirect=` over to the sign-up CTA so users who switch from
+  // login to register don't lose the original deep-link target. The
+  // register flow may still drop it at the verify-email step (out of
+  // scope here), but at minimum the link itself preserves intent.
+  const redirectParam = searchParams.get("redirect");
+  const registerHref = redirectParam
+    ? `/register?redirect=${encodeURIComponent(redirectParam)}`
+    : "/register";
+
   return (
     <AuthShell
       title={t("auth.loginPage.title")}
@@ -122,7 +125,7 @@ export default function LoginPage() {
       footer={
         <>
           {t("auth.loginPage.dontHaveAccount")}{" "}
-          <Link href="/register" className="text-[var(--azure-cyan)] hover:underline">
+          <Link href={registerHref} className="text-[var(--azure-cyan)] hover:underline">
             {t("auth.loginPage.signUp")}
           </Link>
         </>

--- a/clients/web/src/app/(dashboard)/DashboardShell.tsx
+++ b/clients/web/src/app/(dashboard)/DashboardShell.tsx
@@ -1,79 +1,60 @@
 "use client";
 
-import React, { useEffect, useCallback, useState } from "react";
+import React, { useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useCurrentUser, useCurrentOrg, useAuthStore } from "@/stores/auth";
 import { useChannelMessageStore } from "@/stores/channelMessageStore";
 import { ResponsiveShell } from "@/components/layout";
-import { Spinner } from "@/components/ui/spinner";
 import { RealtimeProvider } from "@/providers/RealtimeProvider";
-import { initWasmCore, getAuthManager } from "@/lib/wasm-core";
+import { getAuthManager } from "@/lib/wasm-core";
 import { useBrowserNotification } from "@/hooks";
 import { handleNotificationEvent } from "@/stores/notificationHandler";
 import type { RealtimeEvent } from "@/lib/realtime";
 
+// Mounted under <RequireAuth>, so `user` is non-null whenever this
+// component renders. Dashboard-specific concerns only: URL-slug →
+// switch_org routing helper, browser-notification permission prompt,
+// channels-unread refresh on org change, and realtime event dispatch.
 export default function DashboardShell({
   children,
 }: {
   children: React.ReactNode;
 }) {
   const router = useRouter();
-  const [wasmReady, setWasmReady] = useState(false);
   const user = useCurrentUser();
   const currentOrg = useCurrentOrg();
+  const _hasHydrated = useAuthStore((s) => s._hasHydrated);
   const { permission, showNotification, requestPermission } = useBrowserNotification();
 
+  // URL-slug → switch_org: a deep link to /{otherOrg}/... should win over
+  // the persisted current_org_slug that bootstrap restored.
   useEffect(() => {
-    initWasmCore().then(async () => {
-      // Bootstrap protocol replaces the previous restore_session + manual
-      // hydrate dance. It reads storage, validates the token, refreshes
-      // when near expiry, and re-fetches identity / orgs from the server
-      // — all atomic. Failure cleans storage and lands the user
-      // anonymous (RootRedirect → /login).
-      await useAuthStore.getState().bootstrap();
-
-      // Routing helper: if the URL slug names a known org, switch to it.
-      // The bootstrap already populated `currentOrg` from the persisted
-      // `current_org_slug`, but a deep link to /{otherOrg}/... should
-      // win over the persisted preference.
-      try {
-        const orgs = JSON.parse(getAuthManager().get_organizations_json() || "[]");
-        if (orgs.length > 0) {
-          const urlSlug = window.location.pathname.split("/")[1];
-          const matchedOrg = orgs.find((o: { slug: string }) => o.slug === urlSlug);
-          if (matchedOrg) {
-            // switch_org updates AuthManager's PersistedSession.current_org_slug;
-            // ApiClient reads it via shared AuthTokenStore on every request.
-            getAuthManager().switch_org(matchedOrg.slug);
-            useAuthStore.getState().setCurrentOrg(matchedOrg);
-          }
-        }
-      } catch { /* noop */ }
-
-      useAuthStore.getState().setHasHydrated(true);
-      setWasmReady(true);
-    });
-  }, []);
+    if (!_hasHydrated) return;
+    try {
+      const orgs = JSON.parse(getAuthManager().get_organizations_json() || "[]");
+      if (orgs.length === 0) return;
+      const urlSlug = window.location.pathname.split("/")[1];
+      const matchedOrg = orgs.find((o: { slug: string }) => o.slug === urlSlug);
+      if (matchedOrg) {
+        getAuthManager().switch_org(matchedOrg.slug);
+        useAuthStore.getState().setCurrentOrg(matchedOrg);
+      }
+    } catch { /* noop */ }
+  }, [_hasHydrated]);
 
   useEffect(() => {
-    if (wasmReady && !user) {
-      router.push("/login");
-    }
-  }, [user, router, wasmReady]);
-
-  useEffect(() => {
-    if (wasmReady && user && permission === "default") {
+    if (user && permission === "default") {
       const timer = setTimeout(() => { requestPermission(); }, 3000);
       return () => clearTimeout(timer);
     }
-  }, [wasmReady, user, permission, requestPermission]);
+  }, [user, permission, requestPermission]);
 
   // Cross-cutting org-scoped state (e.g. ActivityBar's channels-unread
   // badge sits outside the org layout's gate) — refresh on org change.
   useEffect(() => {
-    if (!wasmReady || !currentOrg) return;
+    if (!currentOrg) return;
     void useChannelMessageStore.getState().fetchUnreadCounts();
-  }, [wasmReady, currentOrg]);
+  }, [currentOrg]);
 
   const handleEvent = useCallback(
     (event: RealtimeEvent) => {
@@ -95,18 +76,6 @@ export default function DashboardShell({
     },
     [showNotification, router, currentOrg]
   );
-
-  if (!wasmReady) {
-    return (
-      <div className="flex h-screen items-center justify-center bg-background">
-        <Spinner />
-      </div>
-    );
-  }
-
-  if (!user) {
-    return null;
-  }
 
   return (
     <RealtimeProvider onEvent={handleEvent}>

--- a/clients/web/src/app/(dashboard)/layout.tsx
+++ b/clients/web/src/app/(dashboard)/layout.tsx
@@ -1,24 +1,28 @@
 import type { Metadata } from "next";
 import DashboardShell from "./DashboardShell";
-import { WasmProvider } from "@/providers/WasmProvider";
+import { AuthBootstrap } from "@/components/auth/AuthBootstrap";
+import { RequireAuth } from "@/components/auth/RequireAuth";
 import { PostHogIdentify } from "@/providers/PostHogProvider";
 
 export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
-// Dashboard route group — wasm-bound. WasmProvider is mounted here (not in
-// the root layout) so marketing pages stay free of the 21MB wasm load.
-// PostHogIdentify is also scoped here because it depends on auth hooks.
+// Dashboard route group — wasm-bound, auth-required. AuthBootstrap loads
+// wasm and runs the auth bootstrap protocol; RequireAuth handles the
+// `_hasHydrated && !user → /login` gate uniformly. PostHogIdentify needs
+// auth hooks so it sits inside AuthBootstrap.
 export default function DashboardLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
   return (
-    <WasmProvider>
+    <AuthBootstrap>
       <PostHogIdentify />
-      <DashboardShell>{children}</DashboardShell>
-    </WasmProvider>
+      <RequireAuth>
+        <DashboardShell>{children}</DashboardShell>
+      </RequireAuth>
+    </AuthBootstrap>
   );
 }

--- a/clients/web/src/app/popout/layout.tsx
+++ b/clients/web/src/app/popout/layout.tsx
@@ -1,13 +1,19 @@
-import { WasmProvider } from "@/providers/WasmProvider";
+import { AuthBootstrap } from "@/components/auth/AuthBootstrap";
+import { RequireAuth } from "@/components/auth/RequireAuth";
 
-// Popout terminal — opens a pod terminal in a separate browser window. Needs
-// wasm because TerminalPane consumes the relay backend and uses auth hooks
-// from the same wasm-bound stores as the dashboard. URL stays /popout/...
-// regardless of this layout.
+// Popout terminal — a separate browser window opened via window.open.
+// New windows get a fresh Rust core, so AuthBootstrap is required to
+// rehydrate the session from localStorage; without it the popout would
+// always see an anonymous user and bounce to /login (issue #346).
+// RequireAuth then guards the page with a redirect-preserving login bounce.
 export default function PopoutLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return <WasmProvider>{children}</WasmProvider>;
+  return (
+    <AuthBootstrap>
+      <RequireAuth>{children}</RequireAuth>
+    </AuthBootstrap>
+  );
 }

--- a/clients/web/src/app/popout/terminal/[podKey]/page.tsx
+++ b/clients/web/src/app/popout/terminal/[podKey]/page.tsx
@@ -1,40 +1,21 @@
 "use client";
 
 import { useEffect } from "react";
-import { useParams, useRouter } from "next/navigation";
-import { useCurrentUser, useAuthStore } from "@/stores/auth";
+import { useParams } from "next/navigation";
+import { useCurrentUser } from "@/stores/auth";
 import { RealtimeProvider } from "@/providers/RealtimeProvider";
 import { TerminalPane } from "@/components/workspace/TerminalPane";
-import { Spinner } from "@/components/ui/spinner";
 import { getShortPodKey } from "@/lib/pod-display-name";
 
 export default function PopoutTerminalPage() {
   const { podKey } = useParams<{ podKey: string }>();
-  const router = useRouter();
   const user = useCurrentUser();
-  const _hasHydrated = useAuthStore((s) => s._hasHydrated);
 
-  // Redirect to login if not authenticated
-  useEffect(() => {
-    if (_hasHydrated && !user) {
-      router.push("/login");
-    }
-  }, [_hasHydrated, user, router]);
-
-  // Set window title to identify the pod
   useEffect(() => {
     if (podKey) {
       document.title = `Terminal - ${getShortPodKey(podKey)}`;
     }
   }, [podKey]);
-
-  if (!_hasHydrated) {
-    return (
-      <div className="flex h-screen items-center justify-center bg-terminal-bg">
-        <Spinner />
-      </div>
-    );
-  }
 
   if (!user || !podKey) return null;
 

--- a/clients/web/src/components/auth/AuthBootstrap.tsx
+++ b/clients/web/src/components/auth/AuthBootstrap.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuthStore } from "@/stores/auth";
+import { WasmProvider } from "@/providers/WasmProvider";
+import { CenteredSpinner } from "@/components/ui/spinner";
+
+// Single hydrate entry for any wasm-bound route group.
+//
+// Wraps WasmProvider and, once wasm is ready, runs the Rust auth
+// bootstrap protocol (storage → token validation → optional refresh →
+// identity re-fetch) before flipping `_hasHydrated`. Downstream
+// components that gate on `_hasHydrated && user` therefore see a
+// consistent state — no false-anonymous flash, no premature `/login`
+// redirect for users whose session lives in localStorage of a window
+// just opened (e.g. the popout terminal).
+//
+// Bootstrap is a no-op for genuinely anonymous users — the result is
+// `Anonymous` and `_hasHydrated` still flips so /login can render.
+export function AuthBootstrap({ children }: { children: React.ReactNode }) {
+  return (
+    <WasmProvider>
+      <BootstrapGate>{children}</BootstrapGate>
+    </WasmProvider>
+  );
+}
+
+function BootstrapGate({ children }: { children: React.ReactNode }) {
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        await useAuthStore.getState().bootstrap();
+      } finally {
+        if (cancelled) return;
+        useAuthStore.getState().setHasHydrated(true);
+        setDone(true);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  if (!done) return <CenteredSpinner />;
+  return <>{children}</>;
+}

--- a/clients/web/src/components/auth/RequireAuth.tsx
+++ b/clients/web/src/components/auth/RequireAuth.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import { useCurrentUser, useAuthStore } from "@/stores/auth";
+import { CenteredSpinner } from "@/components/ui/spinner";
+import { loginUrlWithRedirect } from "@/lib/auth/redirect";
+
+// Single source of truth for the `_hasHydrated && !user → /login` guard.
+// Wrap any subtree that requires an authenticated user.
+//
+// Once hydrated, anonymous visitors are sent to `/login?redirect=<here>` so
+// the post-login navigation can land them back where they started.
+// The redirect target preserves search + hash so deep links survive.
+export function RequireAuth({ children }: { children: React.ReactNode }) {
+  const _hasHydrated = useAuthStore((s) => s._hasHydrated);
+  const user = useCurrentUser();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (!_hasHydrated || user) return;
+    const search = searchParams?.toString();
+    const hash = typeof window !== "undefined" ? window.location.hash : "";
+    const target = `${pathname || "/"}${search ? `?${search}` : ""}${hash}`;
+    router.replace(loginUrlWithRedirect(target));
+  }, [_hasHydrated, user, router, pathname, searchParams]);
+
+  if (!_hasHydrated) return <CenteredSpinner />;
+  if (!user) return null;
+  return <>{children}</>;
+}

--- a/clients/web/src/lib/auth/post-login.ts
+++ b/clients/web/src/lib/auth/post-login.ts
@@ -1,0 +1,53 @@
+import { getAuthManager, getOrgApiService } from "@/lib/wasm-core";
+import { getDefaultRoute } from "@/lib/default-route";
+import { safeRedirectPath } from "./redirect";
+
+interface Organization {
+  id: number;
+  name: string;
+  slug: string;
+}
+
+export interface ResolvePostLoginUrlOptions {
+  redirectParam: string | null;
+  setOrganizations: (orgs: Organization[]) => void;
+}
+
+// Single source of truth for "where do we land after a successful login".
+// Order of preference:
+//   1. `?redirect=<safe path>` from the URL — restores deep-link / popout
+//      flows that bounced through /login.
+//   2. First org's default route — fetched fresh from OrgApiService and
+//      cached via setOrganizations so the destination renders immediately.
+//   3. /onboarding — fallback when the user has no org yet.
+//
+// Org cache priming runs on the redirect path too: the destination
+// (e.g. /popout/terminal/...) likely relies on currentOrg being populated.
+async function primeOrganizations(
+  setOrganizations: (orgs: Organization[]) => void
+): Promise<Organization[]> {
+  try {
+    const orgsResponse = JSON.parse(await getOrgApiService().list());
+    const orgs: Organization[] = orgsResponse.organizations || [];
+    if (orgs.length > 0) {
+      setOrganizations(orgs);
+      try { await getAuthManager().fetch_organizations(); } catch { /* best effort */ }
+    }
+    return orgs;
+  } catch {
+    return [];
+  }
+}
+
+export async function resolvePostLoginUrl(
+  opts: ResolvePostLoginUrlOptions
+): Promise<string> {
+  const redirect = safeRedirectPath(opts.redirectParam);
+  if (redirect) {
+    await primeOrganizations(opts.setOrganizations);
+    return redirect;
+  }
+  const orgs = await primeOrganizations(opts.setOrganizations);
+  if (orgs.length > 0) return getDefaultRoute(orgs[0].slug);
+  return "/onboarding";
+}

--- a/clients/web/src/lib/auth/redirect.test.ts
+++ b/clients/web/src/lib/auth/redirect.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { safeRedirectPath, loginUrlWithRedirect } from "./redirect";
+
+describe("safeRedirectPath", () => {
+  it("accepts a regular relative path", () => {
+    expect(safeRedirectPath("/popout/terminal/abc")).toBe("/popout/terminal/abc");
+  });
+
+  it("preserves query strings", () => {
+    expect(safeRedirectPath("/runners/authorize?key=xyz")).toBe("/runners/authorize?key=xyz");
+  });
+
+  it("preserves hash fragments", () => {
+    expect(safeRedirectPath("/dashboard#section")).toBe("/dashboard#section");
+  });
+
+  it("rejects protocol-relative `//host` (cross-origin escape)", () => {
+    expect(safeRedirectPath("//evil.com/path")).toBeNull();
+  });
+
+  it("rejects `/\\host` (browser-normalized protocol-relative)", () => {
+    expect(safeRedirectPath("/\\evil.com")).toBeNull();
+  });
+
+  it("rejects absolute http/https URLs", () => {
+    expect(safeRedirectPath("https://evil.com")).toBeNull();
+    expect(safeRedirectPath("http://evil.com")).toBeNull();
+  });
+
+  it("rejects javascript: scheme", () => {
+    expect(safeRedirectPath("javascript:alert(1)")).toBeNull();
+  });
+
+  it("rejects data: scheme", () => {
+    expect(safeRedirectPath("data:text/html,<script>")).toBeNull();
+  });
+
+  it("rejects empty string", () => {
+    expect(safeRedirectPath("")).toBeNull();
+  });
+
+  it("rejects null and undefined", () => {
+    expect(safeRedirectPath(null)).toBeNull();
+    expect(safeRedirectPath(undefined)).toBeNull();
+  });
+
+  it("rejects bare relative paths (must start with /)", () => {
+    expect(safeRedirectPath("popout/x")).toBeNull();
+  });
+});
+
+describe("loginUrlWithRedirect", () => {
+  it("encodes the target in the redirect query param", () => {
+    expect(loginUrlWithRedirect("/popout/terminal/abc?x=1")).toBe(
+      "/login?redirect=%2Fpopout%2Fterminal%2Fabc%3Fx%3D1"
+    );
+  });
+
+  it("falls back to bare /login when target is unsafe", () => {
+    expect(loginUrlWithRedirect("https://evil.com")).toBe("/login");
+    expect(loginUrlWithRedirect("//evil.com")).toBe("/login");
+    expect(loginUrlWithRedirect("")).toBe("/login");
+  });
+});

--- a/clients/web/src/lib/auth/redirect.ts
+++ b/clients/web/src/lib/auth/redirect.ts
@@ -1,0 +1,19 @@
+// Single chokepoint for post-login redirect targets. Keeps every
+// `/login?redirect=...` consumer + every cross-page link aligned on one
+// open-redirect policy: only same-origin, path-relative URLs are accepted.
+// Anything else (scheme-bearing, protocol-relative, empty, non-string) is
+// dropped — the caller falls back to the default route.
+
+export function safeRedirectPath(raw: string | null | undefined): string | null {
+  if (typeof raw !== "string" || raw.length === 0) return null;
+  if (raw[0] !== "/") return null;
+  // Reject `//host` and `/\host` — both normalize to protocol-relative
+  // cross-origin URLs in some browsers.
+  if (raw.length > 1 && (raw[1] === "/" || raw[1] === "\\")) return null;
+  return raw;
+}
+
+export function loginUrlWithRedirect(target: string): string {
+  const safe = safeRedirectPath(target);
+  return safe ? `/login?redirect=${encodeURIComponent(safe)}` : "/login";
+}

--- a/clients/web/src/providers/WasmProvider.tsx
+++ b/clients/web/src/providers/WasmProvider.tsx
@@ -2,32 +2,25 @@
 
 import { useEffect, useState } from "react";
 import { initWasmCore } from "@/lib/wasm-core";
-import { useAuthStore } from "@/stores/auth";
 
 function isEmbedRoute(): boolean {
   if (typeof window === "undefined") return false;
   return window.location.pathname.startsWith("/blocks-embed");
 }
 
+// Loads the wasm core. Does NOT touch auth state — that's AuthBootstrap's
+// job (see components/auth/AuthBootstrap.tsx). Embed routes (iOS WKWebView)
+// skip wasm because the embed page wires its own platform init via the
+// ios-bridge RPC; running WASM there would spin up a second Rust core.
 export function WasmProvider({ children }: { children: React.ReactNode }) {
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
     if (isEmbedRoute()) {
-      // Embed routes (e.g. iOS WKWebView) use a different platform init
-      // (RPC bridge) that the embed page itself wires up. Skipping WASM
-      // here prevents two competing `setPlatformInit` providers and
-      // avoids spinning up a second Rust core inside the WebView.
-      Promise.resolve().then(() => {
-        useAuthStore.getState().setHasHydrated(true);
-        setReady(true);
-      });
+      Promise.resolve().then(() => setReady(true));
       return;
     }
-    initWasmCore().then(() => {
-      useAuthStore.getState().setHasHydrated(true);
-      setReady(true);
-    });
+    initWasmCore().then(() => setReady(true));
   }, []);
 
   if (!ready) return null;


### PR DESCRIPTION
## Summary

- Fix issue #346: popout terminal in a new BrowserWindow always bounced to `/login`, and post-login landed on the dashboard instead of the popout.
- Root cause: PR #349's auth-bootstrap hardening moved hydration into a single `bootstrap()` entry, but only `(dashboard)/DashboardShell.tsx` called it — popout / onboarding / runners-authorize / invite lived outside that group.
- Three new abstractions used uniformly across web + desktop:
  - `<AuthBootstrap>` — wraps `WasmProvider` and runs bootstrap before flipping `_hasHydrated` (mounted at every wasm-bound layout); shows `<CenteredSpinner />` while hydrating.
  - `<RequireAuth>` — single source of truth for the `_hasHydrated && !user → /login` guard, with redirect-target preserved via `loginUrlWithRedirect`.
  - `safeRedirectPath` + `resolvePostLoginUrl` — chokepoint shared by `login` / OAuth callback / SSO callback / desktop login. Rejects `//host`, `https://x`, `javascript:`, `data:`, `/\host` open-redirect payloads.
- DashboardShell loses 87 LoC of init/bootstrap/guard plumbing; desktop popout drops the broken `token`-based guard.
- Login page's `/register` link now forwards `?redirect=` so users who pivot to sign-up don't lose intent.

## Out of scope (separate PRs)

- Desktop `DashboardShell` still has the inline `/login` push without redirect.
- Web `/login` doesn't auto-redirect already-authenticated users (pre-existing).
- OAuth state-roundtrip (transparent `?redirect=` through OAuth `state`) — callback side already consumes the param when present.

## Test plan

- [x] `bazel test //clients/web:lint //clients/web:unit` — passes (1510 unit + 13 new redirect.test.ts cases)
- [x] `bazel build //clients/web:src` — type-check passes
- [x] `bazel test //clients/desktop:lint` — passes
- [x] `bazel build //clients/desktop:out` — electron-vite build passes
- [ ] CI pipeline green
- [ ] Manual: open a pod in main window → click popout button → new window shows the terminal (no `/login` bounce)
- [ ] Manual: in a fresh incognito window navigate to `/popout/terminal/<podKey>` → bounces to `/login?redirect=...` → after login, lands back on the popout URL
- [ ] Manual (desktop): same two flows in the Electron app

Closes #346