### PR TITLE
feat(connect): auth interceptor reusing existing JWT middleware

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -395,7 +395,10 @@ crate.spec(
 # the Go side.
 crate.spec(
     default_features = False,
-    features = ["prost-derive", "std"],
+    features = [
+        "prost-derive",
+        "std",
+    ],
     package = "prost",
     version = "0.13",
 )

--- a/backend/cmd/server/BUILD.bazel
+++ b/backend/cmd/server/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//backend/internal/api/connect",
+        "//backend/internal/api/connect/interceptors",
         "//backend/internal/api/grpc",
         "//backend/internal/api/rest",
         "//backend/internal/api/rest/v1:rest",
@@ -81,6 +82,7 @@ go_library(
         "//backend/migrations",
         "//backend/pkg/crypto",
         "//proto/runner/v1:runner_go_proto",
+        "@com_connectrpc_connect//:connect",
         "@com_github_golang_migrate_migrate_v4//:migrate",
         "@com_github_golang_migrate_migrate_v4//database/postgres",
         "@com_github_golang_migrate_migrate_v4//source/iofs",

--- a/backend/cmd/server/connect_init.go
+++ b/backend/cmd/server/connect_init.go
@@ -3,6 +3,11 @@ package main
 import (
 	"net/http"
 	"strings"
+
+	"connectrpc.com/connect"
+
+	"github.com/anthropics/agentsmesh/backend/internal/api/connect/interceptors"
+	"github.com/anthropics/agentsmesh/backend/internal/config"
 )
 
 // connectPathPrefix is the Connect-RPC canonical URL prefix —
@@ -12,13 +17,44 @@ import (
 // additive against the existing REST surface.
 const connectPathPrefix = "/proto."
 
+// defaultConnectHandlerOptions returns the HandlerOption set applied to
+// every Connect handler. The auth interceptor mirrors REST's
+// `middleware.AuthMiddleware`: it parses `Authorization: Bearer …`,
+// validates the JWT against `cfg.JWT.Secret`, and injects the resulting
+// `*middleware.TenantContext` (with UserID only — org scoping is the
+// service handler's job) into the request context.
+//
+// Per-service Mount functions accept `...connect.HandlerOption` and
+// must thread these through:
+//
+//	func Mount(mux *http.ServeMux, srv *Server, opts ...connect.HandlerOption) {
+//	    path, h := fooconnect.NewFooServiceHandler(srv, opts...)
+//	    mux.Handle(path, h)
+//	}
+//
+// Callers in wrapWithConnect wire it as `Mount(mux, srv, defaults...)`.
+func defaultConnectHandlerOptions(cfg *config.Config) []connect.HandlerOption {
+	return []connect.HandlerOption{
+		connect.WithInterceptors(
+			interceptors.NewAuthInterceptor(cfg.JWT.Secret),
+		),
+	}
+}
+
 // wrapWithConnect returns a top-level handler that prefers Connect for
 // `/proto.*` paths and falls through to the Gin REST router for
-// everything else. Service handlers are registered onto connectMux by
-// per-service mount calls added as services migrate off REST; the REST
-// router is untouched.
-func wrapWithConnect(rest http.Handler) http.Handler {
+// everything else. Per-service Mount calls registered onto connectMux
+// here pick up the default HandlerOptions (auth interceptor, …); the
+// REST router is untouched.
+func wrapWithConnect(cfg *config.Config, rest http.Handler) http.Handler {
 	connectMux := http.NewServeMux()
+	opts := defaultConnectHandlerOptions(cfg)
+
+	// Per-service mount points land here as Connect migration progresses,
+	// e.g.:
+	//   extensionconnect.Mount(connectMux, extensionconnect.NewServer(deps), opts...)
+	//   podconnect.Mount(connectMux, podconnect.NewServer(deps), opts...)
+	mountConnectServices(connectMux, opts)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, connectPathPrefix) {
@@ -28,3 +64,8 @@ func wrapWithConnect(rest http.Handler) http.Handler {
 		rest.ServeHTTP(w, r)
 	})
 }
+
+// mountConnectServices is the seam each per-service migration PR adds
+// to. Today it is empty (Phase 0: no services on Connect yet); the
+// signature is fixed so specialist PRs only insert one line each.
+func mountConnectServices(_ *http.ServeMux, _ []connect.HandlerOption) {}

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -225,7 +225,7 @@ func main() {
 	subscriptionScheduler := startSubscriptionJobs(db, cfg, services.email, appLogger.Logger)
 
 	// Start HTTP server
-	srv := startHTTPServer(cfg, wrapWithConnect(router))
+	srv := startHTTPServer(cfg, wrapWithConnect(cfg, router))
 
 	// Graceful shutdown
 	waitForShutdown(srv, grpcResult.server, eventBus, heartbeatBatcher, subscriptionScheduler, loopScheduler, orgAwareness, relayManager, services, db, redisClient)

--- a/backend/internal/api/connect/interceptors/BUILD.bazel
+++ b/backend/internal/api/connect/interceptors/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "interceptors",
+    srcs = [
+        "auth.go",
+        "claims.go",
+    ],
+    importpath = "github.com/anthropics/agentsmesh/backend/internal/api/connect/interceptors",
+    visibility = ["//backend:__subpackages__"],
+    deps = [
+        "//backend/internal/middleware",
+        "@com_connectrpc_connect//:connect",
+        "@com_github_golang_jwt_jwt_v5//:jwt",
+    ],
+)
+
+go_test(
+    name = "interceptors_test",
+    srcs = ["auth_test.go"],
+    deps = [
+        ":interceptors",
+        "//backend/internal/middleware",
+        "@com_connectrpc_connect//:connect",
+        "@com_github_golang_jwt_jwt_v5//:jwt",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/backend/internal/api/connect/interceptors/auth.go
+++ b/backend/internal/api/connect/interceptors/auth.go
@@ -1,0 +1,74 @@
+// Package interceptors holds Connect-RPC interceptors shared across the
+// per-service handlers in `backend/internal/api/connect/...`. The auth
+// interceptor adapts the existing REST JWT middleware
+// (`backend/internal/middleware/auth.go`) into the Connect handler
+// pipeline so business code reads the same `TenantContext` regardless of
+// transport.
+package interceptors
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"connectrpc.com/connect"
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/anthropics/agentsmesh/backend/internal/middleware"
+)
+
+// NewAuthInterceptor returns a Connect unary interceptor that validates
+// the JWT in the `Authorization: Bearer <token>` request header and
+// injects a `*middleware.TenantContext` (populated with UserID) into the
+// downstream context using `middleware.SetTenant`.
+//
+// The interceptor only fills `TenantContext.UserID`; per-RPC tenant
+// resolution (org slug → org ID + membership check) is the service
+// handler's job because the RPC procedure path carries no org slug.
+//
+// Tokens are parsed with the same HS256 logic as
+// `middleware.AuthMiddleware`; behavioural drift between the two paths
+// would be a security bug.
+func NewAuthInterceptor(jwtSecret string) connect.UnaryInterceptorFunc {
+	return func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			if req.Spec().IsClient {
+				return next(ctx, req)
+			}
+
+			claims, err := parseBearerToken(req.Header().Get("Authorization"), jwtSecret)
+			if err != nil {
+				return nil, err
+			}
+
+			ctx = middleware.SetTenant(ctx, &middleware.TenantContext{UserID: claims.UserID})
+			ctx = withClaims(ctx, claims)
+			return next(ctx, req)
+		}
+	}
+}
+
+func parseBearerToken(header, secret string) (*middleware.JWTClaims, error) {
+	parts := strings.SplitN(header, " ", 2)
+	if len(parts) != 2 || parts[0] != "Bearer" || parts[1] == "" {
+		return nil, connect.NewError(
+			connect.CodeUnauthenticated,
+			errors.New("authorization bearer token is required"),
+		)
+	}
+
+	claims := &middleware.JWTClaims{}
+	token, err := jwt.ParseWithClaims(parts[1], claims, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, errors.New("unexpected signing method")
+		}
+		return []byte(secret), nil
+	})
+	if err != nil || !token.Valid {
+		return nil, connect.NewError(
+			connect.CodeUnauthenticated,
+			errors.New("invalid or expired token"),
+		)
+	}
+	return claims, nil
+}

