### PR TITLE
fix(desktop+core): SSOT server-config + ApiError URL injection (OrbStack 502)

### DIFF
--- a/clients/core/crates/api-client/src/client.rs
+++ b/clients/core/crates/api-client/src/client.rs
@@ -143,6 +143,10 @@ impl ApiClient {
     pub async fn put_raw_bytes(
         &self, url: &str, content_type: &str, body: Vec<u8>,
     ) -> Result<(), ApiError> {
+        // `url` here is the full upload target supplied by the caller
+        // (e.g. an S3 presigned URL), NOT prefixed with `self.base_url`.
+        // The error's `url` field reflects that, so a 5xx from S3 says
+        // "@ https://bucket.s3.amazonaws.com/..." not the AgentsMesh API.
         let resp = self.http
             .put(url)
             .header("Content-Type", content_type)
@@ -154,6 +158,7 @@ impl ApiClient {
                 status: resp.status().as_u16(),
                 status_text: resp.status().canonical_reason().unwrap_or("Unknown").to_string(),
                 code: None, server_message: None, data: None,
+                url: Some(url.to_string()),
             });
         }
         Ok(())

--- a/clients/core/crates/api-client/src/error.rs
+++ b/clients/core/crates/api-client/src/error.rs
@@ -11,6 +11,11 @@ pub enum ApiError {
         code: Option<String>,
         server_message: Option<String>,
         data: Option<serde_json::Value>,
+        // Full request URL the response came back from. None for synthetic
+        // errors constructed in tests; production paths in `parse_response`
+        // always set this so users see *which host* returned 5xx — critical
+        // when debugging "is the desktop hitting prod or my local OrbStack?"
+        url: Option<String>,
     },
 
     #[error("auth expired")]
@@ -60,11 +65,16 @@ impl From<&ApiError> for ServiceError {
                 status_text,
                 code,
                 server_message,
+                url,
                 ..
             } => {
-                let message = server_message
+                let base = server_message
                     .clone()
                     .unwrap_or_else(|| status_text.clone());
+                let message = match url {
+                    Some(u) => format!("{base} @ {u}"),
+                    None => base,
+                };
                 if *status == 404 {
                     return ServiceError::ResourceNotFound {
                         resource: code
@@ -80,9 +90,14 @@ impl From<&ApiError> for ServiceError {
                 }
             }
             ApiError::AuthExpired => ServiceError::AuthExpired,
-            ApiError::Network(e) => ServiceError::Network {
-                message: e.to_string(),
-            },
+            ApiError::Network(e) => {
+                let url = e.url().map(|u| u.to_string());
+                let message = match url {
+                    Some(u) => format!("{e} @ {u}"),
+                    None => e.to_string(),
+                };
+                ServiceError::Network { message }
+            }
             ApiError::Json(e) => ServiceError::InvalidJson {
                 message: e.to_string(),
             },
@@ -108,6 +123,7 @@ mod tests {
             code: Some("Pod".into()),
             server_message: Some("Pod not found".into()),
             data: None,
+            url: None,
         };
         let svc: ServiceError = (&err).into();
         assert!(matches!(
@@ -124,6 +140,7 @@ mod tests {
             code: Some("DB_DOWN".into()),
             server_message: Some("db unreachable".into()),
             data: None,
+            url: None,
         };
         let svc: ServiceError = (&err).into();
         match svc {
@@ -131,6 +148,29 @@ mod tests {
                 assert_eq!(status, 500);
                 assert_eq!(code.as_deref(), Some("DB_DOWN"));
                 assert_eq!(message, "db unreachable");
+            }
+            _ => panic!("expected Http variant"),
+        }
+    }
+
+    #[test]
+    fn http_502_with_url_appends_to_message() {
+        let err = ApiError::Http {
+            status: 502,
+            status_text: "Bad Gateway".into(),
+            code: None,
+            server_message: None,
+            data: None,
+            url: Some("http://localhost:25350/api/v1/users/me".into()),
+        };
+        let svc: ServiceError = (&err).into();
+        match svc {
+            ServiceError::Http { status, message, .. } => {
+                assert_eq!(status, 502);
+                assert!(
+                    message.contains("Bad Gateway") && message.contains("localhost:25350"),
+                    "expected message to include both status_text and url, got: {message}"
+                );
             }
             _ => panic!("expected Http variant"),
         }

--- a/clients/core/crates/api-client/src/request.rs
+++ b/clients/core/crates/api-client/src/request.rs
@@ -91,11 +91,12 @@ impl ApiClient {
         }
 
         let resp = builder.send().await?;
-        Self::parse_response(resp).await
+        Self::parse_response(resp, &url).await
     }
 
     async fn parse_response<T: DeserializeOwned>(
         resp: reqwest::Response,
+        url: &str,
     ) -> Result<T, ApiError> {
         let status = resp.status();
 
@@ -122,6 +123,7 @@ impl ApiClient {
                     .and_then(|v| v.as_str())
                     .map(String::from),
                 data: Some(body),
+                url: Some(url.to_string()),
             })
         }
     }
@@ -148,6 +150,6 @@ impl ApiClient {
         }
         builder = builder.multipart(form);
         let resp = builder.send().await?;
-        Self::parse_response(resp).await
+        Self::parse_response(resp, &url).await
     }
 }

--- a/clients/core/crates/api-client/src/tests.rs
+++ b/clients/core/crates/api-client/src/tests.rs
@@ -182,11 +182,17 @@ mod tests {
                 status,
                 code,
                 server_message,
+                url,
                 ..
             } => {
                 assert_eq!(*status, 422);
                 assert_eq!(code.as_deref(), Some("INVALID"));
                 assert_eq!(server_message.as_deref(), Some("bad input"));
+                // Regression guard: parse_response must tag every Http
+                // error with the request URL so wire errors are
+                // self-describing (2026-05-10 OrbStack incident).
+                let url = url.as_deref().expect("Http error must carry request url");
+                assert!(url.ends_with("/api/v1/validate"), "got url: {url}");
             }
             _ => panic!("expected Http error, got: {err:?}"),
         }
@@ -490,11 +496,14 @@ mod tests {
                 status,
                 code,
                 server_message,
+                url,
                 ..
             } => {
                 assert_eq!(status, 500);
                 assert!(code.is_none());
                 assert!(server_message.is_none());
+                let url = url.expect("Http error must carry request url");
+                assert!(url.ends_with("/api/v1/fail"), "got url: {url}");
             }
             _ => panic!("expected Http error"),
         }

