### PR TITLE
fix(desktop-e2e): bump firstWindow timeout to 90s on CI

### DIFF
--- a/clients/desktop/e2e/fixtures/electron.fixture.ts
+++ b/clients/desktop/e2e/fixtures/electron.fixture.ts
@@ -57,7 +57,12 @@ export const test = base.extend<ElectronFixtures>({
   },
 
   page: async ({ electronApp, authFile, skipAuthRestore }, use) => {
-    const page = await electronApp.firstWindow();
+    // firstWindow() defaults to playwright's 30s timeout, but the
+    // macmini-03 self-hosted runner cold-starts the Electron renderer
+    // in 30-60s under load (Bazel cache restore + electron-vite bundle
+    // resolution + Rust core init via NAPI). Match the launch timeout
+    // window — repeated CI failures on main were all this one assertion.
+    const page = await electronApp.firstWindow({ timeout: isCi() ? 90_000 : 30_000 });
     await page.waitForLoadState("domcontentloaded");
 
     if (!skipAuthRestore) {

--- a/clients/desktop/e2e/global.setup.ts
+++ b/clients/desktop/e2e/global.setup.ts
@@ -37,7 +37,10 @@ setup("authenticate as test user (Electron)", async () => {
   });
 
   try {
-    const page = await app.firstWindow();
+    // See electron.fixture.ts: macmini-03 cold-starts the renderer in
+    // 30-60s; the default 30s firstWindow timeout was tripping the
+    // global setup before any spec even ran.
+    const page = await app.firstWindow({ timeout: isCi() ? 90_000 : 30_000 });
     page.on("pageerror", (err) => console.log(`[pageerror]`, err.message));
     await page.waitForLoadState("domcontentloaded");
 

--- a/clients/desktop/e2e/tests/auth/logout-survives-restart.spec.ts
+++ b/clients/desktop/e2e/tests/auth/logout-survives-restart.spec.ts
@@ -69,7 +69,7 @@ test.describe("Auth · logout survives restart", () => {
       timeout: isCi() ? 120_000 : 30_000,
     });
     try {
-      const page2 = await app2.firstWindow();
+      const page2 = await app2.firstWindow({ timeout: isCi() ? 90_000 : 30_000 });
       await page2.waitForLoadState("domcontentloaded");
 
       // Bootstrap is async; give it a beat to settle before asserting route.

--- a/clients/desktop/e2e/tests/auth/server-switch-clears-session.spec.ts
+++ b/clients/desktop/e2e/tests/auth/server-switch-clears-session.spec.ts
@@ -52,7 +52,7 @@ test.describe("Auth · server switch clears session", () => {
       timeout: isCi() ? 120_000 : 30_000,
     });
     try {
-      const page2 = await app2.firstWindow();
+      const page2 = await app2.firstWindow({ timeout: isCi() ? 90_000 : 30_000 });
       await page2.waitForLoadState("domcontentloaded");
       await page2.waitForTimeout(2000); // bootstrap settles
 


### PR DESCRIPTION
## Summary

main has been red on `E2E (Desktop — Electron)` every recent push (runs 25625249163, 25628815266, 25631202377 — three consecutive merges into main, all on macmini-03, all the same assertion):

```
TimeoutError: electronApplication.firstWindow:
  Timeout 30000ms exceeded while waiting for event "window"
```

## Root cause

`clients/desktop/e2e/fixtures/electron.fixture.ts:60`

```ts
const app = await electron.launch({
  args: [...],
  env: {...},
  timeout: isCi() ? 120_000 : 30_000,   // launch: 120s on CI ✓
});
...
const page = await electronApp.firstWindow();  // ← defaults to playwright's 30s
```

`electron.launch` already gets 120s on CI, but `firstWindow()` then waits with playwright's default 30s. On macmini-03 under load (Bazel cache restore + electron-vite renderer bundle resolution + Rust core init via NAPI), the renderer typically takes 30-60s to register the first BrowserWindow — just enough to clip the 30s ceiling about half the time. The recent main flake was 100% this one timeout.

## Fix

All four `firstWindow()` call sites get `{ timeout: isCi() ? 90_000 : 30_000 }`:

- `clients/desktop/e2e/fixtures/electron.fixture.ts` (main fixture used by every spec)
- `clients/desktop/e2e/global.setup.ts` (one-time auth setup)
- `clients/desktop/e2e/tests/auth/server-switch-clears-session.spec.ts:55` (second-app relaunch)
- `clients/desktop/e2e/tests/auth/logout-survives-restart.spec.ts:72` (second-app relaunch)

Local runs untouched (still 30s — no point waiting on a fast dev machine).

## Test plan

- [ ] CI `E2E (Desktop — Electron)` passes on macmini-03 (run on this PR)
- [ ] Manual `pnpm exec playwright test` from `clients/desktop/e2e/` still cold-starts in < 30s on dev macOS