### PR TITLE
fix(email): log Resend send failures (no more silent swallow)

### DIFF
--- a/backend/internal/api/rest/v1/auth_login.go
+++ b/backend/internal/api/rest/v1/auth_login.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"errors"
+	"log/slog"
 	"net/http"
 
 	domainUser "github.com/anthropics/agentsmesh/backend/internal/domain/user"
@@ -120,8 +121,12 @@ func (h *AuthHandler) Register(c *gin.Context) {
 		return
 	}
 
-	// Send verification email (don't fail registration if email fails)
-	_ = h.emailService.SendVerificationEmail(c.Request.Context(), result.User.Email, verificationToken)
+	// 邮件失败不阻塞注册（用户可后续通过 ResendVerification 重发），
+	// 但必须落日志——否则"收不到激活邮件"投诉在 backend 日志里没有痕迹。
+	if err := h.emailService.SendVerificationEmail(c.Request.Context(), result.User.Email, verificationToken); err != nil {
+		slog.ErrorContext(c.Request.Context(), "failed to send verification email after registration",
+			"user_id", result.User.ID, "email", result.User.Email, "error", err)
+	}
 
 	c.JSON(http.StatusCreated, gin.H{
 		"token":         result.Token,

--- a/backend/internal/infra/email/service.go
+++ b/backend/internal/infra/email/service.go
@@ -4,12 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/resend/resend-go/v2"
-)
-
-import (
-	"time"
 )
 
 // Service defines the email service interface
@@ -59,6 +56,21 @@ type ResendService struct {
 	baseURL     string
 }
 
+// send 是所有 Resend 调用的唯一入口。集中在这里是为了可观测性：
+// SDK 任何失败都会带 kind/to/from 落日志——没有这层，"用户收不到激活邮件"
+// 的投诉在后端日志里没有任何痕迹（之前 4 个发送方法 return err 后丢日志）。
+func (s *ResendService) send(ctx context.Context, kind, to string, req *resend.SendEmailRequest) error {
+	resp, err := s.client.Emails.SendWithContext(ctx, req)
+	if err != nil {
+		slog.ErrorContext(ctx, "resend send failed",
+			"kind", kind, "to", to, "from", s.fromAddress, "error", err)
+		return err
+	}
+	slog.InfoContext(ctx, "resend send ok",
+		"kind", kind, "to", to, "message_id", resp.Id)
+	return nil
+}
+
 // SendVerificationEmail sends email verification via Resend
 func (s *ResendService) SendVerificationEmail(ctx context.Context, to, token string) error {
 	verifyURL := fmt.Sprintf("%s/verify-email/callback?token=%s", s.baseURL, token)
@@ -84,13 +96,12 @@ func (s *ResendService) SendVerificationEmail(ctx context.Context, to, token str
 </html>
 `, verifyURL, verifyURL, verifyURL)
 
-	_, err := s.client.Emails.SendWithContext(ctx, &resend.SendEmailRequest{
+	return s.send(ctx, "verification", to, &resend.SendEmailRequest{
 		From:    s.fromAddress,
 		To:      []string{to},
 		Subject: "Verify your email - AgentsMesh",
 		Html:    html,
 	})
-	return err
 }
 
 // SendPasswordResetEmail sends password reset email via Resend
@@ -118,13 +129,12 @@ func (s *ResendService) SendPasswordResetEmail(ctx context.Context, to, token st
 </html>
 `, resetURL, resetURL, resetURL)
 
-	_, err := s.client.Emails.SendWithContext(ctx, &resend.SendEmailRequest{
+	return s.send(ctx, "password_reset", to, &resend.SendEmailRequest{
 		From:    s.fromAddress,
 		To:      []string{to},
 		Subject: "Reset your password - AgentsMesh",
 		Html:    html,
 	})
-	return err
 }
 
 // SendOrgInvitationEmail sends organization invitation via Resend
@@ -152,13 +162,12 @@ func (s *ResendService) SendOrgInvitationEmail(ctx context.Context, to, orgName,
 </html>
 `, orgName, inviterName, orgName, inviteURL, inviteURL, inviteURL)
 
-	_, err := s.client.Emails.SendWithContext(ctx, &resend.SendEmailRequest{
+	return s.send(ctx, "org_invitation", to, &resend.SendEmailRequest{
 		From:    s.fromAddress,
 		To:      []string{to},
 		Subject: fmt.Sprintf("You've been invited to join %s - AgentsMesh", orgName),
 		Html:    html,
 	})
-	return err
 }
 
 // SendRenewalReminder sends subscription renewal reminder via Resend
@@ -201,13 +210,12 @@ func (s *ResendService) SendRenewalReminder(ctx context.Context, to, orgName, pl
 </html>
 `, urgencyClass, urgencyText, planName, orgName, expiryDateStr, renewURL, renewURL, renewURL)
 
-	_, err := s.client.Emails.SendWithContext(ctx, &resend.SendEmailRequest{
+	return s.send(ctx, "renewal_reminder", to, &resend.SendEmailRequest{
 		From:    s.fromAddress,
 		To:      []string{to},
 		Subject: fmt.Sprintf("Subscription Renewal Reminder - %s expires in %d days", orgName, daysRemaining),
 		Html:    html,
 	})
-	return err
 }
 
 // ConsoleService implements email service for development (prints to console)


### PR DESCRIPTION
## Summary

排查"用户收不到激活邮件"投诉时发现：注册接口 `_ = h.emailService.SendVerificationEmail(...)` 用 `_` 丢弃了所有 Resend 错误，同时 `ResendService` 的 4 个 `Send*` 方法都 `return err` 但不打日志。结果：**Resend 任何 4xx/5xx/timeout 在 backend 日志里完全没有痕迹**，运维无法定位问题。

- 新增私有 `send()` helper，集中处理 Resend 调用：失败 `slog.Error` 带 kind/to/from/error；成功 `slog.Info` 带 message_id
- 4 个 `Send*` 方法（verification / password_reset / org_invitation / renewal_reminder）改走 helper
- `auth_login.go:124` 由 `_ =` 改成显式 `if err != nil { slog.ErrorContext(...) }`，带 user_id 上下文
- 不改变接口/行为：邮件失败仍然不阻塞注册（用户可走 ResendVerification 重发）

## Test plan

- [x] `bazel build //backend/internal/infra/email:email //backend/internal/api/rest/v1:rest` 通过
- [x] `bazel test //backend/internal/infra/email:email_test //backend/internal/api/rest/v1:rest_test` 通过
- [ ] 部署后在 Loki `{service="agentsmesh-backend"} |= "resend send"` 可看到每封邮件的发送结果

## Follow-up（非本 PR 范围）

- `agentsmesh.cn` 域名需要在 Resend 注册并配置 DNS（当前国区用户收到的邮件 From 是 `noreply@agentsmesh.ai`，跨域导致部分国内邮箱判垃圾）
- 国区前端 `OAuthButtons.tsx` 应隐藏 Google 按钮（北京 backend 到 Google OAuth 端点全部超时）