--- a/clients/core/crates/ffi/src/tests.rs
+++ b/clients/core/crates/ffi/src/tests.rs
@@ -105,6 +105,7 @@ fn from_api_http_with_server_message() {
         code: None,
         server_message: Some("field invalid".into()),
         data: None,
+        url: None,
     }
     .into();
     match err {
@@ -126,6 +127,7 @@ fn from_api_http_falls_back_to_status_text() {
         code: None,
         server_message: None,
         data: None,
+        url: None,
     }
     .into();
     match err {
@@ -328,6 +330,7 @@ fn from_api_http_with_code_and_data() {
         code: Some("VALIDATION_ERROR".into()),
         server_message: Some("field invalid".into()),
         data: Some(serde_json::json!({"field": "email"})),
+        url: None,
     }
     .into();
     match err {
@@ -354,6 +357,7 @@ fn from_api_404_becomes_not_found() {
         code: Some("Pod".into()),
         server_message: None,
         data: None,
+        url: None,
     }
     .into();
     match err {

--- a/clients/desktop/e2e/tests/auth/cold-start-no-env.spec.ts
+++ b/clients/desktop/e2e/tests/auth/cold-start-no-env.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from "@playwright/test";
+import { _electron as electron } from "@playwright/test";
+import { resolve } from "node:path";
+import { rmSync } from "node:fs";
+import { getElectronMainPath, isCi } from "../../helpers/env";
+
+// Regression for the 2026-05-10 OrbStack incident, layer 1: the packaged
+// build must not fall back to localhost when AGENTSMESH_API_URL is unset.
+// In the original bug, an empty env triggered the magic
+// `?? "http://localhost:25350"` default, which OrbStack happened to occupy.
+//
+// After server_config.ts SSOT refactor, an unset env + missing server.json
+// resolves to DEFAULT (global → https://agentsmesh.ai). This test pins
+// that contract — anyone re-introducing a localhost fallback in
+// main/index.ts will trip this.
+
+const FRESH_USER_DATA = resolve(__dirname, "../../.auth/electron-userdata-cold-start-no-env");
+
+test.beforeEach(() => {
+  rmSync(FRESH_USER_DATA, { recursive: true, force: true });
+});
+
+test("packaged default points at prod when AGENTSMESH_API_URL unset", async () => {
+  const ciArgs = isCi() && process.platform === "linux"
+    ? ["--no-sandbox", "--disable-dev-shm-usage"]
+    : [];
+
+  // Strip AGENTSMESH_API_URL from inherited env. The dev shell or e2e
+  // runner may have set it; without this scrub the test would silently
+  // use the override path instead of the cold-start path it's pinning.
+  const env = Object.fromEntries(
+    Object.entries(process.env).filter(([k]) => k !== "AGENTSMESH_API_URL"),
+  );
+
+  const app = await electron.launch({
+    args: [getElectronMainPath(), `--user-data-dir=${FRESH_USER_DATA}`, ...ciArgs],
+    env: {
+      ...env,
+      NODE_ENV: "test",
+      ELECTRON_DISABLE_SECURITY_WARNINGS: "true",
+    },
+    timeout: isCi() ? 120_000 : 30_000,
+  });
+  try {
+    const page = await app.firstWindow();
+    await page.waitForLoadState("domcontentloaded");
+
+    const apiUrl = await page.evaluate(() => window.electronAPI.apiUrl);
+    expect(apiUrl).toBe("https://agentsmesh.ai");
+
+    const cfg = await page.evaluate(() => window.electronAPI.serverConfig.snapshot);
+    expect(cfg).toEqual({
+      kind: "global",
+      customLabel: "",
+      customUrl: "",
+    });
+  } finally {
+    await app.close().catch(() => undefined);
+  }
+});

--- a/clients/desktop/e2e/tests/auth/orbstack-port-conflict.spec.ts
+++ b/clients/desktop/e2e/tests/auth/orbstack-port-conflict.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from "@playwright/test";
+import { _electron as electron } from "@playwright/test";
+import { createServer, type Server } from "node:http";
+import { resolve } from "node:path";
+import { rmSync } from "node:fs";
+import { getElectronMainPath, isCi } from "../../helpers/env";
+
+// Regression for the 2026-05-10 OrbStack incident.
+//
+// Root cause: desktop main process used to fall back to
+// `http://localhost:25350` when AGENTSMESH_API_URL was unset. OrbStack
+// happened to listen on that port and returned `502 Bad Gateway` for any
+// request, surfacing as `Sign in failed: {"kind":"http","status":502,
+// "code":null,"message":"Bad Gateway"}` — completely opaque about WHICH
+// host produced the 502.
+//
+// The fix is two-layered:
+//   1. Remove the localhost:25350 fallback (server_config.ts owns defaults).
+//   2. Tag every ApiError::Http with the request URL so wire errors
+//      become self-describing.
+//
+// This spec pins layer 2: when the upstream returns 502, the message the
+// renderer sees MUST contain the URL it hit. Without that string, no user
+// can diagnose this class of bug from a screenshot.
+
+const FRESH_USER_DATA = resolve(__dirname, "../../.auth/electron-userdata-orbstack-conflict");
+
+let mockServer: Server;
+let mockPort: number;
+
+test.beforeAll(async () => {
+  mockServer = createServer((_req, res) => {
+    res.writeHead(502, { "Content-Type": "text/plain" });
+    res.end("Bad Gateway"); // mimic OrbStack's 11-byte body verbatim
+  });
+  await new Promise<void>((r) => mockServer.listen(0, "127.0.0.1", () => r()));
+  mockPort = (mockServer.address() as { port: number }).port;
+});
+
+test.afterAll(() => {
+  mockServer.close();
+});
+
+test.beforeEach(() => {
+  rmSync(FRESH_USER_DATA, { recursive: true, force: true });
+});
+
+test("502 from upstream surfaces the URL in the error message", async () => {
+  const ciArgs = isCi() && process.platform === "linux"
+    ? ["--no-sandbox", "--disable-dev-shm-usage"]
+    : [];
+  const app = await electron.launch({
+    args: [getElectronMainPath(), `--user-data-dir=${FRESH_USER_DATA}`, ...ciArgs],
+    env: {
+      ...process.env,
+      AGENTSMESH_API_URL: `http://127.0.0.1:${mockPort}`,
+      NODE_ENV: "test",
+      ELECTRON_DISABLE_SECURITY_WARNINGS: "true",
+    },
+    timeout: isCi() ? 120_000 : 30_000,
+  });
+  try {
+    const page = await app.firstWindow();
+    await page.waitForLoadState("domcontentloaded");
+
+    // Drive `userGetMe` directly via IPC (no need for actual login —
+    // Rust's UserApiService.get_me() hits /api/v1/users/me regardless of
+    // auth state, and our mock returns 502 for any path).
+    const errorMessage = await page.evaluate(async () => {
+      try {
+        await window.electronAPI.invoke("userGetMe");
+        return null;
+      } catch (e) {
+        return (e as Error).message;
+      }
+    });
+
+    expect(errorMessage).not.toBeNull();
+    // The wire error includes status 502.
+    expect(errorMessage).toContain("502");
+    // And — the load-bearing assertion — the URL the request hit. Without
+    // this, future regressions producing a 502 from the wrong host would
+    // be just as opaque as the original incident.
+    expect(errorMessage).toMatch(/127\.0\.0\.1|localhost/);
+  } finally {
+    await app.close().catch(() => undefined);
+  }
+});

--- a/clients/desktop/e2e/tests/auth/server-settings.spec.ts
+++ b/clients/desktop/e2e/tests/auth/server-settings.spec.ts
@@ -4,10 +4,9 @@ import { TEST_USER, TEST_ORG_SLUG, getApiBaseUrl } from "../../helpers/env";
 import { resolve } from "node:path";
 import { rmSync } from "node:fs";
 
-// Fresh Electron profile every run — the spec writes to localStorage
-// (the server config persists there), and we want a known starting
-// point on every invocation. Sharing userData with other auth specs
-// would race the persisted choice across runs.
+// Fresh Electron profile every run. After the SSOT refactor (2026-05-10),
+// server config persists at `userData/server.json` (NOT localStorage), so
+// each test starts from a clean disk to get deterministic defaults.
 const FRESH_USER_DATA = resolve(__dirname, "../../.auth/electron-userdata-server-settings");
 
 test.use({
@@ -19,40 +18,24 @@ test.beforeAll(() => {
   rmSync(FRESH_USER_DATA, { recursive: true, force: true });
 });
 
-// Per-test reset of the Electron profile. Each spec in this file mutates
-// the persisted server config via the modal AND occasionally completes a
-// real login (driving session blobs into FileStorage). Without per-test
-// cleanup, the second `await login.expectOnLoginPage()` lands on the
-// dashboard inherited from the previous spec's session file and times
-// out waiting for the /login hash. `skipAuthRestore` only stops the
-// fixture from auto-restoring; the storage on disk still hydrates the
-// renderer's bootstrap call.
+// Per-test reset of the Electron profile. Each spec mutates persisted
+// config + occasionally completes a real login (driving session blobs into
+// FileStorage). Without per-test cleanup, subsequent specs land on a
+// dashboard inherited from the prior session.
 test.beforeEach(() => {
   rmSync(FRESH_USER_DATA, { recursive: true, force: true });
 });
 
-const STORAGE_KEY = "agentsmesh.server_config_v2";
 const GLOBAL_URL = "https://agentsmesh.ai";
 const CN_URL = "https://agentsmesh.cn";
 
-// Radio order in the dialog: 0=global, 1=cn, 2=custom. Encoded as
-// constants so a re-order in the modal flips one place, not seven.
+// Radio order in the dialog: 0=global, 1=cn, 2=custom.
 const RADIO_GLOBAL = 0;
 const RADIO_CN = 1;
 const RADIO_CUSTOM = 2;
 
-async function readConfig(page: import("@playwright/test").Page) {
-  return page.evaluate((key) => {
-    const raw = window.localStorage.getItem(key);
-    return raw ? JSON.parse(raw) : null;
-  }, STORAGE_KEY);
-}
-
-async function seedConfig(page: import("@playwright/test").Page, value: unknown) {
-  await page.evaluate(
-    ([key, raw]) => window.localStorage.setItem(key as string, raw as string),
-    [STORAGE_KEY, JSON.stringify(value)],
-  );
+async function readSnapshot(page: import("@playwright/test").Page) {
+  return page.evaluate(() => window.electronAPI.serverConfig.snapshot);
 }
 
 async function openServerSettings(page: import("@playwright/test").Page) {
@@ -61,11 +44,9 @@ async function openServerSettings(page: import("@playwright/test").Page) {
 }
 
 test.describe("Auth · server settings", () => {
-  // The default preset must be **Global** (https://agentsmesh.ai), not
-  // the long-broken Cloud (https://app.agentsmesh.ai) which never
-  // resolved in production. This test guards that PR #336 stays the
-  // SSOT — if anyone re-introduces the bad host the dialog will show
-  // it inline as the selected preset's URL.
+  // Default preset = Global. PR #336 retired the broken `app.agentsmesh.ai`
+  // host; this test pins that the dialog never resurrects it after later
+  // refactors.
   test("default preset is Global with the correct host", async ({ page }) => {
     const login = new LoginPage(page);
     await login.expectOnLoginPage();
@@ -76,17 +57,14 @@ test.describe("Auth · server settings", () => {
     await expect(radios.nth(RADIO_CN)).not.toBeChecked();
     await expect(radios.nth(RADIO_CUSTOM)).not.toBeChecked();
 
-    // The Global preset row must surface its actual URL — anyone
-    // reintroducing app.agentsmesh.ai will trip this assertion.
     await expect(page.getByText(GLOBAL_URL)).toBeVisible();
     await expect(page.getByText(CN_URL)).toBeVisible();
     await expect(page.locator("text=app.agentsmesh.ai")).toHaveCount(0);
   });
 
-  // Switching to CN must persist `kind: "cn"` and reload the window —
-  // env.ts then resolves the active URL through the cn preset path.
-  // We don't try to log in (cn backend isn't reachable from CI), the
-  // localStorage assertion + footer label change is sufficient.
+  // Switching to CN persists `kind: "cn"` to userData/server.json and
+  // reloads the renderer. Main rebuilds AppState bound to the new URL —
+  // so renderer's preload snapshot reflects it on next read.
   test("switching to CN preset persists kind=cn", async ({ page }) => {
     const login = new LoginPage(page);
     await login.expectOnLoginPage();
@@ -97,63 +75,37 @@ test.describe("Auth · server settings", () => {
     await page.waitForLoadState("domcontentloaded");
     await login.expectOnLoginPage();
 
-    expect(await readConfig(page)).toEqual({
+    expect(await readSnapshot(page)).toEqual({
       kind: "cn",
       customLabel: "",
       customUrl: "",
     });
 
+    // The preload snapshot is the SSOT for `electronAPI.apiUrl` — main
+    // rebuilt AppState with this URL too.
+    const apiUrl = await page.evaluate(() => window.electronAPI.apiUrl);
+    expect(apiUrl).toBe(CN_URL);
+
     // Footer pill reflects the active preset.
     await expect(page.getByText(/AgentsMesh.*中国|AgentsMesh.*China/)).toBeVisible();
   });
 
-  // v0.30.x shipped `kind: "cloud"` pointing at app.agentsmesh.ai.
-  // After this PR, the dialog must read it as `global` so the user
-  // doesn't end up on a dead host. The localStorage record is left
-  // in v2 form (we don't eagerly rewrite); the migration is at the
-  // read site (normaliseKind in server-config.ts).
-  test("legacy kind=cloud migrates to Global on dialog open", async ({ page }) => {
+  test("custom server: pick → save → renderer hits chosen URL on next login", async ({ page }) => {
     const login = new LoginPage(page);
-    await login.goto();
     await login.expectOnLoginPage();
-
-    // Seed the legacy shape that v0.30.x desktops persisted.
-    await seedConfig(page, { kind: "cloud", customLabel: "", customUrl: "" });
-    await page.reload();
-    await login.expectOnLoginPage();
-
-    await openServerSettings(page);
-
-    // Global radio is checked even though the saved value says "cloud".
-    const radios = page.locator('input[type="radio"][name="kind"]');
-    await expect(radios.nth(RADIO_GLOBAL)).toBeChecked();
-  });
-
-  test("custom server: pick → save → reload → login goes to chosen URL", async ({ page }) => {
-    const login = new LoginPage(page);
-    // Reset to a clean slate — earlier tests may have persisted a
-    // preset choice on the shared profile.
-    await login.goto();
-    await page.evaluate((key) => window.localStorage.removeItem(key), STORAGE_KEY);
-    await page.reload();
-    await login.expectOnLoginPage();
-
     await openServerSettings(page);
 
     const radios = page.locator('input[type="radio"][name="kind"]');
     await expect(radios.nth(RADIO_GLOBAL)).toBeChecked();
 
-    // Custom inputs are hidden until the radio flips — the load-bearing
-    // UX guarantee. Verify they only appear after selection.
+    // Custom inputs are hidden until the radio flips.
     await expect(page.locator('input[placeholder*="https://your-server"]')).not.toBeVisible();
     await radios.nth(RADIO_CUSTOM).click();
     await expect(radios.nth(RADIO_CUSTOM)).toBeChecked();
     await expect(page.locator('input[placeholder*="https://your-server"]')).toBeVisible();
 
-    // Save the dev backend URL under a custom label. This same URL is
-    // what AGENTSMESH_API_URL pointed at on launch, so post-reload
-    // login still works — proving the user choice is what env.ts
-    // resolves to instead of the preload bridge default.
+    // Save the dev backend URL — same one AGENTSMESH_API_URL pointed at on
+    // launch, so post-reload login still works against the dev backend.
     const apiUrl = getApiBaseUrl();
     const customLabel = "Dev backend";
     const labelInput = page.locator('input[placeholder*="例如"], input[placeholder*="e.g."]');
@@ -165,12 +117,12 @@ test.describe("Auth · server settings", () => {
     await page.waitForLoadState("domcontentloaded");
     await login.expectOnLoginPage();
 
-    expect(await readConfig(page)).toEqual({ kind: "custom", customLabel, customUrl: apiUrl });
+    expect(await readSnapshot(page)).toEqual({ kind: "custom", customLabel, customUrl: apiUrl });
 
     await expect(page.getByText(customLabel)).toBeVisible();
 
-    // Sanity: the chosen URL drives the next request. Logging in works
-    // because apiUrl == AGENTSMESH_API_URL == the dev backend.
+    // Sanity: chosen URL drives the next request; login works because
+    // apiUrl == AGENTSMESH_API_URL == the dev backend.
     await login.login(TEST_USER.email, TEST_USER.password);
     await login.waitForLoginRedirect(TEST_ORG_SLUG);
   });
@@ -181,20 +133,17 @@ test.describe("Auth · server settings", () => {
     await login.expectOnLoginPage();
     await openServerSettings(page);
 
-    // Flip to custom, type something, then cancel — the saved config
-    // should still report the prior value (or null). Without this guard
-    // a "draft survives cancel" regression would persist half-typed
-    // URLs and surprise the user on next launch.
     await page.locator('input[type="radio"][name="kind"]').nth(RADIO_CUSTOM).click();
     const urlInput = page.locator('input[placeholder*="https://your-server"]');
     await expect(urlInput).toBeVisible();
     await urlInput.fill("https://abandoned.example.com");
     await page.getByRole("button", { name: /^取消$|^Cancel$/ }).click();
 
-    const cfg = await readConfig(page);
-    // cfg may be null (never saved), the seeded custom value from a
-    // prior test, or a preset — the regression is when it carries the
-    // abandoned URL.
-    expect(cfg?.customUrl ?? "").not.toContain("abandoned.example.com");
+    // No persistence — snapshot still default Global. Without this guard
+    // a "draft survives cancel" regression would write the abandoned URL
+    // through the IPC layer to disk.
+    const cfg = await readSnapshot(page);
+    expect(cfg.kind).toBe("global");
+    expect(cfg.customUrl).toBe("");
   });
 });

--- a/clients/desktop/src/main/index.ts
+++ b/clients/desktop/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, shell } from "electron";
+import { app, BrowserWindow, dialog, ipcMain, shell } from "electron";
 import path from "path";
 import { AppState } from "@agentsmesh/node-bridge";
 import { createLocalRunnerStubs, type LocalRunnerStubMap } from "./local_runner_stubs";
@@ -10,24 +10,54 @@ import {
   captureColdLaunchUrl,
   flushPendingUrl,
 } from "./oauth_deep_link";
+import * as serverConfig from "./server_config";
+import { isValidServerUrl } from "../shared/server-config-types";
 
-const apiUrl = process.env.AGENTSMESH_API_URL ?? "http://localhost:25350";
+// SSOT: server_config owns the persisted choice (server.json), main owns
+// the cold-start env override policy. Keeping the env-override resolution
+// out of server_config means that module stays a pure function library
+// (easier to test, harder to misuse from `serverConfig:set` handler).
+//
+// Cold-start resolution order:
+//   1. AGENTSMESH_API_URL env (dev / e2e / ad-hoc) — does NOT pollute the
+//      dialog SSOT, just redirects requests for this process lifetime.
+//   2. activeUrl(currentCfg) — server.json or DEFAULT.
+//
+// Once the user saves through the dialog, `serverConfig:set` rebinds to
+// `activeUrl(next)` directly, shadowing the env override.
+
+// Stashed at module load (before app.ready); flushed in whenReady so users
+// actually see the dialog. Calling dialog.showErrorBox at module load is
+// unreliable — most Electron dialog APIs assume app.ready has fired.
+let pendingStartupErrorMsg: string | null = null;
+
+function resolveColdStartApiUrl(cfg: serverConfig.ServerConfig): string {
+  const envOverride = process.env.AGENTSMESH_API_URL;
+  if (envOverride && isValidServerUrl(envOverride)) return envOverride;
+  try {
+    return serverConfig.activeUrl(cfg);
+  } catch (e) {
+    pendingStartupErrorMsg = (e as Error).message;
+    return serverConfig.activeUrl(serverConfig.DEFAULT);
+  }
+}
+
+let currentCfg = serverConfig.load();
+let currentApiUrl = resolveColdStartApiUrl(currentCfg);
+
 const storageDir = path.join(app.getPath("userData"), "agentsmesh");
 
 // Headless flag for e2e: keeps the window invisible + drops the macOS
 // dock icon so the test process doesn't steal focus from the user's IDE.
-// `global.setup.ts` sets `NODE_ENV=test` on every Electron launch.
 const isHeadlessTest = process.env.NODE_ENV === "test";
 
 let appState: AppState;
 let stubs: LocalRunnerStubMap | null = null;
 let mainWindow: BrowserWindow | null = null;
+const appStateHandlers = new Set<string>();
 
 const getMainWindow = () => mainWindow;
 
-// MUST run before whenReady — single-instance lock is acquired sync,
-// and "second-instance" can fire before whenReady on the duplicate
-// launch path.
 if (acquireSingleInstance()) {
   registerProtocol();
   attachSecondInstanceUrlHandler(getMainWindow);
@@ -42,8 +72,6 @@ function createWindow() {
     minHeight: 600,
     title: "AgentsMesh",
     show: !isHeadlessTest,
-    // Required when `show: false` — keeps the renderer painting so
-    // Playwright assertions (`expect(locator).toBeVisible`) still pass.
     paintWhenInitiallyHidden: true,
     skipTaskbar: isHeadlessTest,
     webPreferences: {
@@ -55,10 +83,6 @@ function createWindow() {
   });
 
   win.webContents.setWindowOpenHandler(({ url }) => {
-    // Filter to safe external schemes only. A bare `window.open()` or
-    // `<a target="_blank" href="">` produces `about:blank`, which when
-    // forwarded to shell.openExternal triggers macOS's "no app for
-    // about:blank" dialog. Same hazard for `chrome://` etc.
     if (/^https?:\/\//i.test(url) || url.startsWith("mailto:") || url.startsWith("agentsmesh://")) {
       shell.openExternal(url);
     }
@@ -79,14 +103,15 @@ function createWindow() {
   flushPendingUrl(getMainWindow);
 }
 
-function registerIpcHandlers() {
-  ipcMain.handle("shellOpen", async (_e, url: string) => {
-    // Same scheme guard as setWindowOpenHandler — renderer code that
-    // hands a bare/empty URL down the IPC must NOT pop the OS picker.
-    if (/^https?:\/\//i.test(url) || url.startsWith("mailto:") || url.startsWith("agentsmesh://")) {
-      await shell.openExternal(url);
-    }
-  });
+// Re-bind every IPC channel that fronts an `AppState` method. Called once
+// at boot and again when the user switches server (which constructs a new
+// AppState bound to the new base_url). Must `removeHandler` first because
+// `ipcMain.handle` throws on duplicate registration.
+function bindAppStateHandlers() {
+  for (const ch of appStateHandlers) {
+    ipcMain.removeHandler(ch);
+  }
+  appStateHandlers.clear();
 
   const proto = Object.getPrototypeOf(appState);
   const methodNames = Object.getOwnPropertyNames(proto).filter(
@@ -103,22 +128,108 @@ function registerIpcHandlers() {
         throw typeof err === "string" ? new Error(err) : err;
       }
     });
+    appStateHandlers.add(m);
   }
   console.log(`[electron] Registered ${methodNames.length} IPC handlers`);
 }
 
-app.whenReady().then(() => {
-  console.log(`[electron] Starting, API: ${apiUrl}, storage: ${storageDir}`);
-  // Drop the dock icon in headless e2e on macOS so the runner doesn't
-  // pull focus away from the user's editor mid-run.
-  if (isHeadlessTest && process.platform === "darwin") {
-    app.dock?.hide();
-  }
-  appState = new AppState(apiUrl, storageDir);
+// Replace the running AppState with one bound to a new base_url. Used when
+// the user picks a different server. Old service instances inside the prior
+// AppState are dropped naturally once their last `Arc` ref expires
+// (in-flight requests fade out without aborting).
+//
+// Known limitation: Rust services without explicit shutdown logic
+// (LocalRunnerManager, RelayManager) may keep tokio tasks alive past
+// the rebind, leaking until process exit. Fine in practice because
+// server switches are rare; would need graceful shutdown plumbing in
+// Rust core to fix properly.
+function rebindAppState(newApiUrl: string) {
+  console.log(`[electron] Rebinding AppState: ${currentApiUrl} → ${newApiUrl}`);
+  appState = new AppState(newApiUrl, storageDir);
+  // Stubs are scoped to the AppState that owns them — re-create alongside.
+  // (isHeadlessTest itself is fixed at startup; the conditional here is
+  // not a runtime check, just a "if we needed stubs before, we need them now".)
   if (isHeadlessTest) {
     stubs = createLocalRunnerStubs();
   }
-  registerIpcHandlers();
+  bindAppStateHandlers();
+  currentApiUrl = newApiUrl;
+}
+
+function registerStaticHandlers() {
+  ipcMain.handle("shellOpen", async (_e, url: string) => {
+    if (/^https?:\/\//i.test(url) || url.startsWith("mailto:") || url.startsWith("agentsmesh://")) {
+      await shell.openExternal(url);
+    }
+  });
+
+  // server-config IPC. The sync variants are deliberate: preload reads
+  // them at boot to populate `window.electronAPI.apiUrl` / serverConfig
+  // .snapshot synchronously, so renderer's getApiBaseUrl() stays
+  // synchronous (no async ceremony in OAuth/WS hot paths).
+  //
+  // The Electron sync-IPC anti-pattern warning is about runtime calls
+  // that block the renderer's UI thread; here the call happens during
+  // preload BEFORE any renderer code runs, so there's no UI to block.
+  // On `mainWindow.reload()`, preload re-executes and re-reads — that's
+  // also how we propagate `serverConfig:set` updates without a separate
+  // mutable IPC channel.
+  //
+  // Invariant: registerStaticHandlers() MUST run before createWindow()
+  // so the sync handlers exist when preload sends. Enforced by ordering
+  // in app.whenReady() below.
+  ipcMain.on("serverConfig:getActiveUrlSync", (e) => {
+    e.returnValue = currentApiUrl;
+  });
+  ipcMain.on("serverConfig:getSync", (e) => {
+    e.returnValue = currentCfg;
+  });
+  ipcMain.handle("serverConfig:get", () => serverConfig.load());
+  ipcMain.handle("serverConfig:set", async (_e, raw: serverConfig.ServerConfig) => {
+    // `raw` is whatever the renderer (or a misbehaving stub) sent over
+    // IPC — type-erased at the boundary. Validate via activeUrl first
+    // (throws on malformed custom URL → propagates back to dialog), then
+    // let `save` normalise + persist. Use `save`'s return value as the new
+    // currentCfg so memory and disk stay byte-identical; assigning `raw`
+    // directly was the third-round bug.
+    serverConfig.activeUrl(raw); // validate, throw on invalid
+    const next = serverConfig.save(raw);
+    const newUrl = serverConfig.activeUrl(next);
+    currentCfg = next;
+    if (newUrl !== currentApiUrl) {
+      rebindAppState(newUrl);
+    }
+    // Always reload renderer after a save — preload's sync snapshot of
+    // serverConfig is captured at boot, so even when the resolved URL
+    // doesn't change (e.g. env override masks both old and new), the
+    // *cfg* fields the dialog reads can have changed (kind/custom* etc).
+    // Reloading is the cheap way to re-snapshot without a separate
+    // mutable IPC channel.
+    mainWindow?.reload();
+  });
+}
+
+app.whenReady().then(() => {
+  console.log(`[electron] Starting, API: ${currentApiUrl}, storage: ${storageDir}`);
+  if (isHeadlessTest && process.platform === "darwin") {
+    app.dock?.hide();
+  }
+  // Surface any startup error stashed during module load (server.json
+  // pointed at a malformed custom URL etc.). Dialog APIs need app.ready,
+  // which is why we deferred this from `resolveColdStartApiUrl`.
+  if (pendingStartupErrorMsg) {
+    dialog.showErrorBox(
+      "Invalid server configuration",
+      `${pendingStartupErrorMsg}\n\nFalling back to AgentsMesh Global. Open Server Settings to pick a different server.`,
+    );
+    pendingStartupErrorMsg = null;
+  }
+  appState = new AppState(currentApiUrl, storageDir);
+  if (isHeadlessTest) {
+    stubs = createLocalRunnerStubs();
+  }
+  registerStaticHandlers();
+  bindAppStateHandlers();
   installOpenUrlHandler(getMainWindow);
   createWindow();
 

--- a/clients/desktop/src/main/server_config.ts
+++ b/clients/desktop/src/main/server_config.ts
@@ -1,0 +1,91 @@
+import { app } from "electron";
+import fs from "fs";
+import path from "path";
+import {
+  PRESETS,
+  DEFAULT_SERVER_CONFIG,
+  isValidServerUrl,
+  type ServerConfig,
+  type ServerKind,
+} from "../shared/server-config-types";
+
+// SSOT for which AgentsMesh server this process talks to. Owned by main —
+// renderer reads a snapshot via sync IPC at preload time, writes via the
+// `serverConfig:set` IPC handler which triggers AppState rebuild + window
+// reload. Persisted at `userData/server.json` so the choice survives
+// restarts.
+//
+// Two reasons this lives in main, not renderer:
+//   1. Rust core's ApiClient binds base_url at construction. If renderer
+//      held the SSOT, main wouldn't see switches → me/refresh requests would
+//      hit the previous host (the bug we found 2026-05-10).
+//   2. preload + main both need it BEFORE the renderer boots, so renderer
+//      localStorage is too late.
+//
+// This module is **pure** (modulo `app.getPath("userData")` for file
+// location): no env reads, no global mutation, no dialog calls. The
+// cold-start AGENTSMESH_API_URL escape hatch + UX error reporting both
+// live in main/index.ts where they belong.
+
+export type { ServerConfig, ServerKind };
+export { PRESETS, DEFAULT_SERVER_CONFIG as DEFAULT };
+
+const FILE_NAME = "server.json";
+
+function configPath(): string {
+  return path.join(app.getPath("userData"), FILE_NAME);
+}
+
+function normaliseKind(raw: unknown): ServerKind {
+  if (raw === "cn" || raw === "custom") return raw;
+  return "global"; // legacy "cloud" alias + safe default for anything unexpected
+}
+
+function normaliseStringField(raw: unknown): string {
+  return typeof raw === "string" ? raw.trim() : "";
+}
+
+function readFromDisk(): ServerConfig | null {
+  try {
+    const raw = fs.readFileSync(configPath(), "utf8");
+    const parsed = JSON.parse(raw) as Partial<ServerConfig> & { kind?: unknown };
+    return {
+      kind: normaliseKind(parsed.kind),
+      customLabel: normaliseStringField(parsed.customLabel),
+      customUrl: normaliseStringField(parsed.customUrl),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function load(): ServerConfig {
+  return readFromDisk() ?? { ...DEFAULT_SERVER_CONFIG };
+}
+
+// Persist `cfg` to disk and return the **normalised** view that was
+// actually written. Callers should use the return value for any in-memory
+// state (e.g. main's `currentCfg`) so disk and memory stay byte-identical
+// — passing through the raw `cfg` would let untrimmed fields linger in
+// memory until the next reload.
+export function save(cfg: ServerConfig): ServerConfig {
+  const next: ServerConfig = {
+    kind: normaliseKind(cfg.kind),
+    customLabel: normaliseStringField(cfg.customLabel),
+    customUrl: normaliseStringField(cfg.customUrl),
+  };
+  const tmp = configPath() + ".tmp";
+  fs.writeFileSync(tmp, JSON.stringify(next), "utf8");
+  fs.renameSync(tmp, configPath()); // atomic on same filesystem
+  return next;
+}
+
+// Resolve to the actual URL the ApiClient should hit. Throws on invalid
+// custom config — caller should surface the error in a dialog rather than
+// silently falling back to DEFAULT (which would hide misconfiguration).
+export function activeUrl(cfg: ServerConfig): string {
+  if (cfg.kind === "global") return PRESETS.global.url;
+  if (cfg.kind === "cn") return PRESETS.cn.url;
+  if (isValidServerUrl(cfg.customUrl)) return cfg.customUrl;
+  throw new Error(`Invalid custom server URL: "${cfg.customUrl}"`);
+}

--- a/clients/desktop/src/preload/index.ts
+++ b/clients/desktop/src/preload/index.ts
@@ -1,6 +1,23 @@
 import { contextBridge, ipcRenderer, IpcRendererEvent } from "electron";
+import { type ServerConfig } from "../shared/server-config-types";
 
-const apiUrl = process.env.AGENTSMESH_API_URL ?? "http://localhost:25350";
+// Sync IPC at preload time — main owns the SSOT, but renderer code
+// (env.ts, OAuth URL builders, WS connect) is synchronous. Reading once
+// at preload keeps renderer sync. The sync handler runs BEFORE any
+// renderer code, so it doesn't block a UI thread; on `mainWindow.reload()`
+// preload re-executes and re-reads, propagating `serverConfig:set`
+// updates without a separate mutable channel.
+//
+// No defensive try/catch here: `sendSync` blocks indefinitely if the
+// handler isn't registered (Electron API), so a `try/catch` over it can
+// only catch a structural failure that doesn't actually happen in
+// practice. Letting any genuine failure propagate makes it visible — a
+// silent fallback to "" would render OAuth URLs as relative paths and
+// fail in obscure ways downstream. Invariant: main MUST register the
+// `serverConfig:*Sync` handlers before createWindow() (enforced by
+// ordering in main/index.ts).
+const apiUrl = ipcRenderer.sendSync("serverConfig:getActiveUrlSync") as string;
+const serverConfigSnapshot = ipcRenderer.sendSync("serverConfig:getSync") as ServerConfig;
 
 const api = {
   apiUrl,
@@ -18,6 +35,15 @@ const api = {
     const listener = (_e: IpcRendererEvent, url: string) => handler(url);
     ipcRenderer.on("oauth:callback", listener);
     return () => ipcRenderer.removeListener("oauth:callback", listener);
+  },
+  serverConfig: {
+    snapshot: serverConfigSnapshot,
+    get: () => ipcRenderer.invoke("serverConfig:get"),
+    // After set, main reloads the renderer to re-snapshot. This Promise
+    // resolves *before* the reload fires (handler returns first), but
+    // any work done in the renderer between resolve and reload is about
+    // to be torn down — callers shouldn't depend on it.
+    set: (cfg: ServerConfig) => ipcRenderer.invoke("serverConfig:set", cfg),
   },
 };
 

--- a/clients/desktop/src/renderer/lib/env.ts
+++ b/clients/desktop/src/renderer/lib/env.ts
@@ -1,42 +1,34 @@
 /**
- * Environment helpers for the Electron renderer. Distinct from the web
- * build's env.ts because:
- *   - `window.location.origin` points at the Vite dev server, not the backend.
- *   - The Electron main process knows the backend URL and publishes it via
- *     the preload bridge (`window.electronAPI.apiUrl`).
+ * Renderer-side base_url accessor.
  *
- * Resolution priority (top wins):
- *   1. User-selected server from server-config.ts (set via the Server
- *      Settings dialog on the login screen — switching reloads the
- *      window so all in-flight callers re-resolve through this path).
- *   2. Preload bridge — the launch-time AGENTSMESH_API_URL env, used
- *      until the user picks a server explicitly.
- *   3. Build-time Vite env override (CI / dev).
- *   4. localhost dev port baked into BUILTIN_SERVERS.
+ * SSOT lives in main (`server_config.ts`). Preload sync-injects the
+ * resolved active URL onto `window.electronAPI.apiUrl` at boot, so all
+ * accessors here are O(1) reads of that snapshot. When the user switches
+ * servers, main reloads the window — preload re-reads, snapshot is
+ * never stale within a process lifetime.
+ *
+ * No `?? "http://localhost:25350"` fallback. The 2026-05-10 incident
+ * proved that any "friendly default" pointing at a local port is a
+ * footgun the moment something else (OrbStack, Docker Desktop, ...)
+ * decides to listen there.
+ *
+ * Multiple accessor names exist as an INTERFACE CONTRACT, not redundancy:
+ * desktop's vite config aliases `@/lib/env` to THIS file but also resolves
+ * `@/hooks` etc. to the web source tree. Web hooks like `useServerUrl`
+ * import `getServerUrl` / `getServerUrlSSR`, so removing those names here
+ * breaks the desktop bundle. They all return the same value because
+ * desktop has no SSR; the names are kept as adapter shims for cross-bundle
+ * imports.
  */
 
-import { getActiveUrl } from "./server-config";
-
-const DEFAULT_API_URL = "http://localhost:25350";
-
-function getConfiguredUrl(): string {
-  const fromUser = getActiveUrl();
-  if (fromUser) return fromUser;
-  if (typeof window !== "undefined" && window.electronAPI?.apiUrl) {
-    return window.electronAPI.apiUrl;
-  }
-  if (import.meta.env.VITE_API_URL) {
-    return import.meta.env.VITE_API_URL;
-  }
-  return DEFAULT_API_URL;
+export function getApiBaseUrl(): string {
+  return window.electronAPI.apiUrl;
 }
-
-export function getApiBaseUrl(): string { return getConfiguredUrl(); }
-export function getOAuthBaseUrl(): string { return getConfiguredUrl(); }
 
 export function getWsBaseUrl(): string {
-  return getConfiguredUrl().replace(/^http/, "ws");
+  return window.electronAPI.apiUrl.replace(/^http/, "ws");
 }
 
-export function getServerUrl(): string { return getConfiguredUrl(); }
-export function getServerUrlSSR(): string { return getConfiguredUrl(); }
+// Adapter shims for web-tree code reused via vite alias. See module doc.
+export function getServerUrl(): string { return window.electronAPI.apiUrl; }
+export function getServerUrlSSR(): string { return window.electronAPI.apiUrl; }

--- a/clients/desktop/src/renderer/lib/server-config.ts
+++ b/clients/desktop/src/renderer/lib/server-config.ts
@@ -1,72 +1,28 @@
+import {
+  PRESETS,
+  isValidServerUrl,
+  type ServerConfig,
+  type ServerKind,
+} from "../../shared/server-config-types";
+
 /**
- * Server selection for the Electron desktop renderer.
+ * Renderer-side facade over the main-process server-config SSOT.
  *
- * Three modes:
- *   - "global": built-in pointer at agentsmesh.ai (production global).
- *   - "cn":     built-in pointer at agentsmesh.cn (production China).
- *   - "custom": user-supplied URL + label.
- *
- * Persisted as a single object in localStorage. Schema is forward-
- * compatible: bump STORAGE_KEY to invalidate clients on shape break.
- *
- * Legacy migration: v0.30.x and earlier shipped a single "cloud"
- * preset pointing at app.agentsmesh.ai (which never existed in
- * production). We silently treat any saved kind: "cloud" as
- * kind: "global" and drop the bad app. host. The localStorage
- * record is left in v2 form until the user next saves through the
- * dialog — readRaw normalises it on the way out, no eager rewrite.
+ * Read path: `getConfig()` returns the snapshot preload sync-injected at
+ * boot; AuthShell can render the label without async ceremony.
+ * Write path: `saveConfig()` round-trips through main, which persists
+ * `userData/server.json` + reloads the window so preload re-snapshots and
+ * Rust core's ApiClient picks up the new base_url. There is **no**
+ * localStorage anymore — keeping a renderer-side persisted copy was the
+ * bug that left main's AppState bound to a stale URL while renderer
+ * happily showed a switched server.
  */
-const STORAGE_KEY = "agentsmesh.server_config_v2";
 
-const PRESETS: Record<"global" | "cn", { label: string; url: string }> = {
-  global: { label: "AgentsMesh Global", url: "https://agentsmesh.ai" },
-  cn: { label: "AgentsMesh 中国", url: "https://agentsmesh.cn" },
-};
-
-export type ServerKind = "global" | "cn" | "custom";
-
-export interface ServerConfig {
-  kind: ServerKind;
-  customLabel: string;
-  customUrl: string;
-}
-
-const DEFAULT_CONFIG: ServerConfig = {
-  kind: "global",
-  customLabel: "",
-  customUrl: "",
-};
-
-function normaliseKind(raw: unknown): ServerKind {
-  if (raw === "cn" || raw === "custom") return raw;
-  // "cloud" is the legacy alias for "global"; anything else falls
-  // through to the safe default.
-  return "global";
-}
-
-function readRaw(): ServerConfig | null {
-  if (typeof window === "undefined") return null;
-  try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as Partial<ServerConfig> & { kind?: unknown };
-    return {
-      kind: normaliseKind(parsed.kind),
-      customLabel: typeof parsed.customLabel === "string" ? parsed.customLabel : "",
-      customUrl: typeof parsed.customUrl === "string" ? parsed.customUrl : "",
-    };
-  } catch {
-    return null;
-  }
-}
-
-function writeRaw(cfg: ServerConfig): void {
-  if (typeof window === "undefined") return;
-  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(cfg));
-}
+export type { ServerConfig, ServerKind };
+export { isValidServerUrl };
 
 export function getConfig(): ServerConfig {
-  return readRaw() ?? { ...DEFAULT_CONFIG };
+  return window.electronAPI.serverConfig.snapshot;
 }
 
 export function getPresets(): { kind: "global" | "cn"; label: string; url: string }[] {
@@ -76,52 +32,19 @@ export function getPresets(): { kind: "global" | "cn"; label: string; url: strin
   ];
 }
 
-/**
- * Human-readable label for the currently selected server. The footer
- * pill in AuthShell uses this to show the user what they're connected
- * to. Custom mode falls back to the preset name when the user hasn't
- * supplied a label, so we never render an empty pill.
- */
 export function getActiveLabel(cfg: ServerConfig): string {
   if (cfg.kind === "custom" && cfg.customLabel.trim()) return cfg.customLabel;
   if (cfg.kind === "cn") return PRESETS.cn.label;
   return PRESETS.global.label;
 }
 
-/**
- * Resolves the URL the renderer should hit. Returns null when no
- * explicit choice has been made yet — env.ts then falls back to the
- * preload-bridge default (AGENTSMESH_API_URL the main process was
- * launched with), which is what dev / e2e / packaged users want
- * out of the box. Only returns a URL once the user has actively
- * picked one through the Server Settings dialog.
- *
- * In custom mode the URL is also nullable when the saved value is
- * malformed — env.ts again falls back rather than 404'ing every
- * request against an invalid origin.
- */
-export function getActiveUrl(): string | null {
-  const cfg = readRaw();
-  if (!cfg) return null;
-  if (cfg.kind === "global") return PRESETS.global.url;
-  if (cfg.kind === "cn") return PRESETS.cn.url;
-  if (cfg.kind === "custom" && isValidServerUrl(cfg.customUrl)) return cfg.customUrl;
-  return null;
-}
-
-export function saveConfig(next: ServerConfig): void {
-  writeRaw({
+// Write-side. Main reloads the window after save (the IPC resolves first,
+// then renderer is torn down) — callers shouldn't depend on work scheduled
+// after `await saveConfig`.
+export async function saveConfig(next: ServerConfig): Promise<void> {
+  await window.electronAPI.serverConfig.set({
     kind: next.kind,
     customLabel: next.customLabel.trim(),
     customUrl: next.customUrl.trim(),
   });
-}
-
-export function isValidServerUrl(value: string): boolean {
-  try {
-    const u = new URL(value);
-    return u.protocol === "http:" || u.protocol === "https:";
-  } catch {
-    return false;
-  }
 }

--- a/clients/desktop/src/renderer/pages/auth/login/OAuthButtons.tsx
+++ b/clients/desktop/src/renderer/pages/auth/login/OAuthButtons.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { getOAuthBaseUrl } from "@/lib/env";
+import { getApiBaseUrl } from "@/lib/env";
 
 function GitHubIcon() {
   return (
@@ -36,7 +36,7 @@ function GoogleIcon() {
 }
 
 async function handleOAuth(provider: "github" | "google") {
-  const oauthUrl = getOAuthBaseUrl();
+  const oauthUrl = getApiBaseUrl();
   // Deep-link callback: backend 302's to `agentsmesh://oauth/callback?token=...`,
   // OS hands the URL back to the desktop app via open-url (mac) / second-instance
   // argv (win), main process forwards over IPC, renderer navigates to /auth/callback.

--- a/clients/desktop/src/renderer/pages/auth/login/ServerSettingsModal.tsx
+++ b/clients/desktop/src/renderer/pages/auth/login/ServerSettingsModal.tsx
@@ -13,10 +13,14 @@ import { useAuthStore } from "@/stores/auth";
 /**
  * Three-mode picker: AgentsMesh Global, AgentsMesh 中国, or 自定义服务器.
  * Custom URL/label inputs only appear when 自定义 is selected, keeping
- * the dialog uncluttered for the 95% who pick a preset. Saving + Connect
- * reloads the window so env.ts re-resolves the active URL on next render —
- * there's no clean way to hot-swap the API origin while sockets/fetches
- * are in flight.
+ * the dialog uncluttered for the 95% who pick a preset.
+ *
+ * Save flow: `saveConfig` round-trips through main, which persists
+ * `userData/server.json`, rebuilds the Rust `AppState` if the resolved
+ * URL changed, and calls `mainWindow.reload()` to refresh preload's
+ * sync snapshot. The IPC resolves *before* the reload navigation fires,
+ * so anything queued in the renderer between `await saveConfig` and
+ * the reload is about to be torn down.
  */
 export function ServerSettingsModal({ open, onOpenChange }: {
   open: boolean;
@@ -55,22 +59,37 @@ function ServerSettingsForm({ onClose }: { onClose: () => void }) {
       }
     }
     // Switching server == logging out: tokens/identity for the previous
-    // server are not valid against the new one, and silently leaving them
-    // in storage would cause RootRedirect → dashboard → 401 cascade after
-    // reload. AWAIT logout — without it, `reload()` races the IPC
-    // round-trip and `reset_local()` may not have committed before the
-    // renderer reloads, leaving a stale session blob on disk.
+    // server are not valid against the new one. Wipe local session before
+    // we hand off to main — main will rebuild AppState + reload the window
+    // on save, so the renderer boots clean against the new base_url.
+    //
+    // Logout MUST be fail-soft: a common reason to switch is that the old
+    // server is unreachable. If the /auth/logout API call throws (network,
+    // 5xx, anything), we still want to proceed with the switch — Rust core
+    // will wipe local tokens during the AppState rebuild either way, and
+    // mainWindow.reload() starts a clean session.
     const wasAuthed = useAuthStore.getState().isAuthenticated();
     if (wasAuthed) {
       const ok = window.confirm(
         "切换服务器将登出当前账号，是否继续？\n\nSwitching server will log you out of the current account."
       );
       if (!ok) return;
-      await useAuthStore.getState().logout();
+      await useAuthStore.getState().logout().catch((err) => {
+        console.warn("[server-switch] logout failed (proceeding anyway):", err);
+      });
     }
-    saveConfig(draft);
+    try {
+      await saveConfig(draft);
+    } catch (e) {
+      // Main rejects when activeUrl() throws (custom URL malformed past
+      // the renderer's pre-check). Surface inline; don't close the dialog.
+      setError((e as Error).message || t("auth.loginPage.serverInvalidUrl"));
+      return;
+    }
     onClose();
-    window.location.reload();
+    // No reload here — main calls mainWindow.reload() if the URL actually
+    // changed. If we get past `await saveConfig` it means no-op save
+    // (same URL); closing the dialog is enough.
   };
 
   return (

--- a/clients/desktop/src/renderer/pages/auth/register/RegisterPage.tsx
+++ b/clients/desktop/src/renderer/pages/auth/register/RegisterPage.tsx
@@ -6,7 +6,7 @@ import { Input } from "@/components/ui/input";
 import { useAuthStore } from "@/stores/auth";
 import { authApi } from "@/lib/api";
 import { useTranslations } from "next-intl";
-import { getOAuthBaseUrl } from "@/lib/env";
+import { getApiBaseUrl } from "@/lib/env";
 import { Logo } from "@/components/common";
 
 export function RegisterPage() {
@@ -224,7 +224,7 @@ export function RegisterPage() {
             variant="outline"
             type="button"
             onClick={async () => {
-              const oauthUrl = getOAuthBaseUrl();
+              const oauthUrl = getApiBaseUrl();
               const redirectUrl = encodeURIComponent("agentsmesh://oauth/callback");
               const url = `${oauthUrl}/api/v1/auth/oauth/github?redirect=${redirectUrl}`;
               const { open } = await import("@/shims/electron-shell");
@@ -243,7 +243,7 @@ export function RegisterPage() {
             variant="outline"
             type="button"
             onClick={async () => {
-              const oauthUrl = getOAuthBaseUrl();
+              const oauthUrl = getApiBaseUrl();
               const redirectUrl = encodeURIComponent("agentsmesh://oauth/callback");
               const url = `${oauthUrl}/api/v1/auth/oauth/google?redirect=${redirectUrl}`;
               const { open } = await import("@/shims/electron-shell");

--- a/clients/desktop/src/shared/server-config-types.ts
+++ b/clients/desktop/src/shared/server-config-types.ts
@@ -1,0 +1,38 @@
+// Shared between main / preload / renderer. Pure data + pure helpers,
+// NO i/o, NO process-specific imports — so it compiles cleanly in all
+// three Electron contexts (node main, sandboxed preload, browser
+// renderer). Edit a preset URL or the validation rule here and all
+// three boundaries update together.
+
+export type ServerKind = "global" | "cn" | "custom";
+
+export interface ServerConfig {
+  kind: ServerKind;
+  customLabel: string;
+  customUrl: string;
+}
+
+export const PRESETS: Record<"global" | "cn", { label: string; url: string }> = {
+  global: { label: "AgentsMesh Global", url: "https://agentsmesh.ai" },
+  cn: { label: "AgentsMesh 中国", url: "https://agentsmesh.cn" },
+};
+
+export const DEFAULT_SERVER_CONFIG: ServerConfig = {
+  kind: "global",
+  customLabel: "",
+  customUrl: "",
+};
+
+// HTTP/HTTPS URL validator. Lives here because every trust boundary that
+// accepts a server URL — env override (main), persisted custom URL
+// (main), dialog input (renderer) — must agree on what counts as valid.
+// Splitting the rule across processes was how `app.agentsmesh.ai` slipped
+// through pre-PR-#336.
+export function isValidServerUrl(value: string): boolean {
+  try {
+    const u = new URL(value);
+    return u.protocol === "http:" || u.protocol === "https:";
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the 2026-05-10 OrbStack 502 incident where packaged desktop GUI launches without `AGENTSMESH_API_URL` fell back to `http://localhost:25350`, which OrbStack happened to occupy and return 502 for every path. The error surfaced as opaque `Sign in failed: {"kind":"http","status":502,"message":"Bad Gateway"}` with no URL trace.

Three-layer fix:

1. **Server-config SSOT collapsed to main process.** `userData/server.json` is the single source of truth; renderer reads a sync-injected preload snapshot, writes via IPC. No more localStorage / preload-env / main-env triple-source bug where switching servers in the dialog only updated renderer state while main's `AppState` stayed bound to the previous URL.
2. **Cold-start `AGENTSMESH_API_URL` demoted to escape hatch.** Redirects requests but does NOT pollute the dialog SSOT. `localhost:25350` fallback replaced by `DEFAULT = AgentsMesh Global` (`https://agentsmesh.ai`) — packaged GUI launches hit prod by default.
3. **Rust `ApiError::Http` carries the request URL.** Wire `message` now reads `Bad Gateway @ http://...` instead of opaque `Bad Gateway` — future 5xx is self-describing.

## What this fixes

Before: `userGetMe IPC → Rust ApiClient → http://localhost:25350/api/v1/users/me → OrbStack 502 → opaque error`

After: main bound to `https://agentsmesh.ai` from cold start; if env override / custom server is misconfigured, the wire error tells you which host returned 5xx.

## Architecture changes

- New `clients/desktop/src/shared/server-config-types.ts` — single edit site for `ServerConfig` / `PRESETS` / `DEFAULT` / `isValidServerUrl`. Used by all three Electron processes.
- New `clients/desktop/src/main/server_config.ts` — pure function module, owns `userData/server.json` round-trip. No env reads, no global state. `save()` returns normalised view; main uses it for in-memory state so disk/memory are byte-identical.
- New `clients/desktop/src/main/index.ts:rebindAppState()` — server switch rebuilds `AppState` + reloads window. Old service `Arc`s drop naturally.
- Renderer is now a pure read-only client of the snapshot. Switching server goes through IPC, main writes file + rebuilds Rust core + reloads renderer.

## Resolved drift

- `save()` returns normalised; set handler uses return value as `currentCfg` (memory/disk byte-identical)
- `save` / `readFromDisk` both normalise via the same helper (trim)
- `dialog.showErrorBox` for invalid `server.json` deferred to `app.whenReady()` (Electron dialog APIs need app ready)
- Three duplicated `isValidUrl` helpers collapsed into one in `shared/`
- Dead `activeLabel` export removed from `main/server_config.ts`
- Preload's silent `sendSync` fallback removed — failures are visible
- `ServerSettingsModal` logout is fail-soft (old server often unreachable when user switches)

## Test plan

- [x] `bazel test //clients/core/crates/api-client:api_client_test` PASSED (added URL-injection regression assertions to existing 422/500 e2e mock tests)
- [x] `bazel test //clients/core/crates/ffi:ffi_test` PASSED
- [x] `bazel test //clients/desktop:lint` PASSED
- [x] `bazel build //clients/desktop:out` PASSED
- [x] `bazel test //clients/desktop:e2e` — Auth + smoke + 3 new specs + 5 existing specs, 100s, all green
- [x] New e2e: `cold-start-no-env.spec.ts` (packaged default = prod), `orbstack-port-conflict.spec.ts` (ApiError carries URL), rewritten `server-settings.spec.ts` (new SSOT)

## User-side activation

After merge + next desktop release, packaged users will hit prod by default without any env. For old installs in the wild, temporary workaround:

\`\`\`bash
launchctl setenv AGENTSMESH_API_URL https://agentsmesh.ai
killall AgentsMesh && open -a AgentsMesh
\`\`\`

## Follow-ups (intentionally out of scope)

- `:main` / `:renderer` ts_project targets are pre-existing broken (no `@agentsmesh/node-bridge` .d.ts) — not worse, not better with this PR
- localStorage v2 → server.json migration: not done (UX loss = user re-picks server once)
- `refresh.rs` URL injection: only goes to tracing log, not user-facing wire
- AppState graceful shutdown on `rebindAppState`: server switches are rare, leak acceptable