### PR TITLE
fix(desktop+web+core): OAuth deep-link setAuth forwards session to Rust SSOT

### DIFF
--- a/clients/desktop/e2e/tests/auth/oauth-deeplink-happy-path.spec.ts
+++ b/clients/desktop/e2e/tests/auth/oauth-deeplink-happy-path.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from "../../fixtures";
+import { LoginPage } from "../../pages/login.page";
+import { TEST_USER, TEST_ORG_SLUG } from "../../helpers/env";
+import { invokeIpc } from "../../helpers/ipc";
+import { resolve } from "node:path";
+import { rmSync } from "node:fs";
+
+// Fresh profile so the OAuth callback runs against a clean session — any
+// bleed-through from a prior login would confuse the assertion ("did we
+// reach dashboard because OAuth worked, or because the cached session
+// was already there?").
+const FRESH_USER_DATA = resolve(__dirname, "../../.auth/electron-userdata-oauth-happy");
+
+test.use({
+  skipAuthRestore: true,
+  userDataDir: FRESH_USER_DATA,
+});
+
+test.beforeAll(() => {
+  rmSync(FRESH_USER_DATA, { recursive: true, force: true });
+});
+
+test.describe("Auth · OAuth deep link · happy path", () => {
+  // The negative-path specs (oauth-deep-link, oauth-callback-no-placeholder)
+  // both feed bogus tokens and expect failure cleanup. They could not catch
+  // the v0.31.x bug where `setAuth` only wrote the renderer cache and never
+  // pushed the token to the main-process Rust AuthManager — both "bogus
+  // token + bug" and "valid token + bug" produce the same auth_expired
+  // observable. This spec drives the deep-link with a REAL token obtained
+  // via authLogin and asserts the post-OAuth state is dashboard, not error.
+  test("real-token deep link completes login without auth_expired", async ({
+    page,
+    electronApp,
+  }) => {
+    const login = new LoginPage(page);
+    await login.expectOnLoginPage();
+
+    // 1. Get a real token by driving the main-process login directly. Using
+    //    IPC instead of the UI keeps this spec orthogonal to LoginPage's
+    //    SSO-discovery + form-submit choreography (separate test surface).
+    const loginJson = await invokeIpc<string>(
+      page,
+      "authLogin",
+      TEST_USER.email,
+      TEST_USER.password,
+    );
+    const session = JSON.parse(loginJson) as { token: string; refresh_token: string };
+    expect(session.token, "authLogin must return a JWT").toBeTruthy();
+    expect(session.refresh_token, "authLogin must return a refresh token").toBeTruthy();
+
+    // 2. Clear the main-process session so the next OAuth callback can't
+    //    succeed by accident — userGetMe must specifically depend on the
+    //    token that setAuth → authApplySession just installed, NOT on any
+    //    state left behind by step 1.
+    await invokeIpc(page, "authClearSession");
+
+    // Sanity: after clear, userGetMe MUST fail with auth_expired. If this
+    // fails it means the test environment is broken (token cached
+    // somewhere unexpected) and the next assertion would be meaningless.
+    const meAfterClearError = await page.evaluate(async () => {
+      const api = (window as unknown as { electronAPI: { invoke: (c: string) => Promise<unknown> } }).electronAPI;
+      try {
+        await api.invoke("userGetMe");
+        return null;
+      } catch (e) {
+        return e instanceof Error ? e.message : String(e);
+      }
+    });
+    expect(meAfterClearError, "userGetMe must fail after authClearSession").toContain("auth_expired");
+
+    // 3. Inject the deep-link as main process would after open-url /
+    //    second-instance. Renderer subscribes to `oauth:callback` in
+    //    main.tsx and navigates to /auth/callback?token=...
+    await electronApp.evaluate(({ BrowserWindow }, payload) => {
+      const win = BrowserWindow.getAllWindows()[0];
+      if (!win) throw new Error("no BrowserWindow");
+      win.webContents.send("oauth:callback", payload);
+    }, `agentsmesh://oauth/callback?token=${session.token}&refresh_token=${session.refresh_token}`);
+
+    // 4. The OAuthCallbackPage runs setAuth → userGetMe → setOrganizations →
+    //    redirect. Wait for it to leave the callback route — either toward
+    //    workspace (org exists) or onboarding (no org). Failure shape: hash
+    //    stays on /auth/callback while an error banner says "Sign in failed".
+    await page.waitForFunction(
+      (slug) => {
+        const h = window.location.hash;
+        return h.includes(`/${slug}/`) || h.includes("/workspace") || h.includes("/onboarding");
+      },
+      TEST_ORG_SLUG,
+      { timeout: 20_000 },
+    );
+
+    const hash = await page.evaluate(() => window.location.hash);
+    expect(hash, "should leave /auth/callback after successful login").not.toContain("/auth/callback");
+    expect(hash, "should not bounce back to /login").not.toContain("/login");
+
+    // 5. Direct assertion on the bug: userGetMe must succeed now that
+    //    setAuth completed. If apply_session forgets to fan out
+    //    authApplySession IPC, this fails the same way the production
+    //    "Sign in failed · auth_expired" UI does.
+    const meJson = await invokeIpc<string>(page, "userGetMe");
+    const me = JSON.parse(meJson) as { user: { email: string } };
+    expect(me.user.email).toBe(TEST_USER.email);
+  });
+});

