### PR TITLE
fix(core+web): align SkillRegistry list wrapper across wasm relay (#341)

### DIFF
--- a/clients/core/crates/api-client/src/api_core_tests.rs
+++ b/clients/core/crates/api-client/src/api_core_tests.rs
@@ -327,7 +327,7 @@ mod api_core_tests {
     async fn list_skill_registries() {
         let s = MockServer::start().await;
         Mock::given(method("GET")).and(path("/api/v1/orgs/acme/skill-registries"))
-            .respond_with(ok(json!({"registries":[]})))
+            .respond_with(ok(json!({"skill_registries":[]})))
             .expect(1).mount(&s).await;
         let c = ApiClient::new(s.uri(), MockTokenStore::with_org("acme"));
         let _ = c.list_skill_registries().await.unwrap();

--- a/clients/core/crates/types/src/extension.rs
+++ b/clients/core/crates/types/src/extension.rs
@@ -140,8 +140,7 @@ pub struct UpdateMcpInstallRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SkillRegistryListResponse {
-    #[serde(alias = "skill_registries")]
-    pub registries: Vec<SkillRegistry>,
+    pub skill_registries: Vec<SkillRegistry>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -172,7 +171,7 @@ pub struct RepoMcpServerInstallListResponse {
 
 #[cfg(test)]
 mod skill_registry_tests {
-    use super::SkillRegistry;
+    use super::{SkillRegistry, SkillRegistryListResponse};
 
     const BACKEND_PAYLOAD: &str = r#"{
         "id": 7,
@@ -211,5 +210,29 @@ mod skill_registry_tests {
                     "last_commit_sha", "detected_type"] {
             assert!(!parsed[key].is_null(), "field `{key}` dropped by relay");
         }
+    }
+
+    // Regression for #341: backend wire wrapper is `skill_registries`, but PR #349
+    // used `#[serde(alias)]` on a Rust field named `registries`. Serde's `alias`
+    // only affects deserialization; re-serializing for the wasm relay emitted
+    // `{"registries": ...}` instead, so the TS layer (which reads
+    // `.skill_registries`) always saw `undefined` and rendered an empty list.
+    // This test pins the round-trip key.
+    #[test]
+    fn skill_registry_list_response_relay_key_matches_backend_wire() {
+        let backend_wire = format!(r#"{{"skill_registries":[{BACKEND_PAYLOAD}]}}"#);
+        let typed: SkillRegistryListResponse = serde_json::from_str(&backend_wire).unwrap();
+        assert_eq!(typed.skill_registries.len(), 1);
+
+        let relayed = serde_json::to_string(&typed).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&relayed).unwrap();
+        assert!(
+            parsed.get("skill_registries").is_some(),
+            "wasm relay must emit `skill_registries`, got: {relayed}"
+        );
+        assert!(
+            parsed.get("registries").is_none(),
+            "legacy `registries` key must not leak through: {relayed}"
+        );
     }
 }

--- a/clients/web/e2e-playwright/tests/extensions/skill-registry-wasm-roundtrip.spec.ts
+++ b/clients/web/e2e-playwright/tests/extensions/skill-registry-wasm-roundtrip.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from "../../fixtures/index";
+import { SettingsNavPage } from "../../pages/settings/settings-nav.page";
+import { TEST_ORG_SLUG } from "../../helpers/env";
+import { clearAuthRateLimit } from "../../helpers/redis";
+
+// Regression for issue #341.
+//
+// The bug: backend returns `{"skill_registries": [...]}`, but the Rust DTO
+// renamed the wrapper field to `registries` with `#[serde(alias = "skill_registries")]`.
+// Serde's `alias` only affects deserialization; re-serializing for the wasm
+// relay emitted `{"registries": ...}` instead. The TS layer reads
+// `.skill_registries` and got `undefined`, so the UI list stayed empty even
+// though the DB row existed — and re-registering the same repo tripped the
+// unique-key check on the backend.
+//
+// Pure API tests can't catch this because the backend wire format is correct
+// — the drift happens inside the wasm boundary. This spec drives the full UI
+// path so the round-trip is exercised end-to-end. The two scenarios cover the
+// two symptoms the user reported:
+//   1. After adding a source, list stays empty until refresh (or forever).
+//   2. Reloading the page with an existing DB row still shows empty list.
+
+const TEST_URL_PREFIX = "https://github.com/agentsmesh-e2e/skill-roundtrip-";
+
+const orgIdSql = `(SELECT id FROM organizations WHERE slug = '${TEST_ORG_SLUG}')`;
+const deleteTestRegistries = `DELETE FROM skill_registries WHERE organization_id = ${orgIdSql} AND repository_url LIKE '${TEST_URL_PREFIX}%'`;
+
+test.describe("Skill registry — wasm round-trip (#341)", () => {
+  test.beforeEach(async ({ db }) => {
+    clearAuthRateLimit();
+    db.cleanup(deleteTestRegistries);
+  });
+
+  test.afterEach(async ({ db }) => {
+    db.cleanup(deleteTestRegistries);
+  });
+
+  test("UI shows newly added org registry after submit", async ({ page, db }) => {
+    const testUrl = `${TEST_URL_PREFIX}add-${Date.now()}`;
+
+    const nav = new SettingsNavPage(page, TEST_ORG_SLUG);
+    await nav.goto("organization", "extensions");
+
+    // The "Add Source" button only lives on the org-registries section, so
+    // its visibility implicitly confirms we landed on the right tab.
+    const addSourceButton = page.getByRole("button", { name: /add source|添加注册表/i });
+    await expect(addSourceButton).toBeVisible();
+    await addSourceButton.click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await dialog.getByPlaceholder("https://github.com/owner/skills-repo").fill(testUrl);
+    // The dialog heading also reads "Add Source"; scoping by role inside the
+    // dialog hits the submit button only.
+    await dialog.getByRole("button", { name: /add source|添加注册表/i }).click();
+
+    await expect(dialog).toBeHidden();
+
+    // The bug manifested as an empty list even though the POST succeeded.
+    // Asserting the URL is rendered proves the wasm relay preserved the
+    // `skill_registries` wrapper key on the subsequent list refresh.
+    await expect(page.getByText(testUrl)).toBeVisible();
+
+    // Belt-and-braces: confirm the DB row exists, so a future bug that hides
+    // rows in the UI without ever POSTing can't pass by simply staying empty.
+    const dbCount = db.queryValue(
+      `SELECT COUNT(*) FROM skill_registries WHERE organization_id = ${orgIdSql} AND repository_url = '${testUrl}'`
+    );
+    expect(dbCount).toBe("1");
+  });
+
+  test("UI lists pre-existing org registry on page load", async ({ page, api }) => {
+    // Symptom 2 from the bug report: even if the DB has rows, the page renders
+    // empty. Pre-seed via the backend API (which bypasses wasm), then load the
+    // settings page and assert the row appears — this exercises the wasm
+    // list_skill_registries() path without going through the create dialog.
+    const testUrl = `${TEST_URL_PREFIX}preexisting-${Date.now()}`;
+    const createRes = await api.post(`/api/v1/orgs/${TEST_ORG_SLUG}/skill-registries`, {
+      repository_url: testUrl,
+      branch: "main",
+      auth_type: "none",
+    });
+    expect([200, 201]).toContain(createRes.status);
+
+    const nav = new SettingsNavPage(page, TEST_ORG_SLUG);
+    await nav.goto("organization", "extensions");
+
+    await expect(page.getByText(testUrl)).toBeVisible();
+  });
+});

--- a/clients/web/e2e-playwright/tests/extensions/skill-registry-wasm-roundtrip.spec.ts
+++ b/clients/web/e2e-playwright/tests/extensions/skill-registry-wasm-roundtrip.spec.ts
@@ -41,17 +41,24 @@ test.describe("Skill registry — wasm round-trip (#341)", () => {
     const nav = new SettingsNavPage(page, TEST_ORG_SLUG);
     await nav.goto("organization", "extensions");
 
-    // The "Add Source" button only lives on the org-registries section, so
-    // its visibility implicitly confirms we landed on the right tab.
-    const addSourceButton = page.getByRole("button", { name: /add source|添加注册表/i });
-    await expect(addSourceButton).toBeVisible();
-    await addSourceButton.click();
+    // Open the add-source dialog. The "Add Source" button only renders inside
+    // OrgRegistriesList — PlatformRegistriesList has no equivalent — so the
+    // page has exactly one such button before the dialog opens.
+    const openButton = page.getByRole("button", { name: /add source|添加注册表/i });
+    await expect(openButton).toBeVisible();
+    await openButton.click();
 
-    const dialog = page.getByRole("dialog");
+    // The project's Dialog is a custom portal — it does NOT set role="dialog".
+    // It marks the overlay with `data-dialog-overlay`, which is what we scope
+    // by; getByRole("dialog") would silently miss every spec that touches it.
+    const dialog = page.locator("[data-dialog-overlay]");
     await expect(dialog).toBeVisible();
+
     await dialog.getByPlaceholder("https://github.com/owner/skills-repo").fill(testUrl);
-    // The dialog heading also reads "Add Source"; scoping by role inside the
-    // dialog hits the submit button only.
+    // Inside the dialog overlay the only `<button>` carrying the "Add Source"
+    // label is the footer submit (the heading is an <h2>, the cancel button
+    // reads "Cancel" / "取消"). Scoping by dialog excludes the now-occluded
+    // OrgRegistriesList "Add Source" button on the page behind the overlay.
     await dialog.getByRole("button", { name: /add source|添加注册表/i }).click();
 
     await expect(dialog).toBeHidden();

--- a/clients/web/src/test/setup.ts
+++ b/clients/web/src/test/setup.ts
@@ -676,7 +676,7 @@ vi.mock('@/lib/wasm-core', () => {
       list_merge_requests: fn().mockResolvedValue('{"merge_requests":[]}'),
     })),
     getExtensionService: fn(() => ({
-      list_skill_registries: fn().mockResolvedValue('{"registries":[]}'),
+      list_skill_registries: fn().mockResolvedValue('{"skill_registries":[]}'),
       create_skill_registry: fn().mockResolvedValue('{}'),
       sync_skill_registry: fn().mockResolvedValue(undefined),
       toggle_skill_registry: fn().mockResolvedValue('{}'),


### PR DESCRIPTION
## Summary

Closes the still-open symptom on #341. PR #349 fixed per-item DTO drift; the **list-response wrapper key** itself was still drifting through the wasm boundary, which is why the user could still reproduce.

- Backend wire: `{"skill_registries": [...]}`
- Rust DTO: `SkillRegistryListResponse.registries` with `#[serde(alias = "skill_registries")]`
- Serde's `alias` only affects **deserialize**; re-serializing through the wasm relay emitted `{"registries": [...]}`
- TS at `SkillRegistriesSettings.tsx:32` read `.skill_registries` → `undefined` → UI list stayed empty → DB row was there → re-adding the same repo tripped the unique-key check

Two mocks (`api_core_tests.rs`, vitest `setup.ts`) were also written against the drifted shape, which is why CI on #349 passed without exposing this.

## Changes

- **`clients/core/crates/types/src/extension.rs`** — rename the field to `skill_registries`, drop the alias. Backend wire = Rust DTO = TS reader, single key, no translation.
- **`clients/core/crates/api-client/src/api_core_tests.rs`** — correct mock to real backend wire.
- **`clients/web/src/test/setup.ts`** — correct vitest mock.
- **`clients/web/e2e-playwright/tests/extensions/skill-registry-wasm-roundtrip.spec.ts`** *(new)* — full-UI regression covering both reported symptoms:
  1. submit dialog → list refresh shows new URL
  2. pre-existing DB row → page load shows row

  Pure API specs would not catch this class of drift since the backend envelope is correct.
- **Rust round-trip test** `skill_registry_list_response_relay_key_matches_backend_wire` — pins the key in **both** directions (must emit `skill_registries`; must never leak `registries`).

## Test plan

- [x] `bazel test //clients/core/crates/types/...` — PASS (includes new round-trip test)
- [x] `bazel test //clients/core/crates/api-client/... services/... wasm/... node-bridge/...` — PASS
- [x] `bazel test //clients/web:unit //clients/web:lint //clients/web-admin:lint` — PASS
- [x] `bazel run //clients/web/e2e-playwright:e2e -- --list` — Playwright discovers the new spec
- [ ] CI on this PR (full e2e against dev infra)

Refs #341.