### PR TITLE
fix(install): darwin downloads per-arch tarball (404 on v0.34.0+)

### DIFF
--- a/clients/web/public/install.sh
+++ b/clients/web/public/install.sh
@@ -126,13 +126,7 @@ detect_platform() {
     ARCH=$(uname -m)
 
     case "$OS" in
-        darwin)
-            OS="darwin"
-            # Use universal binary for macOS
-            ARCH="all"
-            ;;
-        linux)
-            OS="linux"
+        darwin|linux)
             case "$ARCH" in
                 x86_64|amd64)
                     ARCH="amd64"


### PR DESCRIPTION
## Summary

- macOS users running \`curl -fsSL https://agentsmesh.ai/install.sh | sh\` hit a **404** on v0.34.0 (and likely every prior tag since the script landed in #305).
- The script hard-coded \`ARCH=all\` for macOS expecting a universal binary, but the Bazel-based release pipeline (\`runner_release_bundle\`) only emits per-arch artifacts (\`darwin_amd64\` / \`darwin_arm64\`). \`agentsmesh-runner_<ver>_darwin_all.tar.gz\` has never existed.
- Fix: detect macOS arch via \`uname -m\` like Linux already does. Apple Silicon now gets a native arm64 binary instead of Rosetta amd64.

## Other platforms (verified)

| Path | Status |
|---|---|
| \`install.sh\` linux (\`linux_amd64\`/\`linux_arm64\`) | aligned with release ✓ |
| \`install.ps1\` (\`windows_amd64\`/\`windows_arm64\`) | aligned with release ✓ |
| \`useLocalRunnerOnboarding.ts\` (web onboarding) | routes through Rust \`host_target()\`; asserted in \`clients/core/crates/local-runner/src/lib.rs:153\` ✓ |

## User report

\`\`\`
==> Detected platform: darwin_all
==> Downloading from: https://github.com/AgentsMesh/AgentsMesh/releases/download/v0.34.0/agentsmesh-runner_0.34.0_darwin_all.tar.gz
curl: (56) The requested URL returned error: 404
\`\`\`

## Test plan

- [x] Inlined-detection unit harness — covers darwin/linux × amd64/arm64, plus unsupported-arch and unsupported-OS error paths
- [ ] After merge: tag \`v0.34.1\` and confirm \`curl -fsSL https://agentsmesh.ai/install.sh | sh\` succeeds on macOS (Intel + Apple Silicon)

## Follow-up (separate doc PR)

\`docs/rfc/RFC-003-runner-release-pipeline.md\` still documents \`darwin_all\` plus several \`.deb\`/\`.rpm\`/\`.apk\`/\`.dmg\` artifacts that the Bazel pipeline no longer produces. Needs a doc-only sweep.