--- a/clients/desktop/e2e/tests/auth/oauth-deeplink-happy-path.spec.ts
+++ b/clients/desktop/e2e/tests/auth/oauth-deeplink-happy-path.spec.ts
@@ -97,9 +97,12 @@ test.describe("Auth · OAuth deep link · happy path", () => {
     // 5. Direct assertion on the bug: userGetMe must succeed now that
     //    setAuth completed. If apply_session forgets to fan out
     //    authApplySession IPC, this fails the same way the production
-    //    "Sign in failed · auth_expired" UI does.
+    //    "Sign in failed · auth_expired" UI does. IPC userGetMe returns
+    //    a serialized User directly (Rust ApiClient unwraps the backend's
+    //    `{user: ...}` envelope in get_resource), so JSON.parse yields
+    //    the bare user object.
     const meJson = await invokeIpc<string>(page, "userGetMe");
-    const me = JSON.parse(meJson) as { user: { email: string } };
-    expect(me.user.email).toBe(TEST_USER.email);
+    const me = JSON.parse(meJson) as { email: string };
+    expect(me.email).toBe(TEST_USER.email);
   });
 });

--- a/clients/desktop/src/renderer/pages/auth/callback/OAuthCallbackPage.tsx
+++ b/clients/desktop/src/renderer/pages/auth/callback/OAuthCallbackPage.tsx
@@ -37,20 +37,24 @@ function OAuthCallbackContent() {
 
       try {
         // Set the token first so ApiClient can include it in /users/me.
+        // MUST await — on Electron, setAuth fans out an authApplySession
+        // IPC to the main-process Rust AuthManager (ApiClient's SSOT). The
+        // synchronous v0.31.x path left the token in renderer-only state,
+        // so the next userGetMe IPC saw no token → 401 → auth_expired.
         // This placeholder is overwritten with the real user as soon as
         // getMe() succeeds — but if anything below throws, we MUST run
         // logout() in catch to wipe it. Leaving a placeholder with token
         // but invalid identity is what the v0.31 onboarding-loop bug
         // was about.
-        setAuth(token, { id: 0, email: "", username: "" }, refreshToken || undefined);
+        await setAuth(token, { id: 0, email: "", username: "" }, refreshToken || undefined);
 
         const userResponse = await userApi.getMe();
         const user = userResponse.user;
-        setAuth(token, user, refreshToken || undefined);
+        await setAuth(token, user, refreshToken || undefined);
 
         const orgsResponse = await organizationApi.list();
         if (orgsResponse.organizations && orgsResponse.organizations.length > 0) {
-          setOrganizations(orgsResponse.organizations);
+          await setOrganizations(orgsResponse.organizations);
           setStatus("success");
           setTimeout(() => {
             router.push(`/${orgsResponse.organizations[0].slug}/workspace`);
@@ -65,7 +69,7 @@ function OAuthCallbackContent() {
         // Wipe the placeholder auth before surfacing the error — otherwise
         // RootRedirect on the next mount would still see a token and route
         // back to dashboard, creating an infinite loop.
-        useAuthStore.getState().logout();
+        await useAuthStore.getState().logout();
         setStatus("error");
         if (err instanceof Error) {
           setErrorMessage(err.message);

--- a/clients/desktop/src/renderer/pages/auth/login/LoginPage.tsx
+++ b/clients/desktop/src/renderer/pages/auth/login/LoginPage.tsx
@@ -78,7 +78,7 @@ export function LoginPage() {
     setError("");
     try {
       const response = await ssoApi.ldapAuth(ldapConfig.domain, { username, password: pwd });
-      setAuth(response.token, response.user, response.refresh_token);
+      await setAuth(response.token, response.user, response.refresh_token);
       navigateAfterLogin(router.push, searchParams.get("redirect"));
     } catch (err) {
       setError(err instanceof ApiError && err.status >= 500

--- a/clients/desktop/src/renderer/pages/auth/register/RegisterPage.tsx
+++ b/clients/desktop/src/renderer/pages/auth/register/RegisterPage.tsx
@@ -56,7 +56,7 @@ export function RegisterPage() {
         password: formData.password,
         name: formData.name,
       });
-      setAuth(response.token, response.user, response.refresh_token);
+      await setAuth(response.token, response.user, response.refresh_token);
 
       // Redirect to email verification page
       router.push(`/verify-email?email=${encodeURIComponent(formData.email)}`);

--- a/clients/desktop/src/renderer/pages/auth/sso-callback/SSOCallbackPage.tsx
+++ b/clients/desktop/src/renderer/pages/auth/sso-callback/SSOCallbackPage.tsx
@@ -59,18 +59,18 @@ function SSOCallbackContent() {
 
       try {
         // Set token so subsequent API calls work
-        setAuth(token, { id: 0, email: "", username: "" }, refreshToken || undefined);
+        await setAuth(token, { id: 0, email: "", username: "" }, refreshToken || undefined);
 
         // Get user info
         const userResponse = await userApi.getMe();
-        setAuth(token, userResponse.user, refreshToken || undefined);
+        await setAuth(token, userResponse.user, refreshToken || undefined);
 
         // Get organizations and redirect
         try {
           const orgsResponse = await organizationApi.list();
           const orgs = orgsResponse.organizations;
           if (orgs && orgs.length > 0) {
-            setOrganizations(orgs);
+            await setOrganizations(orgs);
             setStatus("success");
             scheduleRedirect(`/${orgs[0].slug}/workspace`);
           } else {

--- a/clients/desktop/src/renderer/pages/auth/verify-email/VerifyEmailPage.tsx
+++ b/clients/desktop/src/renderer/pages/auth/verify-email/VerifyEmailPage.tsx
@@ -31,14 +31,14 @@ function VerifyEmailContent() {
 
     try {
       const result = await authApi.verifyEmail(verificationToken);
-      setAuth(result.token, result.user, result.refresh_token);
+      await setAuth(result.token, result.user, result.refresh_token);
       setVerifyState("success");
       setMessage(t("auth.verifyEmailPage.verificationSuccess"));
 
       try {
         const orgsResponse = await organizationApi.list();
         if (orgsResponse.organizations && orgsResponse.organizations.length > 0) {
-          setOrganizations(orgsResponse.organizations);
+          await setOrganizations(orgsResponse.organizations);
           router.push(`/${orgsResponse.organizations[0].slug}/workspace`);
         } else {
           router.push("/onboarding");

--- a/clients/desktop/src/renderer/pages/auth/verify-email/callback/VerifyEmailCallbackPage.tsx
+++ b/clients/desktop/src/renderer/pages/auth/verify-email/callback/VerifyEmailCallbackPage.tsx
@@ -27,7 +27,7 @@ function VerifyEmailCallbackContent() {
         const response = await authApi.verifyEmail(token);
 
         // Store auth tokens
-        setAuth(response.token, {
+        await setAuth(response.token, {
           id: response.user.id,
           email: response.user.email,
           username: response.user.username,

--- a/clients/web/src/app/(auth)/auth/callback/page.tsx
+++ b/clients/web/src/app/(auth)/auth/callback/page.tsx
@@ -44,14 +44,14 @@ function OAuthCallbackContent() {
       try {
         // First, set the token so subsequent API calls work
         // We'll get user info from the API
-        setAuth(token, { id: 0, email: "", username: "" }, refreshToken || undefined);
+        await setAuth(token, { id: 0, email: "", username: "" }, refreshToken || undefined);
 
         // Get user info
         const userResponse = JSON.parse(await getUserApiService().get_me());
         const user = userResponse.user;
 
         // Update auth with actual user info
-        setAuth(token, user, refreshToken || undefined);
+        await setAuth(token, user, refreshToken || undefined);
 
         const url = await resolvePostLoginUrl({
           redirectParam,

--- a/clients/web/src/app/(auth)/auth/sso/callback/page.tsx
+++ b/clients/web/src/app/(auth)/auth/sso/callback/page.tsx
@@ -66,11 +66,11 @@ function SSOCallbackContent() {
 
       try {
         // Set token so subsequent API calls work
-        setAuth(token, { id: 0, email: "", username: "" }, refreshToken || undefined);
+        await setAuth(token, { id: 0, email: "", username: "" }, refreshToken || undefined);
 
         // Get user info
         const userResponse = JSON.parse(await getUserApiService().get_me());
-        setAuth(token, userResponse.user, refreshToken || undefined);
+        await setAuth(token, userResponse.user, refreshToken || undefined);
 
         const url = await resolvePostLoginUrl({
           redirectParam,

--- a/clients/web/src/app/(auth)/login/page.tsx
+++ b/clients/web/src/app/(auth)/login/page.tsx
@@ -81,7 +81,7 @@ export default function LoginPage() {
     setError("");
     try {
       const response = JSON.parse(await getSSOService().ldap_auth(ldapConfig.domain, JSON.stringify({username, password: pwd})));
-      setAuth(response.token, response.user, response.refresh_token);
+      await setAuth(response.token, response.user, response.refresh_token);
       await navigateAfterLogin();
     } catch (err) {
       setError(err instanceof ApiError && err.status >= 500
@@ -97,7 +97,7 @@ export default function LoginPage() {
     try {
       await initWasmCore();
       const response = JSON.parse(await getAuthManager().login(email, password));
-      setAuth(response.token, response.user, response.refresh_token);
+      await setAuth(response.token, response.user, response.refresh_token);
       await navigateAfterLogin();
     } catch (err) {
       if (err instanceof ApiError && err.hasCode("SSO_REQUIRED")) {

--- a/clients/web/src/app/(auth)/register/page.tsx
+++ b/clients/web/src/app/(auth)/register/page.tsx
@@ -55,7 +55,7 @@ export default function RegisterPage() {
         password: formData.password,
         name: formData.name,
       })));
-      setAuth(response.token, response.user, response.refresh_token);
+      await setAuth(response.token, response.user, response.refresh_token);
       router.push(`/verify-email?email=${encodeURIComponent(formData.email)}`);
     } catch (err: unknown) {
       if (err && typeof err === "object" && "data" in err) {

--- a/clients/web/src/app/(auth)/verify-email/callback/page.tsx
+++ b/clients/web/src/app/(auth)/verify-email/callback/page.tsx
@@ -31,7 +31,7 @@ function VerifyEmailCallbackContent() {
         const response = JSON.parse(await getAuthApiService().verify_email(token));
 
         // Store auth tokens
-        setAuth(response.token, {
+        await setAuth(response.token, {
           id: response.user.id,
           email: response.user.email,
           username: response.user.username,

--- a/clients/web/src/app/(auth)/verify-email/page.tsx
+++ b/clients/web/src/app/(auth)/verify-email/page.tsx
@@ -36,14 +36,14 @@ function VerifyEmailContent() {
 
     try {
       const result = JSON.parse(await getAuthApiService().verify_email(verificationToken));
-      setAuth(result.token, result.user, result.refresh_token);
+      await setAuth(result.token, result.user, result.refresh_token);
       setVerifyState("success");
       setMessage(t("auth.verifyEmailPage.verificationSuccess"));
 
       try {
         const orgsResponse = JSON.parse(await getOrgApiService().list());
         if (orgsResponse.organizations && orgsResponse.organizations.length > 0) {
-          setOrganizations(orgsResponse.organizations);
+          await setOrganizations(orgsResponse.organizations);
           router.push(getDefaultRoute(orgsResponse.organizations[0].slug));
         } else {
           router.push("/onboarding");

--- a/clients/web/src/lib/auth/post-login.ts
+++ b/clients/web/src/lib/auth/post-login.ts
@@ -10,7 +10,7 @@ interface Organization {
 
 export interface ResolvePostLoginUrlOptions {
   redirectParam: string | null;
-  setOrganizations: (orgs: Organization[]) => void;
+  setOrganizations: (orgs: Organization[]) => Promise<void> | void;
 }
 
 // Single source of truth for "where do we land after a successful login".
@@ -24,13 +24,13 @@ export interface ResolvePostLoginUrlOptions {
 // Org cache priming runs on the redirect path too: the destination
 // (e.g. /popout/terminal/...) likely relies on currentOrg being populated.
 async function primeOrganizations(
-  setOrganizations: (orgs: Organization[]) => void
+  setOrganizations: (orgs: Organization[]) => Promise<void> | void
 ): Promise<Organization[]> {
   try {
     const orgsResponse = JSON.parse(await getOrgApiService().list());
     const orgs: Organization[] = orgsResponse.organizations || [];
     if (orgs.length > 0) {
-      setOrganizations(orgs);
+      await setOrganizations(orgs);
       try { await getAuthManager().fetch_organizations(); } catch { /* best effort */ }
     }
     return orgs;

--- a/clients/web/src/stores/__tests__/auth.test.ts
+++ b/clients/web/src/stores/__tests__/auth.test.ts
@@ -30,72 +30,72 @@ describe('useAuthStore', () => {
   })
 
   describe('setAuth', () => {
-    it('should set user', () => {
+    it('should set user', async () => {
       const user = { id: 1, email: 'test@example.com', username: 'testuser', name: 'Test User' }
-      useAuthStore.getState().setAuth('test-token', user)
+      await useAuthStore.getState().setAuth('test-token', user)
       expect(readCurrentUser()).toEqual(user)
     })
 
-    it('should handle user without optional fields', () => {
+    it('should handle user without optional fields', async () => {
       const user = { id: 1, email: 'test@example.com', username: 'testuser' }
-      useAuthStore.getState().setAuth('test-token', user)
+      await useAuthStore.getState().setAuth('test-token', user)
       expect(readCurrentUser()).toEqual(user)
       expect(readCurrentUser()?.name).toBeUndefined()
     })
   })
 
   describe('setOrganizations', () => {
-    it('should set organizations', () => {
+    it('should set organizations', async () => {
       const orgs = [
         { id: 1, name: 'Org 1', slug: 'org-1', role: 'owner' },
         { id: 2, name: 'Org 2', slug: 'org-2', role: 'member' },
       ]
-      useAuthStore.getState().setOrganizations(orgs)
+      await useAuthStore.getState().setOrganizations(orgs)
       expect(readOrganizations()).toEqual(orgs)
     })
 
-    it('should auto-select first org if none selected', () => {
+    it('should auto-select first org if none selected', async () => {
       const orgs = [
         { id: 1, name: 'Org 1', slug: 'org-1', role: 'owner' },
         { id: 2, name: 'Org 2', slug: 'org-2', role: 'member' },
       ]
-      useAuthStore.getState().setOrganizations(orgs)
+      await useAuthStore.getState().setOrganizations(orgs)
       expect(readCurrentOrg()).toEqual(orgs[0])
     })
 
-    it('should not change currentOrg if already selected', () => {
+    it('should not change currentOrg if already selected', async () => {
       const existingOrg = { id: 3, name: 'Existing', slug: 'existing', role: 'admin' }
-      useAuthStore.getState().setCurrentOrg(existingOrg)
+      await useAuthStore.getState().setCurrentOrg(existingOrg)
       const orgs = [
         { id: 1, name: 'Org 1', slug: 'org-1', role: 'owner' },
         { id: 2, name: 'Org 2', slug: 'org-2', role: 'member' },
       ]
-      useAuthStore.getState().setOrganizations(orgs)
+      await useAuthStore.getState().setOrganizations(orgs)
       expect(readCurrentOrg()).toEqual(existingOrg)
     })
 
-    it('should handle empty organizations array', () => {
-      useAuthStore.getState().setOrganizations([])
+    it('should handle empty organizations array', async () => {
+      await useAuthStore.getState().setOrganizations([])
       expect(readOrganizations()).toEqual([])
       expect(readCurrentOrg()).toBeNull()
     })
   })
 
   describe('setCurrentOrg', () => {
-    it('should set current organization', () => {
+    it('should set current organization', async () => {
       const org = { id: 1, name: 'Test Org', slug: 'test-org', role: 'owner' }
-      useAuthStore.getState().setCurrentOrg(org)
+      await useAuthStore.getState().setCurrentOrg(org)
       expect(readCurrentOrg()).toEqual(org)
     })
   })
 
   describe('logout', () => {
-    it('should clear all auth state', () => {
+    it('should clear all auth state', async () => {
       const user = { id: 1, email: 'test@example.com', username: 'testuser' }
       const org = { id: 1, name: 'Org', slug: 'org', role: 'owner' }
-      useAuthStore.getState().setAuth('token', user)
-      useAuthStore.getState().setOrganizations([org])
-      useAuthStore.getState().logout()
+      await useAuthStore.getState().setAuth('token', user)
+      await useAuthStore.getState().setOrganizations([org])
+      await useAuthStore.getState().logout()
       expect(readCurrentUser()).toBeNull()
       expect(readCurrentOrg()).toBeNull()
       expect(readOrganizations()).toEqual([])
@@ -107,16 +107,16 @@ describe('useAuthStore', () => {
       expect(useAuthStore.getState().isAuthenticated()).toBe(false)
     })
 
-    it('should return true when user exists', () => {
+    it('should return true when user exists', async () => {
       const user = { id: 1, email: 'test@example.com', username: 'testuser' }
-      useAuthStore.getState().setAuth('token', user)
+      await useAuthStore.getState().setAuth('token', user)
       expect(useAuthStore.getState().isAuthenticated()).toBe(true)
     })
 
-    it('should return false after logout', () => {
+    it('should return false after logout', async () => {
       const user = { id: 1, email: 'test@example.com', username: 'testuser' }
-      useAuthStore.getState().setAuth('token', user)
-      useAuthStore.getState().logout()
+      await useAuthStore.getState().setAuth('token', user)
+      await useAuthStore.getState().logout()
       expect(useAuthStore.getState().isAuthenticated()).toBe(false)
     })
   })

--- a/clients/web/src/stores/auth.ts
+++ b/clients/web/src/stores/auth.ts
@@ -43,10 +43,14 @@ interface AuthState {
   switchOrg: (slug: string) => void;
   refreshSession: () => Promise<void>;
 
-  setAuth: (token: string, user: User, refreshToken?: string) => void;
-  setOrganizations: (orgs: Organization[]) => void;
+  // setAuth / setOrganizations / logout return Promise: on Electron the
+  // underlying adapter awaits an IPC round-trip to the Rust SSOT. Callers
+  // MUST await — fire-and-forget leaves the main process without the token
+  // (the v0.31.x OAuth deep-link bug). Wasm path resolves synchronously.
+  setAuth: (token: string, user: User, refreshToken?: string) => Promise<void>;
+  setOrganizations: (orgs: Organization[]) => Promise<void>;
   setCurrentOrg: (org: Organization) => Promise<void>;
-  logout: () => void;
+  logout: () => Promise<void>;
   isAuthenticated: () => boolean;
   setHasHydrated: (state: boolean) => void;
   clearError: () => void;
@@ -175,9 +179,9 @@ export const useAuthStore = create<AuthState>((set) => ({
     }
   },
 
-  setAuth: (token, user, refreshToken) => {
+  setAuth: async (token, user, refreshToken) => {
     try {
-      mgr().apply_session(JSON.stringify({
+      await mgr().apply_session(JSON.stringify({
         token,
         refresh_token: refreshToken || "",
         user,
@@ -187,8 +191,8 @@ export const useAuthStore = create<AuthState>((set) => ({
     bump();
   },
 
-  setOrganizations: (organizations) => {
-    try { mgr().set_organizations(JSON.stringify(organizations)); } catch { /* noop */ }
+  setOrganizations: async (organizations) => {
+    try { await mgr().set_organizations(JSON.stringify(organizations)); } catch { /* noop */ }
     bump();
   },
 
@@ -202,10 +206,10 @@ export const useAuthStore = create<AuthState>((set) => ({
     bump();
   },
 
-  logout: () => {
+  logout: async () => {
     // Sync local cleanup first — guarantees post-call state is logged-out
     // even if the network POST below fails or hangs.
-    try { mgr().clear_session(); } catch { /* noop */ }
+    try { await mgr().clear_session(); } catch { /* noop */ }
     // Best-effort API logout (informs server, doesn't block UI).
     try { mgr().logout().catch(() => {}); } catch { /* noop */ }
     set({ error: null });

--- a/packages/electron-adapter/src/auth.ts
+++ b/packages/electron-adapter/src/auth.ts
@@ -80,7 +80,11 @@ export class ElectronAuthService implements IAuthManager {
         this._currentOrgCache = parsed.current_org != null ? JSON.stringify(parsed.current_org) : null;
         this._organizationsCache = (await invoke<string>("authGetOrganizationsJson")) ?? "[]";
       } else {
-        this.clear_session();
+        // Bootstrap reports anonymous → main already has no session; only
+        // wipe renderer cache. Skip the authClearSession IPC that
+        // clear_session() would fan out (redundant + an extra round-trip
+        // on every cold start).
+        this.resetLocalCache();
       }
     } catch {
       // Parse failure: leave caches as-is, caller treats as anonymous via JSON
@@ -96,7 +100,10 @@ export class ElectronAuthService implements IAuthManager {
 
   async logout(): Promise<void> {
     await invoke<void>("authLogout");
-    this.clear_session();
+    // authLogout already cleared the Rust manager's session; only the
+    // renderer cache needs wiping here. clear_session() would re-fan-out
+    // authClearSession — correct but wasteful.
+    this.resetLocalCache();
   }
 
   async refresh_token(): Promise<string> {
@@ -116,14 +123,22 @@ export class ElectronAuthService implements IAuthManager {
     return result;
   }
 
-  // Synchronous cache-setters matching the Wasm AuthManager API. Zustand's
-  // setAuth / setOrganizations / setCurrentOrg call these to keep the local
-  // cache in sync after an IPC round-trip.
-  apply_session(sessionJson: string): void {
+  // Mirror state to BOTH ends: renderer cache (sync) AND main-process Rust
+  // AuthManager (via IPC). The renderer-only path was the v0.31.x OAuth
+  // deep-link bug — token landed in ElectronAuthService but never made it
+  // to ApiClient (which reads from the Rust manager), so the next
+  // `userGetMe` IPC 401'd and surfaced as `{"kind":"auth_expired"}`.
+  // Callers MUST `await` because the IAuthManager signature now returns
+  // Promise<void> | void; on the wasm side this is a no-op `await`.
+  async apply_session(sessionJson: string): Promise<void> {
+    // Push to Rust first so any IPC issued after `apply_session` returns
+    // (e.g. userGetMe in OAuthCallbackPage) sees the token on the main side.
+    await invoke("authApplySession", sessionJson);
     this.applySessionPayload(sessionJson);
   }
 
-  set_organizations(orgsJson: string): void {
+  async set_organizations(orgsJson: string): Promise<void> {
+    await invoke("authSetOrganizations", orgsJson);
     this._organizationsCache = orgsJson;
   }
 
@@ -132,17 +147,27 @@ export class ElectronAuthService implements IAuthManager {
     await invoke("authSetCurrentOrg", orgJson);
   }
 
-  clear_session(): void {
+  async clear_session(): Promise<void> {
+    // Same reasoning as apply_session: the Rust AuthManager is the SSOT
+    // for ApiClient's token, so renderer-only clears leave a logged-in
+    // main process. logout() already covers this for the API-logout path;
+    // clear_session is the local-reset used by Zustand on OAuth-failure
+    // cleanup, where the IPC fan-out is still required.
+    await invoke("authClearSession");
+    this.resetLocalCache();
+  }
+
+  static new_with_storage(baseUrl: string, _storage: unknown): IAuthManager {
+    return new ElectronAuthService(baseUrl);
+  }
+
+  private resetLocalCache(): void {
     this._token = undefined;
     this._refreshToken = undefined;
     this._expiresAt = undefined;
     this._currentUserCache = null;
     this._currentOrgCache = null;
     this._organizationsCache = "[]";
-  }
-
-  static new_with_storage(baseUrl: string, _storage: unknown): IAuthManager {
-    return new ElectronAuthService(baseUrl);
   }
 
   // Single source of truth for "I just got a session payload from server,

--- a/packages/service-interface/src/index.ts
+++ b/packages/service-interface/src/index.ts
@@ -88,9 +88,13 @@ export interface IAuthApiService {
 }
 
 export interface IAuthManager {
-  apply_session?(session_json: string): void;
+  // apply_session / clear_session / set_organizations may return Promise on
+  // adapters that need to fan out to a remote SSOT (Electron IPC → Rust main).
+  // Wasm AuthManager is sync (in-process); callers MUST `await` so both
+  // shapes work — see clients/web/src/stores/auth.ts setAuth.
+  apply_session?(session_json: string): Promise<void> | void;
   bootstrap(): Promise<string>;
-  clear_session?(): void;
+  clear_session?(): Promise<void> | void;
   fetch_organizations(): Promise<string>;
   get_current_org_json(): any;
   get_current_user_json(): any;
@@ -102,7 +106,7 @@ export interface IAuthManager {
   logout(): Promise<void>;
   refresh_token(): Promise<string>;
   set_current_org?(org_json: string): Promise<void> | void;
-  set_organizations?(orgs_json: string): void;
+  set_organizations?(orgs_json: string): Promise<void> | void;
   switch_org(slug: string): void;
   readonly base_url: string;
 }


### PR DESCRIPTION
## Summary

Fixes a v0.31+ desktop regression where GitHub OAuth login surfaced as `Sign in failed · {"kind":"auth_expired"}`.

`ElectronAuthService.apply_session` only mutated renderer cache, so OAuth deep-link tokens never reached the main-process Rust `AuthManager`. The next `userGetMe` IPC hit the Rust `ApiClient` with no token → 401 → `AuthExpired`. Negative-path e2e specs masked this because invalid-token tests produced the same observable.

## Changes

- **`packages/electron-adapter/src/auth.ts`** — `apply_session` / `clear_session` / `set_organizations` now fan out the matching `authApplySession` / `authClearSession` / `authSetOrganizations` IPC so the Rust `AuthManager` (the SSOT `ApiClient` reads from) holds the same token as the renderer cache. `logout` + `bootstrap` skip redundant IPC where main is already cleared. Extracted `resetLocalCache()` to dedupe.
- **`packages/service-interface/src/index.ts`** — `IAuthManager.apply_session` / `clear_session` / `set_organizations` widen to `Promise<void> | void`.
- **`clients/web/src/stores/auth.ts`** — `setAuth` / `setOrganizations` / `logout` return `Promise`; callers must `await`.
- **`clients/web/src/lib/auth/post-login.ts`** — `primeOrganizations` awaits `setOrganizations`.
- **12 call sites** (web + desktop OAuth/SSO/verify-email/login/register pages) prefix `await` so the IPC round-trip lands before the next call.
- **`clients/desktop/e2e/tests/auth/oauth-deeplink-happy-path.spec.ts`** (new) — real-token regression guard: `authLogin` → `authClearSession` → inject `oauth:callback` → assert `userGetMe` succeeds + reaches workspace/onboarding.

## Why CI didn't catch this

Earlier oauth specs (`oauth-deep-link.spec`, `oauth-callback-no-placeholder.spec`) only fed bogus tokens and expected failure — that observable (`auth_expired` + logout cleanup) matches the production bug exactly. New happy-path spec uses a real `authLogin`-obtained token so any future "renderer-only setAuth" regression breaks CI.

## Test plan

- [x] `bazel test //clients/web:unit` — 6 setAuth/setOrganizations/logout tests converted to async, all pass
- [x] `bazel build //clients/web:src` — tsc --noEmit
- [x] `bazel build //clients/desktop:out` — electron-vite bundle
- [x] `bazel test //clients/web:lint //clients/web-admin:lint //clients/desktop:lint` (incl. new e2e spec)
- [x] `bazel build //packages/electron-adapter/... //packages/service-interface/... //packages/service-runtime/...`
- [x] Manual: built a packaged copy of dev electron, walked full GitHub OAuth round-trip, landed in dashboard (session.json on disk has 316-char real JWT)

## Follow-up

There's a latent warning where `OAuthCallbackPage`'s first `setAuth(placeholder)` call IPC-fails with `missing field user` on the Rust deserializer. The second `setAuth(realUser)` succeeds, which is why login still completes. Tracked separately — likely fix is making `AuthSession.user` optional in `clients/core/crates/types/src/auth.rs` so placeholder-token-only updates don't trip the schema.