--- a/backend/internal/api/connect/interceptors/auth_test.go
+++ b/backend/internal/api/connect/interceptors/auth_test.go
@@ -1,0 +1,166 @@
+package interceptors_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anthropics/agentsmesh/backend/internal/api/connect/interceptors"
+	"github.com/anthropics/agentsmesh/backend/internal/middleware"
+)
+
+const testSecret = "test-secret-do-not-use-in-prod"
+
+type echoReq struct{ Msg string }
+type echoRes struct{ Echo string }
+
+func issueToken(t *testing.T, secret string, userID int64, exp time.Duration) string {
+	t.Helper()
+	tok, err := middleware.GenerateToken(userID, "u@example.com", "user", secret, 1)
+	require.NoError(t, err)
+	if exp == 0 {
+		return tok
+	}
+	// Re-mint with custom expiration to support the "expired" case.
+	claims := middleware.JWTClaims{
+		UserID:   userID,
+		Email:    "u@example.com",
+		Username: "user",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(exp)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			NotBefore: jwt.NewNumericDate(time.Now().Add(-time.Hour)),
+		},
+	}
+	signed, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(secret))
+	require.NoError(t, err)
+	return signed
+}
+
+// runInterceptor wraps a captureFunc with the auth interceptor and
+// invokes it the way connect-go does for handler-side unary RPCs.
+func runInterceptor(t *testing.T, header string, next connect.UnaryFunc) (connect.AnyResponse, error) {
+	t.Helper()
+	interceptor := interceptors.NewAuthInterceptor(testSecret)
+	req := connect.NewRequest(&echoReq{Msg: "hi"})
+	if header != "" {
+		req.Header().Set("Authorization", header)
+	}
+	wrapped := interceptor(next)
+	return wrapped(context.Background(), req)
+}
+
+func okHandler(t *testing.T, capture *context.Context) connect.UnaryFunc {
+	t.Helper()
+	return func(ctx context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+		*capture = ctx
+		return connect.NewResponse(&echoRes{Echo: "ok"}), nil
+	}
+}
+
+func TestAuthInterceptor_ValidToken_PopulatesContext(t *testing.T) {
+	token := issueToken(t, testSecret, 42, 0)
+
+	var captured context.Context
+	resp, err := runInterceptor(t, "Bearer "+token, okHandler(t, &captured))
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, captured, "downstream handler must have been called")
+
+	tenant := middleware.GetTenant(captured)
+	require.NotNil(t, tenant, "TenantContext must be injected via middleware.SetTenant")
+	assert.Equal(t, int64(42), tenant.UserID)
+
+	claims := interceptors.ClaimsFromContext(captured)
+	require.NotNil(t, claims)
+	assert.Equal(t, int64(42), claims.UserID)
+	assert.Equal(t, "u@example.com", claims.Email)
+}
+
+func TestAuthInterceptor_MissingHeader_ReturnsUnauthenticated(t *testing.T) {
+	called := false
+	resp, err := runInterceptor(t, "", func(context.Context, connect.AnyRequest) (connect.AnyResponse, error) {
+		called = true
+		return nil, nil
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.False(t, called, "downstream handler must NOT be called on auth failure")
+
+	var connectErr *connect.Error
+	require.True(t, errors.As(err, &connectErr))
+	assert.Equal(t, connect.CodeUnauthenticated, connectErr.Code())
+}
+
+func TestAuthInterceptor_InvalidTokens_ReturnUnauthenticated(t *testing.T) {
+	cases := []struct {
+		name   string
+		header string
+	}{
+		{"malformed_token", "Bearer not-a-jwt"},
+		{"wrong_signing_secret", "Bearer " + issueToken(t, "different-secret", 42, 0)},
+		{"missing_bearer_scheme", issueToken(t, testSecret, 42, 0)},
+		{"empty_bearer_value", "Bearer "},
+		{"non_bearer_scheme", "Basic dXNlcjpwYXNz"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			called := false
+			resp, err := runInterceptor(t, tc.header, func(context.Context, connect.AnyRequest) (connect.AnyResponse, error) {
+				called = true
+				return nil, nil
+			})
+
+			require.Error(t, err)
+			assert.Nil(t, resp)
+			assert.False(t, called)
+
+			var connectErr *connect.Error
+			require.True(t, errors.As(err, &connectErr))
+			assert.Equal(t, connect.CodeUnauthenticated, connectErr.Code())
+		})
+	}
+}
+
+func TestAuthInterceptor_ExpiredToken_ReturnsUnauthenticated(t *testing.T) {
+	expired := issueToken(t, testSecret, 42, -time.Hour)
+
+	called := false
+	resp, err := runInterceptor(t, "Bearer "+expired, func(context.Context, connect.AnyRequest) (connect.AnyResponse, error) {
+		called = true
+		return nil, nil
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.False(t, called)
+
+	var connectErr *connect.Error
+	require.True(t, errors.As(err, &connectErr))
+	assert.Equal(t, connect.CodeUnauthenticated, connectErr.Code())
+}
+
+func TestAuthInterceptor_PassesThroughHandlerErrors(t *testing.T) {
+	token := issueToken(t, testSecret, 42, 0)
+	downstreamErr := connect.NewError(connect.CodeNotFound, errors.New("resource missing"))
+
+	resp, err := runInterceptor(t, "Bearer "+token, func(context.Context, connect.AnyRequest) (connect.AnyResponse, error) {
+		return nil, downstreamErr
+	})
+
+	assert.Nil(t, resp)
+	var connectErr *connect.Error
+	require.True(t, errors.As(err, &connectErr))
+	assert.Equal(t, connect.CodeNotFound, connectErr.Code(),
+		"interceptor must not re-wrap downstream errors as Unauthenticated")
+}

--- a/backend/internal/api/connect/interceptors/claims.go
+++ b/backend/internal/api/connect/interceptors/claims.go
@@ -1,0 +1,23 @@
+package interceptors
+
+import (
+	"context"
+
+	"github.com/anthropics/agentsmesh/backend/internal/middleware"
+)
+
+type claimsCtxKey struct{}
+
+func withClaims(ctx context.Context, claims *middleware.JWTClaims) context.Context {
+	return context.WithValue(ctx, claimsCtxKey{}, claims)
+}
+
+// ClaimsFromContext returns the JWT claims attached by the auth
+// interceptor, or nil if the request was unauthenticated. Service
+// handlers prefer `middleware.GetTenant(ctx)` for the canonical UserID;
+// use this only when full claim fields (Email / Username / Exp / ...)
+// are needed.
+func ClaimsFromContext(ctx context.Context) *middleware.JWTClaims {
+	c, _ := ctx.Value(claimsCtxKey{}).(*middleware.JWTClaims)
+	return c
+}


### PR DESCRIPTION
## Summary

Stand up the Connect-RPC auth interceptor that mirrors REST's `middleware.AuthMiddleware`, so per-service Connect handlers (landing in subsequent PRs) all get auth automatically.

Prerequisite called out in [poc-report.md §3.4](.claude/worktrees/agent-a3d7d9878ce9caca4/poc-report.md):

> Service authentication: this POC has no auth on the Connect handler. The production version will need `connect.WithInterceptors(authInterceptor)` mirroring the existing `middleware.AuthMiddleware`. Test plan: stand up the auth interceptor before migrating the second service.

## What changed

- **New package** `backend/internal/api/connect/interceptors/` with:
  - `auth.go` — `NewAuthInterceptor(jwtSecret string) connect.UnaryInterceptorFunc`. Reads `Authorization: Bearer <token>`, parses HS256 JWT with the same secret + algorithm as REST `AuthMiddleware`, injects `*middleware.TenantContext{UserID: …}` via `middleware.SetTenant` (so handlers read tenants through the same API on both transports), and exposes the full `*middleware.JWTClaims` via `ClaimsFromContext` for handlers that need Email/Username.
  - `claims.go` — typed-key `ClaimsFromContext` accessor.
  - `auth_test.go` — 10 test cases (see below).
- **`backend/cmd/server/connect_init.go`** gains `defaultConnectHandlerOptions(cfg)` returning `[]connect.HandlerOption` containing the auth interceptor, plus a `mountConnectServices(mux, opts)` seam that future per-service Mount PRs extend with one line each — each gets auth automatically. Phase 0 has no services on Connect yet so the seam is empty. The function signature is fixed so specialist PRs only insert one `mount` line each.
- **`main.go`**: `wrapWithConnect` now takes `cfg` so it can build the default options.

## Per-service handler contract (for upcoming PRs)

Each service handler accepts `...connect.HandlerOption` and threads them into `NewXxxServiceHandler`:

```go
func Mount(mux *http.ServeMux, srv *Server, opts ...connect.HandlerOption) {
    path, h := fooconnect.NewFooServiceHandler(srv, opts...)
    mux.Handle(path, h)
}
```

In `mountConnectServices` (connect_init.go) the wiring becomes:

```go
fooconnect.Mount(mux, fooconnect.NewServer(deps), opts...)
barconnect.Mount(mux, barconnect.NewServer(deps), opts...)
```

Each service gets auth automatically.

## Why org scoping is left to handlers

Connect RPC procedure paths are `/<package>.<Service>/<Method>` and carry no org slug, so the auth interceptor only fills `TenantContext.UserID`. Per-RPC org resolution (`GetBySlug` + `IsMember` + role) belongs in the service handler, which reads `org_slug` from the request payload. This mirrors how `APIKeyAuthMiddleware` differs from `AuthMiddleware` + `TenantMiddleware` in REST.

## Test plan

10 test cases in `auth_test.go`, all green:

- `valid_token_populates_context` — ctx has tenant (UserID) + claims (Email, etc.)
- `missing_header_returns_unauthenticated` — CodeUnauthenticated
- `invalid_tokens` parameterized over 5 subcases:
  - `malformed_token` (not a JWT)
  - `wrong_signing_secret`
  - `missing_bearer_scheme`
  - `empty_bearer_value`
  - `non_bearer_scheme` (Basic auth)
- `expired_token_returns_unauthenticated`
- `passes_through_handler_errors` (downstream `CodeNotFound` not re-wrapped as Unauthenticated)

Locally verified:
```
bazel test //backend/internal/api/connect/interceptors:interceptors_test --test_output=streamed --test_arg=-test.v
PASS: 10/10 test cases
bazel test //backend/internal/middleware:middleware_test
PASS (existing REST middleware tests untouched)
bazel build //backend/cmd/server:server
PASS
```

## DO NOT MERGE TO main

Target is `feat/proto-migration`. Leave merge decision to team-lead.

## Notes for team-lead

- Did not touch `backend/internal/middleware/`. Behaviour drift between REST `AuthMiddleware` and the Connect interceptor would be a security bug, but for now the JWT parsing logic is replicated rather than extracted into a shared helper. **Recommend**: when a 3rd transport (e.g. websocket) emerges, refactor a `middleware.ParseBearerToken(header, secret) (*JWTClaims, error)` helper that both this interceptor and the gin middleware delegate to. Doing it now would expand the blast radius of this PR.
- `OptionalAuthMiddleware` is not mirrored — Connect RPCs are either authenticated or public (and public ones live behind their own un-mounted path or under a separate ServeMux). If a public Connect RPC emerges, add a per-RPC opt-out via `connect.WithConditionalHandlerOptions`.
- Lint (`bazel run //backend:lint`) currently fails on the proto-stub copy step on this worktree — reproduces on `origin/feat/proto-migration` HEAD without my changes (verified via `git stash`). Not caused by this PR.