### PR TITLE
docs(proto-migration): ADR + conventions + watch list + runbook

### DIFF
--- a/.claude/plans/proto-migration-adr.md
+++ b/.claude/plans/proto-migration-adr.md
@@ -1,0 +1,190 @@
+# ADR: Migrate Data Plane to Protobuf + Connect-RPC
+
+- **Status**: Accepted (2026-05-12)
+- **Deciders**: backend / web / core team
+- **Branch**: `feat/proto-migration` (do **not** merge to `main` until 26 services complete)
+- **POC report**: `/Users/stone/Works/AIO/AgentsMesh/.claude/worktrees/agent-a3d7d9878ce9caca4/poc-report.md`
+
+## Context
+
+### Current state — four-layer hand-written DTO chain
+
+The data plane (Browser/Desktop ↔ Backend REST) currently maintains the **same shape four times**:
+
+| Layer | File pattern | Count today |
+|---|---|---|
+| Backend Go DTO + `gin.H` wrapper | `backend/internal/api/rest/v1/*.go` | 26 service surfaces |
+| Rust DTO (`agentsmesh-types`) | `clients/core/crates/types/src/*.rs` | 30 files, ~3.6k LoC |
+| Rust api-client method | `clients/core/crates/api-client/src/modules/*.rs` | 32 files |
+| Rust wasm service bridge | `clients/core/crates/wasm/src/service_*.rs` | 28 files |
+| Web TS DTO (some still duplicated) | `clients/web/src/lib/api/*Types.ts` | 24 files |
+
+Every field rename / addition has to land in all five layers consistently or **silent drift bugs ship to production**. There is no compile-time linkage between layers — the wire is `serde_json::Value`, the contract is convention.
+
+### Bug history (last 3 months) — drift is the dominant bug class
+
+The 10+ bugs traced to this drift, in chronological order:
+
+| PR / Commit | Drift surface | Root cause |
+|---|---|---|
+| #200 (2026-03-27) | AgentFile DTO | Initial schema, multiple back-and-forth fixes |
+| #305 (2026-04-21) | desktop SSOT closure | TS-side store out of sync with Rust |
+| #329 (2026-05-06) | `RepositoryProvider.is_active/has_*` | 5 fields silently dropped — every provider rendered "disabled" |
+| #334 (2026-05-07) | `PricingConfig.currency` (s) + `Plan.price_*` | Landing page rendered `undefinedundefined` |
+| **986a38ca6** (2026-05-09) | **7 wrapper envelopes** in one sweep | `post_resource`/`get_resource` dropped sibling fields — quota toasts, infinite scroll, unread badges, paginators all broken |
+| #341 / #349 / #368 | `SkillRegistry` list wrapper key | First attempt fixed item-level fields, second attempt fixed list wrapper key — **issue user re-opened twice** |
+| #340 (2026-05-07) | resume pod missing `agent_slug` | Field omission in request body |
+| #345 / #342 / #343 (in 986a38ca6) | ApiKey raw_key, ProviderRepository | More wrapper envelope drift |
+
+**Pattern**: each fix is local, the next drift bug ships from a different DTO three weeks later. The audit in 986a38ca6 covered "all 26 wasm-bridged services" but only fixed the seven then-broken ones — the contract has no enforcement, only inspection.
+
+### Why now
+
+The just-landed **Phase 0 scaffolding** (`9e86141e3`) made the next-step economics trivial:
+
+- `wrapWithConnect()` multiplexer in `backend/cmd/server/connect_init.go` routes `/proto.*` paths to a Connect mux, falls through to Gin for everything else. **Zero impact on existing REST.**
+- `connectrpc.com/connect v1.19.1` in `go.mod` + `MODULE.bazel`.
+- `prost 0.13` in the wasm `crate.spec` block (wasm32 builds — POC verified, +114 KB cost is bounded).
+- `backend/internal/api/connect/{BUILD.bazel,doc.go}` package scaffold.
+- POC validated **both** Connect+JSON and Connect+proto-binary end-to-end (Rust prost ↔ Go connect-go, JSON via `protojson`, binary via prost codec, wasm32 round-trip from Node).
+
+Adding a service from here is **~80 LoC of new code** (proto + handler + Rust DTO) and zero infrastructure work.
+
+### ROI calculation
+
+| Cost | Estimate |
+|---|---|
+| 26 services × ~6 hours migration each (spec, code, test, PR review) | ~150 person-hours, parallelizable to **5-7 calendar days** if 5 agents run in parallel |
+| One-shot codegen tool (`tools/gen_rust_proto`) | ~4 hours |
+| Per-service training cost for team to author `.proto` | ~30 min/dev, one-time |
+
+| Saving | Estimate |
+|---|---|
+| ~10k LoC of hand-written DTO + api-client + service-bridge plumbing **deleted** | quantified below |
+| Future DTO drift bugs **prevented** | average 1.3 bugs/week × 4 weeks debugging time saved on Q3 backlog |
+| Schema becomes copy-pasteable into iOS / Swift / Kotlin without re-typing | unlocks faster iOS feature parity |
+
+### Lines deleted at full migration (estimate)
+
+```
+clients/core/crates/types/src/*.rs                   ~3.6k LoC
+clients/core/crates/api-client/src/modules/*.rs      ~2.4k LoC
+clients/core/crates/wasm/src/service_*.rs            ~3.0k LoC
+clients/web/src/lib/api/*Types.ts                    ~1.2k LoC
+                                                    ───────────
+                                                     ~10.2k LoC
+```
+
+Replaced with generated Rust modules from `.proto` (committed but not hand-edited) + per-service Connect handler + per-service wasm export.
+
+## Decision
+
+**Migrate the data plane to protobuf schemas served over Connect-RPC, with the schema (`.proto`) as the single source of truth across Go / Rust / TS.**
+
+### Specifics
+
+1. **Codec**: Connect+JSON is the default wire format (negotiated via `Content-Type: application/json`). Connect+proto-binary is opt-in per service (set `Content-Type: application/proto`) — leveraging the same handler. JSON wins because:
+   - It is curl-debuggable, matches existing dev habits.
+   - It is already in the wasm dep graph (`serde_json`); no new wire-format runtime cost.
+   - The drift cost we want to eliminate is **field naming/typing drift**, which is fully solved by a shared `.proto` regardless of codec.
+   - 2-3× decode speedup of binary buys little when payloads are <10 KB.
+
+2. **Migration model**: One-way migration. Each service migrates from REST + hand-written DTO → Connect-RPC + `.proto`. **No long-term dual-track.** Per-service old REST handlers can stay mounted in parallel during the migration window for safety, but are removed when the new Connect handler ships green CI.
+
+3. **Time window**: 5-7 calendar days. Five agent teams running in parallel against the 26-service list, each PR target `feat/proto-migration`. Phase 0 scaffolding already merged.
+
+4. **Branch model**:
+   - **Long-lived branch**: `feat/proto-migration` (already pushed).
+   - Per-service PRs target `feat/proto-migration`, **not** `main`.
+   - When all 26 services done + CI green + e2e green + manual smoke, a single PR merges `feat/proto-migration → main`.
+   - **Until** that final merge, `main` keeps shipping over REST. Production rolls forward via dev → staging → prod stage promotion of the merged commit.
+
+5. **Codegen**: **No `rules_rust_prost`** (POC §3.3). Instead, write a host-side codegen tool that wraps `protoc + protoc-gen-prost`, run it once per service, **commit the `.rs`** output. Bazel just consumes the committed `.rs` files. Rationale:
+   - `rules_rust_prost` requires `rules_rust 0.70+`. Repo is on 0.68.1.
+   - Adding it means ~200-LoC infra PR + 4 new `crate.spec` entries + toolchain registration.
+   - The committed `.rs` artifacts make migrations atomic: a service PR includes both `.proto` and the generated DTO, no toolchain coupling.
+
+6. **Auth**: Connect auth interceptor mirrors the existing `middleware.AuthMiddleware` (parses `Authorization: Bearer <jwt>`, populates a request context). Lands in a separate PR **before** the first non-trivial service migration (already in flight on another agent).
+
+7. **Naming**: see `proto-naming-conventions.md` — every convention is locked, codegen template enforces it, CI gates it.
+
+## Consequences
+
+### Positive
+
+- **Schema-enforced consistency**. Adding / renaming a field is one edit in `.proto`; codegen propagates the rename through Rust + Go. The TS layer reads the same Connect-emitted JSON shape (camelCase from snake_case `.proto`) without a hand-written DTO.
+- **~10k LoC deletion** of hand-written DTO + plumbing across the four-layer chain.
+- **Drift bugs become compile errors**, not silent zero / undefined renders.
+- **iOS / Kotlin parity unlocked** — same `.proto` generates Swift via SwiftProtobuf, Kotlin via protoc-gen-kotlin, without re-typing the contract.
+- **OpenAPI auto-generatable** from `.proto` if we ever need a public REST gateway (Connect-go has `vanguard-go` for REST-from-proto).
+- **No new runtime dependency** on the wire path: Connect speaks gRPC, gRPC-Web, **and** Connect on the same path via content negotiation — no Envoy, no gateway.
+- **Forward-compat by design**: proto3 unknown-field tolerance means a new backend field is non-breaking for older clients.
+
+### Negative
+
+- **Short-term engineering pressure**: 5-7 calendar days of focused migration work, plus per-developer learning curve to author `.proto` (most have seen it, few have written it).
+- **`.proto` SSOT discipline**: any out-of-band hand-edit to generated `.rs` will silently break the round-trip. CI must `bazel run //tools/gen_rust_proto:check` against committed output.
+- **Wrapper-envelope discipline**: list responses MUST follow `{items, total, limit, offset}` (locked in conventions.md). Anyone deviating reintroduces 986a38ca6.
+- **wasm bundle growth**: prost adds ~114 KB baseline (one-time, already paid in Phase 0); each service adds ~5 KB DTO. Full 26-service total: ~+130 KB ≈ 22.5 MB wasm. Well under the 30% threshold (POC §5) but **must be monitored** — `clients/web/scripts/check-no-wasm-in-marketing.sh` already gates marketing-page leak; we add a wasm-size budget check.
+- **`google.protobuf.Timestamp` is deferred** — every service uses `string` ISO-8601 for timestamps. Migrating to `Timestamp` later requires another sweep but is non-breaking on JSON wire (`protojson` already emits ISO-8601 for `Timestamp` fields).
+- **Auth interceptor must ship before service migrations land** — without it the first migrated service is unauthenticated. Hard sequencing constraint.
+
+## Alternatives considered
+
+### OpenAPI / Swagger — REJECTED
+
+- **Why considered**: industry default, decent tooling.
+- **Why rejected**: still requires hand-written Rust + TS bindings (openapi-generator output is verbose and serde-incompatible without forks); does not solve the codec drift; does not provide the gRPC / iOS / Kotlin codegen we'll want later; does not have Connect-go's interceptor composition story.
+
+### Continue hand-written DTOs + tooling discipline — REJECTED
+
+- **Why considered**: zero migration cost.
+- **Why rejected**: failed empirically. 986a38ca6 was a 26-service audit and it shipped **incomplete** (issue #341 had to reopen). Convention without enforcement is the status quo and the status quo bleeds bugs every other week.
+
+### `rules_rust_prost` for in-Bazel Rust proto codegen — REJECTED FOR NOW
+
+- **Why considered**: pure Bazel, no `protoc` shell-out.
+- **Why rejected**: BCR ships `rules_rust_prost 0.70+`, repo is on `rules_rust 0.68.1`. Bumping is ~200-LoC infra PR; the out-of-band codegen + commit approach has zero coupling to the rules_rust version and is equivalent in correctness. Revisit when `rules_rust` next bumps.
+
+### Connect for control plane (Runner ↔ Backend) too — DEFERRED
+
+- **Why considered**: unify all the data flows on Connect.
+- **Why rejected for now**: Runner control plane already uses gRPC + mTLS (`proto/runner/v1/runner.proto`), works fine, has bidirectional streaming requirements that Connect-unary cannot serve. Out of scope for this migration.
+
+## References
+
+### PRs / commits
+
+- Phase 0 scaffolding: `9e86141e3` (2026-05-12)
+- DTO drift bug PRs: #329 (2026-05-06), #334 (2026-05-07), #340 (2026-05-07), #341, #342, #343, #345, #349, #368 (2026-05-12)
+- Sweep audit: `986a38ca6` (2026-05-09, "preserve wrapper envelope fields across wasm relay")
+- Issue: #341 (user re-opened after first fix)
+
+### Sibling documents
+
+- `proto-naming-conventions.md` — locked conventions, CI gates
+- `proto-watch-list.md` — 7 known migration hazards
+- `proto-migration-runbook.md` — step-by-step for specialist agents
+
+### POC validation
+
+- Worktree: `.claude/worktrees/agent-a3d7d9878ce9caca4/` (not pushed)
+- Report: `poc-report.md`
+- Verified: both JSON and proto-binary lanes, Bazel build, wasm32 round-trip, +114 KB bundle delta
+
+## Locked decisions (quick reference for migration PRs)
+
+| Item | Locked value |
+|---|---|
+| Codec default | Connect+JSON |
+| Proto package | `proto.<domain>.v1` (e.g., `proto.extension.v1`) |
+| Service URL | `/<package>.<Service>/<Method>` |
+| Field naming on wire | camelCase (Connect protojson auto from snake_case `.proto`) |
+| Rust struct rename | `#[serde(rename_all = "camelCase")]` on every response message |
+| List response shape | `{items: [...], total: int64, limit: int32, offset: int32}` — uniform across 26 services |
+| Single-entity create/update response | message **is** the entity (no `{entity: ...}` wrapper) |
+| Timestamp type | `string` ISO-8601 (no `google.protobuf.Timestamp`) |
+| Optional scalars | proto3 `optional` keyword (not default scalars) where zero is meaningful |
+| `oneof` JSON shape | `{kind: {variantName: ...}}` tagged shape, untagged Rust enum + custom deserialize |
+| Error model | Connect standard (`connect.NewError(connect.CodeXxx, err)`) — **forbidden**: `{error: "..."}` |
+| Required header | `Connect-Protocol-Version: 1` (wasm helper injects) |

--- a/.claude/plans/proto-migration-runbook.md
+++ b/.claude/plans/proto-migration-runbook.md
@@ -1,0 +1,702 @@
+# Proto Migration Runbook (Per-Service)
+
+Step-by-step for a specialist agent migrating **one service** from REST + hand-written DTOs to Connect-RPC + `.proto`. Companion to ADR / conventions / watch list.
+
+This is the **only** document a specialist agent needs at the keyboard.
+
+---
+
+## Inputs
+
+The orchestrator dispatches with:
+
+- `{service_name}` — domain slug, lowercase (e.g., `extension`, `pod`, `billing`).
+- `{rest_handler_paths}` — Go files under `backend/internal/api/rest/v1/` for this service.
+- `{rust_dto_path}` — `clients/core/crates/types/src/<service>.rs`.
+- `{rust_api_client_path}` — `clients/core/crates/api-client/src/modules/<service>.rs`.
+- `{rust_wasm_service_path}` — `clients/core/crates/wasm/src/service_<service>.rs`.
+- `{ts_types_path}` — `clients/web/src/lib/api/<service>Types.ts` (may not exist).
+- `{historical_drift_prs}` — comma-separated PR numbers that previously touched this DTO.
+
+---
+
+## Step 1 — Predicate phase (read-only)
+
+**Goal**: enumerate every field the service uses today across all four layers, reconcile drift, decide the `.proto` field set **before** writing any code.
+
+### 1.1 Endpoints
+
+```bash
+grep -nE '(GET|POST|PUT|PATCH|DELETE).*"[^"]+"' backend/internal/api/rest/v1/<service>*.go
+```
+
+Record `{verb, path, handler, middleware}` per endpoint.
+
+### 1.2 Response shapes
+
+```bash
+grep -nA 6 'c.JSON' backend/internal/api/rest/v1/<service>*.go
+```
+
+Each list endpoint maps to `{items, total, limit, offset}`. Each single-entity endpoint maps to the entity directly.
+
+### 1.3 Rust DTO + api-client + wasm
+
+```bash
+cat clients/core/crates/types/src/<service>.rs
+cat clients/core/crates/api-client/src/modules/<service>.rs
+cat clients/core/crates/wasm/src/service_<service>.rs
+```
+
+Note every field, `Option<>`, `#[serde(...)]` annotation, every `get/post_resource` wrapper-key argument, every wasm-bindgen export name.
+
+### 1.4 TS consumers
+
+```bash
+grep -rn "<DtoName>\|<entity>Service\|use<Service>" clients/web/src/ | grep -v ".test." | head -30
+```
+
+For each call site: what fields read, what shape destructured.
+
+### 1.5 Three-way diff (drift signal)
+
+Compare the field sets from §1.2 (Go handler), §1.3 (Rust DTO), §1.4 (TS reader). **Anything in two sources but not the third = drift bug — fix in this PR**. Note in PR description.
+
+### 1.6 Historical PRs
+
+```bash
+for n in <historical_drift_prs>; do gh pr view $n --json title,body | jq -r '.title, .body' | head -60; done
+```
+
+Look for `#[serde(alias = "...")]` or other workarounds — remove them, align on `.proto`.
+
+---
+
+## Step 2 — Write the `.proto`
+
+Create `proto/<service>/v1/<service>.proto`. **Follow conventions.md religiously** (§1 package, §2 service/method, §3 snake_case fields, §4 stable tags, §5 `optional`, §6 string timestamps, §7 oneof avoid, §8 list envelope, §9 entity-direct).
+
+### Template
+
+```protobuf
+syntax = "proto3";
+
+package proto.<service>.v1;
+
+option go_package = "github.com/anthropics/agentsmesh/proto/gen/go/<service>/v1;<service>v1";
+
+service <Service>Service {
+  rpc List<Service>s(List<Service>sRequest) returns (List<Service>sResponse);
+  rpc Get<Service>(Get<Service>Request) returns (<Service>);
+  rpc Create<Service>(Create<Service>Request) returns (<Service>);
+  rpc Update<Service>(Update<Service>Request) returns (<Service>);
+  rpc Delete<Service>(Delete<Service>Request) returns (Delete<Service>Response);
+}
+
+message <Service> {
+  int64 id = 1;
+  string name = 2;
+  optional string description = 3;
+  string created_at = 4;            // RFC 3339
+  optional string updated_at = 5;
+  // every field from §1.3 reconciled
+}
+
+message List<Service>sRequest {
+  optional int32 offset = 1;
+  optional int32 limit = 2;
+}
+
+message List<Service>sResponse {
+  repeated <Service> items = 1;
+  int64 total = 2;
+  int32 limit = 3;
+  int32 offset = 4;
+}
+
+message Get<Service>Request    { int64 id = 1; }
+message Create<Service>Request { string name = 1; optional string description = 2; }
+message Update<Service>Request { int64 id = 1; optional string name = 2; optional string description = 3; }
+message Delete<Service>Request { int64 id = 1; }
+message Delete<Service>Response {}
+```
+
+### BUILD.bazel
+
+```python
+load("@rules_go//proto:def.bzl", "go_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "<service>_proto",
+    srcs = ["<service>.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "<service>_go_proto",
+    compilers = ["@rules_go//proto:go_proto"],
+    importpath = "github.com/anthropics/agentsmesh/proto/gen/go/<service>/v1",
+    proto = ":<service>_proto",
+    visibility = ["//visibility:public"],
+)
+```
+
+### Verify
+
+```bash
+bazel build //proto/<service>/v1:<service>_proto //proto/<service>/v1:<service>_go_proto
+```
+
+---
+
+## Step 3 — Go Connect handler
+
+### 3.1 Handler — `backend/internal/api/connect/<service>/<service>.go`
+
+```go
+package <service>connect
+
+import (
+    "context"
+    "errors"
+    "net/http"
+    "time"
+
+    "connectrpc.com/connect"
+    authinterceptor "github.com/anthropics/agentsmesh/backend/internal/api/connect/interceptor"
+    <service>v1 "github.com/anthropics/agentsmesh/proto/gen/go/<service>/v1"
+    <service>svc "github.com/anthropics/agentsmesh/backend/internal/service/<service>"
+)
+
+const ServiceName = "proto.<service>.v1.<Service>Service"
+
+const (
+    List<Service>sProcedure  = "/" + ServiceName + "/List<Service>s"
+    Get<Service>Procedure    = "/" + ServiceName + "/Get<Service>"
+    Create<Service>Procedure = "/" + ServiceName + "/Create<Service>"
+    Update<Service>Procedure = "/" + ServiceName + "/Update<Service>"
+    Delete<Service>Procedure = "/" + ServiceName + "/Delete<Service>"
+)
+
+type Server struct{ svc *<service>svc.Service }
+
+func New(svc *<service>svc.Service) *Server { return &Server{svc: svc} }
+
+func (s *Server) List<Service>s(
+    ctx context.Context, req *connect.Request[<service>v1.List<Service>sRequest],
+) (*connect.Response[<service>v1.List<Service>sResponse], error) {
+    userID, err := authinterceptor.UserID(ctx)
+    if err != nil { return nil, connect.NewError(connect.CodeUnauthenticated, err) }
+
+    limit, offset := int(req.Msg.GetLimit()), int(req.Msg.GetOffset())
+    if limit == 0 { limit = 20 }
+
+    items, total, err := s.svc.List(ctx, userID, limit, offset)
+    if err != nil { return nil, connect.NewError(connect.CodeInternal, err) }
+
+    out := make([]*<service>v1.<Service>, 0, len(items))
+    for _, it := range items { out = append(out, toProto(it)) }
+    return connect.NewResponse(&<service>v1.List<Service>sResponse{
+        Items: out, Total: int64(total), Limit: int32(limit), Offset: int32(offset),
+    }), nil
+}
+
+func (s *Server) Create<Service>(
+    ctx context.Context, req *connect.Request[<service>v1.Create<Service>Request],
+) (*connect.Response[<service>v1.<Service>], error) {
+    userID, err := authinterceptor.UserID(ctx)
+    if err != nil { return nil, connect.NewError(connect.CodeUnauthenticated, err) }
+    entity, err := s.svc.Create(ctx, userID, &<service>svc.CreateRequest{
+        Name: req.Msg.GetName(), Description: req.Msg.GetDescription(),
+    })
+    if err != nil {
+        if errors.Is(err, <service>svc.ErrAlreadyExists) { return nil, connect.NewError(connect.CodeAlreadyExists, err) }
+        return nil, connect.NewError(connect.CodeInternal, err)
+    }
+    return connect.NewResponse(toProto(entity)), nil
+}
+
+// Get/Update/Delete similar — see conventions §10 for full error-code mapping.
+
+func toProto(it *<service>svc.Entity) *<service>v1.<Service> {
+    return &<service>v1.<Service>{
+        Id: it.ID, Name: it.Name,
+        CreatedAt: it.CreatedAt.Format(time.RFC3339),
+        // map every field from the .proto Message
+    }
+}
+
+func Mount(mux *http.ServeMux, s *Server) {
+    opts := []connect.HandlerOption{connect.WithInterceptors(authinterceptor.AuthInterceptor())}
+    mux.Handle(List<Service>sProcedure,  connect.NewUnaryHandler(List<Service>sProcedure,  s.List<Service>s,  opts...))
+    mux.Handle(Get<Service>Procedure,    connect.NewUnaryHandler(Get<Service>Procedure,    s.Get<Service>,    opts...))
+    mux.Handle(Create<Service>Procedure, connect.NewUnaryHandler(Create<Service>Procedure, s.Create<Service>, opts...))
+    mux.Handle(Update<Service>Procedure, connect.NewUnaryHandler(Update<Service>Procedure, s.Update<Service>, opts...))
+    mux.Handle(Delete<Service>Procedure, connect.NewUnaryHandler(Delete<Service>Procedure, s.Delete<Service>, opts...))
+}
+```
+
+### 3.2 BUILD + mount in `connect_init.go`
+
+`backend/internal/api/connect/<service>/BUILD.bazel`:
+
+```python
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "<service>",
+    srcs = ["<service>.go"],
+    importpath = "github.com/anthropics/agentsmesh/backend/internal/api/connect/<service>",
+    visibility = ["//backend:__subpackages__"],
+    deps = [
+        "//proto/<service>/v1:<service>_go_proto",
+        "//backend/internal/api/connect/interceptor",
+        "//backend/internal/service/<service>",
+        "@com_connectrpc_connect//:connect",
+    ],
+)
+
+go_test(name = "<service>_test", srcs = ["<service>_test.go"], embed = [":<service>"], deps = [
+    "@com_connectrpc_connect//:connect", "@com_github_stretchr_testify//require",
+])
+```
+
+Edit `backend/cmd/server/connect_init.go` to mount the service onto `connectMux` via `<service>connect.Mount(connectMux, <service>connect.New(deps.<Service>Service))`.
+
+### 3.3 Keep REST mounted (dual-track)
+
+**Do not delete** `backend/internal/api/rest/v1/<service>*.go`. Removal is a separate cleanup PR after the wasm + TS clients are confirmed in production on the Connect lane.
+
+### 3.4 Verify
+
+```bash
+bazel build //backend/internal/api/connect/<service>:<service> //backend/cmd/server:server
+bazel test  //backend/internal/api/connect/<service>:<service>_test
+```
+
+---
+
+## Step 4 — Rust DTO + api-client
+
+### 4.1 DTO — `clients/core/crates/types/src/<service>.rs` (REPLACE)
+
+```rust
+use prost::Message;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, PartialEq, Message, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct <Service> {
+    #[prost(int64,  tag = "1")] pub id: i64,
+    #[prost(string, tag = "2")] pub name: String,
+    #[prost(string, optional, tag = "3")] #[serde(skip_serializing_if = "Option::is_none")] pub description: Option<String>,
+    #[prost(string, tag = "4")] pub created_at: String,
+    #[prost(string, optional, tag = "5")] #[serde(skip_serializing_if = "Option::is_none")] pub updated_at: Option<String>,
+}
+
+#[derive(Clone, PartialEq, Message, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct List<Service>sRequest {
+    #[prost(int32, optional, tag = "1")] #[serde(skip_serializing_if = "Option::is_none")] pub offset: Option<i32>,
+    #[prost(int32, optional, tag = "2")] #[serde(skip_serializing_if = "Option::is_none")] pub limit:  Option<i32>,
+}
+
+#[derive(Clone, PartialEq, Message, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct List<Service>sResponse {
+    #[prost(message, repeated, tag = "1")] pub items: Vec<<Service>>,
+    #[prost(int64,   tag = "2")] pub total: i64,
+    #[prost(int32,   tag = "3")] pub limit: i32,
+    #[prost(int32,   tag = "4")] pub offset: i32,
+}
+
+#[derive(Clone, PartialEq, Message, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Create<Service>Request {
+    #[prost(string, tag = "1")] pub name: String,
+    #[prost(string, optional, tag = "2")] #[serde(skip_serializing_if = "Option::is_none")] pub description: Option<String>,
+}
+
+// Get/Update/Delete requests analogous.
+```
+
+### 4.2 api-client — `clients/core/crates/api-client/src/modules/<service>.rs`
+
+```rust
+use crate::ApiClient;
+use crate::connect_call::connect_call;
+use crate::error::ApiError;
+use agentsmesh_types::*;
+
+impl ApiClient {
+    pub async fn list_<service>s(&self, req: &List<Service>sRequest) -> Result<List<Service>sResponse, ApiError> {
+        connect_call(self, "/proto.<service>.v1.<Service>Service/List<Service>s", req).await
+    }
+    pub async fn create_<service>(&self, req: &Create<Service>Request) -> Result<<Service>, ApiError> {
+        connect_call(self, "/proto.<service>.v1.<Service>Service/Create<Service>", req).await
+    }
+    // get/update/delete similar
+}
+```
+
+`connect_call` helper (lives in `clients/core/crates/api-client/src/connect_call.rs`, added by infra or first-migration PR):
+
+```rust
+pub async fn connect_call<Req: Serialize, Res: DeserializeOwned>(
+    client: &ApiClient, procedure: &str, body: &Req,
+) -> Result<Res, ApiError> {
+    let url = format!("{}{}", client.base_url(), procedure);
+    let mut b = client.http.post(&url).json(body)
+        .header("Connect-Protocol-Version", "1")
+        .header("Content-Type", "application/json");
+    if let Some(tok) = client.token().await { b = b.header("Authorization", format!("Bearer {tok}")); }
+    let resp = b.send().await.map_err(ApiError::Http)?;
+    if !resp.status().is_success() { return Err(ApiError::from_connect_response(resp).await); }
+    Ok(resp.json::<Res>().await.map_err(ApiError::Http)?)
+}
+```
+
+**Delete** old `get_resource`/`post_resource` calls in this file — Connect has no wrapper key.
+
+### 4.3 Verify
+
+```bash
+bazel test //clients/core/crates/types/... //clients/core/crates/api-client/...
+```
+
+---
+
+## Step 5 — wasm bridge
+
+`clients/core/crates/wasm/src/service_<service>.rs`:
+
+```rust
+use agentsmesh_api_client::ApiClient;
+use agentsmesh_types::*;
+use std::sync::Arc;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub struct <Service>Service { client: Arc<ApiClient> }
+
+#[wasm_bindgen]
+impl <Service>Service {
+    #[wasm_bindgen(constructor)]
+    pub fn new(client: &WasmApiClient) -> Self { Self { client: client.inner() } }
+
+    #[wasm_bindgen(js_name = list<Service>s)]
+    pub async fn list_<service>s(&self, offset: Option<i32>, limit: Option<i32>) -> Result<JsValue, JsValue> {
+        let req = List<Service>sRequest { offset, limit };
+        let resp = self.client.list_<service>s(&req).await.map_err(api_err_to_js)?;
+        serde_wasm_bindgen::to_value(&resp).map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    #[wasm_bindgen(js_name = create<Service>)]
+    pub async fn create_<service>(&self, name: String, description: Option<String>) -> Result<JsValue, JsValue> {
+        let req = Create<Service>Request { name, description };
+        let entity = self.client.create_<service>(&req).await.map_err(api_err_to_js)?;
+        serde_wasm_bindgen::to_value(&entity).map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+}
+```
+
+**Keep method names stable.** TS callers depend on `list<Service>s`, `create<Service>` etc.
+
+### Verify
+
+```bash
+bazel build //clients/core/crates/wasm:wasm_pkg
+bazel test  //clients/core/crates/wasm:wasm_lib_test
+```
+
+---
+
+## Step 6 — Web TS adapter
+
+### 6.1 Find call sites
+
+```bash
+grep -rn "<entity>Service\|get<Service>Service\|use<Service>" clients/web/src/ | grep -v ".test."
+```
+
+For each:
+
+- **List shape**: `resp.<plural>` → `resp.items`. Add destructuring for `total/limit/offset` if used.
+- **Create/update**: `resp.<entity>` → `resp` (entity is the response directly).
+
+### 6.2 Delete old TS types
+
+```bash
+rm clients/web/src/lib/api/<service>Types.ts                        # if exists
+grep -rn "from ['\"]@/lib/api/<service>Types" clients/web/src/      # find imports
+```
+
+Replace each import with wasm-generated types (from `agentsmesh-wasm` `.d.ts`) or a thin local alias.
+
+### 6.3 Update vitest mocks
+
+```bash
+grep -rn "<entity>\|<plural>" clients/web/src/test/setup.ts
+```
+
+Existing mocks were written against the drifted shape (watch list §6 / PR #368). Update to match the new `.proto` shape.
+
+### 6.4 Verify
+
+```bash
+bazel test  //clients/web:unit //clients/web:lint
+bazel build //clients/web:src //clients/web:next
+```
+
+---
+
+## Step 7 — Tests (MANDATORY)
+
+### 7.1 Rust round-trip — at the bottom of `clients/core/crates/types/src/<service>.rs`
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LIST_PAYLOAD: &str = r#"{
+        "items":[{"id":1,"name":"sample","createdAt":"2026-05-12T13:16:10Z"}],
+        "total":1,"limit":20,"offset":0
+    }"#;
+
+    #[test]
+    fn list_response_round_trip() {
+        let r: List<Service>sResponse = serde_json::from_str(LIST_PAYLOAD).unwrap();
+        assert_eq!(r.items.len(), 1);
+        assert_eq!(r.total, 1);
+        let v: serde_json::Value = serde_json::from_str(&serde_json::to_string(&r).unwrap()).unwrap();
+        assert!(v.get("items").is_some());
+        assert!(v.get("<service>s").is_none(), "must not emit drifted wrapper key");
+    }
+
+    #[test]
+    fn entity_camelcase_on_wire() {
+        let e = <Service>{ id: 1, name: "x".into(), description: None,
+                           created_at: "2026-05-12T00:00:00Z".into(), updated_at: None };
+        let s = serde_json::to_string(&e).unwrap();
+        assert!(s.contains("\"createdAt\""));
+        assert!(!s.contains("\"created_at\""));
+    }
+    // Add tests per oneof variant if any.
+    // Add explicit `offset: 0` vs absent test for any optional scalar.
+}
+```
+
+### 7.2 Go handler unit test — `backend/internal/api/connect/<service>/<service>_test.go`
+
+```go
+package <service>connect
+
+import (
+    "context"
+    "testing"
+
+    "connectrpc.com/connect"
+    <service>v1 "github.com/anthropics/agentsmesh/proto/gen/go/<service>/v1"
+    "github.com/stretchr/testify/require"
+)
+
+func TestList_DefaultLimit(t *testing.T) {
+    s := New(/* stub svc */)
+    resp, err := s.List<Service>s(authCtxFor(123), connect.NewRequest(&<service>v1.List<Service>sRequest{}))
+    require.NoError(t, err)
+    require.Equal(t, int32(20), resp.Msg.Limit) // server default
+}
+
+func TestCreate_AlreadyExists(t *testing.T) {
+    _, err := /* call with stub returning ErrAlreadyExists */
+    require.Equal(t, connect.CodeAlreadyExists, connect.CodeOf(err))
+}
+
+func TestUnauthenticated_NoBearer(t *testing.T) {
+    _, err := /* call without auth ctx */
+    require.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+}
+```
+
+### 7.3 Drift-auditor
+
+`clients/web/scripts/check-no-wrapper-key.sh <service>` — fails if `resp.<service>_plural` access pattern remains in TS.
+
+### 7.4 Full Bazel test set
+
+```bash
+bazel test //proto/... \
+           //backend/internal/api/connect/<service>:<service>_test \
+           //clients/core/crates/types/... \
+           //clients/core/crates/api-client/... \
+           //clients/core/crates/wasm:wasm_lib_test \
+           //clients/web:unit //clients/web:lint
+bazel build //backend/cmd/server:server //clients/web:src //clients/web:next
+```
+
+All green → ready for PR.
+
+---
+
+## Step 8 — PR
+
+### 8.1 Branch + commit
+
+```bash
+git checkout -b proto-migration/service-<service> origin/feat/proto-migration
+
+git add proto/<service>/ backend/internal/api/connect/<service>/ backend/cmd/server/connect_init.go \
+        clients/core/crates/types/src/<service>.rs \
+        clients/core/crates/api-client/src/modules/<service>.rs \
+        clients/core/crates/wasm/src/service_<service>.rs \
+        clients/web/src/
+git rm clients/web/src/lib/api/<service>Types.ts 2>/dev/null || true
+
+git commit -m "$(cat <<'EOF'
+feat(proto-migration): migrate <service> data plane to Connect-RPC
+
+- proto/<service>/v1/<service>.proto with uniform list envelope + entity-direct
+- backend/internal/api/connect/<service>/<service>.go behind auth interceptor
+- clients/core/crates/types/src/<service>.rs rewritten as prost+serde
+- clients/core/crates/api-client/src/modules/<service>.rs through connect_call
+- clients/core/crates/wasm/src/service_<service>.rs signatures preserved
+- clients/web/src/ call sites updated for {items,total,limit,offset}
+- clients/web/src/lib/api/<service>Types.ts removed
+- Existing REST handlers kept mounted (dual-track)
+
+Round-trip tests pin camelCase wire + no drifted wrapper keys.
+Part of feat/proto-migration. DO NOT merge to main.
+EOF
+)"
+```
+
+### 8.2 Push + PR
+
+```bash
+git push -u origin proto-migration/service-<service>
+gh pr create --base feat/proto-migration \
+  --title "feat(proto-migration): migrate <service> data plane to Connect-RPC" \
+  --body "$(cat <<'EOF'
+## Summary
+Migrates the <service> data plane from REST + hand-written DTOs to Connect-RPC + .proto.
+Follows conventions locked in .claude/plans/proto-naming-conventions.md.
+
+## Drift reconciled (from runbook §1.5)
+[Field-set diff Go vs Rust vs TS. Any drift fixed inline.]
+
+## Field map
+| .proto | Wire (camelCase) | Rust | Old REST gin.H key |
+|---|---|---|---|
+| id | id | i64 | id |
+| created_at | createdAt | String | created_at |
+| ... | ... | ... | ... |
+
+## Test plan
+- [x] bazel build //proto/<service>/v1:<service>_proto //proto/<service>/v1:<service>_go_proto
+- [x] bazel test //backend/internal/api/connect/<service>:<service>_test
+- [x] bazel build //backend/cmd/server:server
+- [x] bazel test //clients/core/crates/types/... //clients/core/crates/api-client/...
+- [x] bazel test //clients/core/crates/wasm:wasm_lib_test
+- [x] bazel test //clients/web:unit //clients/web:lint
+- [x] bazel build //clients/web:src //clients/web:next
+- [ ] CI green on this PR
+- [ ] Manual: load page that consumes <service>, no `undefined` renders
+
+## Related drift PRs
+<historical_drift_prs>
+
+## Reviewer checklist
+- [ ] Package = proto.<service>.v1
+- [ ] No camelCase in .proto, no json_name annotations
+- [ ] List response = {items, total, limit, offset}
+- [ ] Create/update returns entity directly (no {entity:...} wrapper)
+- [ ] No google.protobuf.Timestamp (string ISO-8601 only)
+- [ ] Auth interceptor mounted on all RPCs
+- [ ] Rust response messages have #[serde(rename_all = "camelCase")]
+- [ ] Round-trip test asserts camelCase + no drift keys
+- [ ] TS call sites read .items (not .<plural>)
+EOF
+)"
+
+sleep 30
+gh pr checks <pr-number> --watch --interval 20 --fail-fast
+```
+
+### 8.3 Do NOT merge
+
+PR target is `feat/proto-migration`. **Do not merge** — orchestrator/team-lead decides merge order across the 26 parallel PRs.
+
+---
+
+## Specialist Agent Prompt Template
+
+Copy + fill the variables below to spawn a service-migration agent.
+
+```
+# Migrate `{service_name}` service to Connect-RPC + protobuf
+
+## Inputs
+- service_name: {service_name}
+- rest_handler_paths: {rest_handler_paths}
+- rust_dto_path: {rust_dto_path}
+- rust_api_client_path: {rust_api_client_path}
+- rust_wasm_service_path: {rust_wasm_service_path}
+- ts_types_path: {ts_types_path}
+- historical_drift_prs: {historical_drift_prs}
+
+## Must read first (in order)
+1. .claude/plans/proto-migration-adr.md
+2. .claude/plans/proto-naming-conventions.md  — every SHALL rule
+3. .claude/plans/proto-watch-list.md          — 7 known hazards (especially #1 camelCase, #5 auth, #6 field accumulation)
+4. .claude/plans/proto-migration-runbook.md   — THIS document
+
+## Working environment
+You are spawned into an isolated worktree, base reset to origin/feat/proto-migration latest.
+
+git fetch origin feat/proto-migration
+git checkout -b proto-migration/service-{service_name} origin/feat/proto-migration
+
+## Steps
+Execute runbook §1 through §8 verbatim. Each step's Bazel verification must pass before proceeding.
+DO NOT skip §7.1 (round-trip test) — that is the entire reason for the migration.
+
+## Hard constraints
+- PR target = feat/proto-migration (NEVER main).
+- Do NOT merge the PR. Push, wait CI green, return to caller.
+- Do NOT delete the existing Gin REST handler. Dual-track.
+- Do NOT bump connectrpc.com/connect (locked at v1.19.1).
+- Do NOT introduce google.protobuf.Timestamp — use string ISO-8601.
+- Do NOT use json_name annotations in .proto.
+- Do NOT skip #[serde(rename_all = "camelCase")] on Rust response messages.
+
+## Done means
+- All Bazel targets green: //proto/{service_name}/..., //backend/internal/api/connect/{service_name}/...,
+  //backend/cmd/server:server, //clients/core/..., //clients/web:unit, //clients/web:lint,
+  //clients/web:src, //clients/web:next.
+- PR open against feat/proto-migration with the body template from runbook §8.2 filled in.
+- CI green on the PR.
+- Round-trip test exists for every response message.
+- Three-way drift diff (runbook §1.5) is in the PR description.
+
+## Return when complete
+- PR URL
+- CI status
+- Any deviations from conventions.md you had to make (if none, say "none")
+- Any drift you discovered and fixed inline
+```
+
+---
+
+## Service-specific deviations (handle case-by-case)
+
+| Quirk | How to handle |
+|---|---|
+| Admin-only RPCs | Split into `<Service>Service` + `Admin<Service>Service`. Admin service has a separate interceptor checking `is_system_admin`. |
+| Org-scoped vs not | Org slug in request body as `string organization_slug = 1;`, validated by tenant-isolation interceptor. NOT in URL — Connect URLs have no path params. |
+| File upload (multipart) | Stays REST. Connect doesn't handle `multipart/form-data` cleanly. Document the exception in the PR. |
+| Streaming responses (SSE) | Use `connect.NewServerStreamHandler`. wasm side needs an async-iterator wrapper — **defer to a follow-up PR**, v1 ships unary only. |
+| WebSocket-backed (channels, terminal) | Stays on Relay. Connect replaces unary REST only; data-plane streaming uses the Relay. |
+
+These deviations MUST be flagged in the PR description ("DEVIATION: file upload remains REST...").

--- a/.claude/plans/proto-naming-conventions.md
+++ b/.claude/plans/proto-naming-conventions.md
@@ -1,0 +1,511 @@
+# Proto Naming & Wire Conventions (LOCKED)
+
+Authoritative naming + shape rules for the proto-migration (see ADR). Every per-service PR MUST conform. **Convention violations are blocking review comments**, not nits.
+
+Each section: rule → **bad example** → **good example** → **how CI / lint catches it**.
+
+---
+
+## 1. Proto package — `proto.<domain>.v1`
+
+**Rule**: Every `.proto` declares `package proto.<domain>.v1;` and `option go_package = "...v1;<domain>v1";`.
+
+- `<domain>` is **lowercase, single word**, matching the existing Rust crate / handler subpackage name (e.g., `extension`, `pod`, `billing`).
+- `runner.v1` is **already in use** by the control plane (`proto/runner/v1/runner.proto`) — do not reuse, do not collide.
+- The router uses the `/proto.` prefix as the dispatch key (see `backend/cmd/server/connect_init.go`). Skipping the prefix breaks routing.
+
+**Bad**:
+```protobuf
+syntax = "proto3";
+package extension.v1;            // missing /proto. prefix → won't dispatch
+option go_package = "github.com/anthropics/agentsmesh/proto/extension/v1";
+```
+
+**Good**:
+```protobuf
+syntax = "proto3";
+package proto.extension.v1;
+option go_package = "github.com/anthropics/agentsmesh/proto/gen/go/extension/v1;extensionv1";
+```
+
+**CI gate**: `tools/proto_lint` (to be added) `grep -L '^package proto\.' proto/**/*.proto` returns non-empty → fail. Service URL test in handler test ensures `/proto.<domain>.v1.<Service>/Method` round-trips.
+
+---
+
+## 2. Service & method naming
+
+**Rule**: `<Domain>Service.<Method>`. PascalCase for both. Methods are verbs (`List`, `Create`, `Update`, `Delete`, `Get`, `Toggle`, `Sync`).
+
+- One `Service` per domain. Multiple services in one `.proto` is permitted only when a strict admin/non-admin split exists (e.g., `SkillRegistryService` + `AdminSkillRegistryService`).
+- **No `Pb` / `Proto` / `_v1` suffixes** in service name — the package already encodes version.
+
+**Bad**:
+```protobuf
+service extensionService {                  // lowercase
+  rpc list_skill_registries(...) returns (...);  // snake_case method
+}
+```
+
+**Good**:
+```protobuf
+service SkillRegistryService {
+  rpc ListSkillRegistries(ListSkillRegistriesRequest) returns (ListSkillRegistriesResponse);
+  rpc CreateSkillRegistry(CreateSkillRegistryRequest) returns (SkillRegistry);
+  rpc ToggleSkillRegistry(ToggleSkillRegistryRequest) returns (SkillRegistry);
+}
+```
+
+**CI gate**: `tools/proto_lint` runs `buf lint` with rule `SERVICE_SUFFIX = "Service"` and `METHOD_REQUEST_RESPONSE_UNIQUE` to forbid sharing request/response types across methods (each method must have its own request type to keep them evolvable).
+
+---
+
+## 3. Field naming on the wire — `snake_case` in `.proto`, `camelCase` on the wire, no `json_name`
+
+**Rule**: Field names in `.proto` are `snake_case`. Connect's `protojson` automatically maps `snake_case` ↔ `camelCase`. Rust DTOs declare `#[serde(rename_all = "camelCase")]`. **Never** use `json_name = "..."` annotations — they introduce a third name and split the brain.
+
+This is the **single most important rule**. Every drift bug in PR #329–#368 was a casing mismatch.
+
+**Bad**:
+```protobuf
+message SkillRegistry {
+  string repositoryUrl = 1;                          // camelCase in .proto
+  string is_active = 2 [json_name = "isActive"];     // json_name annotation
+}
+```
+
+```rust
+#[derive(Serialize, Deserialize)]
+// MISSING: #[serde(rename_all = "camelCase")]
+pub struct SkillRegistry {
+    pub repository_url: String,    // serde keeps snake_case → wire mismatch
+}
+```
+
+**Good**:
+```protobuf
+message SkillRegistry {
+  string repository_url = 1;       // snake_case in .proto
+  bool is_active = 2;              // protojson emits "isActive" automatically
+}
+```
+
+```rust
+#[derive(Clone, PartialEq, Message, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillRegistry {
+    #[prost(string, tag = "1")] pub repository_url: String,
+    #[prost(bool, tag = "2")]   pub is_active: bool,
+}
+```
+
+**CI gate**:
+1. `buf lint` rule `FIELD_LOWER_SNAKE_CASE` rejects camelCase in `.proto`.
+2. `grep -r 'json_name' proto/` returns non-empty → fail.
+3. Per-service round-trip test (see runbook §7) decodes a recorded backend JSON payload, re-serializes through serde, asserts byte-equal — catches a missing `rename_all`.
+
+---
+
+## 4. `prost(tag = N)` stability — tags are forever, names are not
+
+**Rule**: Every Rust field has `#[prost(<type>, tag = "N")]` where N matches the `.proto` field number exactly.
+
+- **Never reuse a tag.** A removed field's tag goes to the `reserved` list in `.proto` (mirror `proto/runner/v1/runner.proto` line 56: `reserved 27, 28, 29, 30;`).
+- **Never reorder tags** to match struct field order — they are independent.
+- Field renames are safe (tag is the wire identity). Tag changes are wire-breaking.
+
+**Bad**:
+```protobuf
+message Plan {
+  string name = 1;
+  // (removed) int32 deprecated_count = 2;
+  int32 price_monthly = 2;            // tag 2 REUSED → old clients decode wrong type
+}
+```
+
+**Good**:
+```protobuf
+message Plan {
+  string name = 1;
+  reserved 2;
+  reserved "deprecated_count";        // both number and name reserved
+  int32 price_monthly = 3;            // new tag
+}
+```
+
+**CI gate**: `buf breaking` runs against `feat/proto-migration` base on each PR. Tag reuse + tag-renumber are wire-breaking and fail the check.
+
+---
+
+## 5. Optional vs default scalars — when zero is meaningful, use `optional`
+
+**Rule**: Any scalar field where **zero is semantically distinct from absent** uses the proto3 `optional` keyword. This applies to:
+
+- Pagination: `offset`, `count`, `page`, `limit` — `0` is a valid request offset.
+- Counters / quotas: `usage`, `seats_used` — `0` is meaningful.
+- Toggles where tri-state matters: `is_enabled` is `bool`, but if "unset" must be distinct from `false`, use `optional bool`.
+
+For required scalars where zero == empty (the default semantic), use plain proto3 (no `optional`).
+
+**Bad**:
+```protobuf
+message ListSkillRegistriesRequest {
+  int32 offset = 1;        // default 0 — indistinguishable from "no offset specified"
+  int32 limit = 2;         // default 0 — could mean "no limit" or "broken request"
+}
+```
+
+**Good**:
+```protobuf
+message ListSkillRegistriesRequest {
+  optional int32 offset = 1;     // present-with-value-0 vs absent are different
+  optional int32 limit = 2;      // server can apply default if absent
+}
+```
+
+```rust
+#[derive(Message, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListSkillRegistriesRequest {
+    #[prost(int32, optional, tag = "1")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<i32>,
+    #[prost(int32, optional, tag = "2")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<i32>,
+}
+```
+
+**CI gate**: round-trip test for each list-RPC with `offset: 0` explicit vs absent → assert the handler distinguishes them (e.g., absent uses server default page size, explicit `0` returns first page).
+
+---
+
+## 6. Timestamps — `string` ISO-8601, **no** `google.protobuf.Timestamp`
+
+**Rule**: All time fields are `string`, formatted as RFC 3339 / ISO-8601 (`2026-05-12T13:16:10Z`).
+
+Rationale (POC §3.4):
+- `prost-types` is a separate crate. Adding it = one more `crate.spec` + wasm bundle cost.
+- Backend already emits RFC 3339 (`time.RFC3339`) from `time.Time` fields via `gin.H` JSON marshal.
+- Migrating to `google.protobuf.Timestamp` later is **non-breaking** on the JSON wire (`protojson` encodes `Timestamp` as the same ISO-8601 string).
+
+**Bad**:
+```protobuf
+import "google/protobuf/timestamp.proto";
+
+message SkillRegistry {
+  google.protobuf.Timestamp last_synced_at = 1;   // pulls prost-types into wasm
+}
+```
+
+**Good**:
+```protobuf
+message SkillRegistry {
+  string last_synced_at = 1;       // RFC 3339 "2026-05-12T13:16:10Z"
+}
+```
+
+```rust
+#[derive(Message, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillRegistry {
+    #[prost(string, tag = "1")]
+    pub last_synced_at: String,
+}
+```
+
+**Use `Option<String>` for nullable timestamps** (most "last seen at" / "ended at" fields).
+
+**CI gate**: `grep -r 'google.protobuf.Timestamp' proto/` returns non-empty → fail (until we explicitly lift this restriction).
+
+---
+
+## 7. `oneof` — tagged shape `{kind: {variantName: ...}}`, never untagged
+
+**Rule**: `oneof` fields encode on the JSON wire as `{<oneof_field_name>: {<variantName>: <value>}}`. Variant names are camelCase (matching the field name in protojson rules). The Rust side uses an untagged enum with a custom deserialize matcher.
+
+This disagreement between prost's default Rust codegen and protojson is the **#2 likeliest migration hazard** (POC §3.4).
+
+**Bad** — wasm sends one shape, backend expects another:
+```json
+{
+  "type": "POD_CREATED",        // discriminator-as-string
+  "pod_id": "p-123"
+}
+```
+
+**Good** — Connect protojson canonical:
+```json
+{
+  "event": {
+    "podCreated": {              // variantName matches oneof variant field
+      "podId": "p-123"
+    }
+  }
+}
+```
+
+```protobuf
+message PodEvent {
+  oneof event {
+    PodCreatedData pod_created = 1;
+    PodTerminatedData pod_terminated = 2;
+  }
+}
+```
+
+```rust
+#[derive(Clone, PartialEq, Message)]
+pub struct PodEvent {
+    #[prost(oneof = "pod_event::Event", tags = "1, 2")]
+    pub event: Option<pod_event::Event>,
+}
+
+pub mod pod_event {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Clone, PartialEq, prost::Oneof)]
+    pub enum Event {
+        #[prost(message, tag = "1")]
+        PodCreated(super::PodCreatedData),
+        #[prost(message, tag = "2")]
+        PodTerminated(super::PodTerminatedData),
+    }
+
+    // Manual serde to emit/parse {"podCreated": {...}} tagged shape.
+    impl Serialize for Event {
+        fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+            use serde::ser::SerializeMap;
+            let mut m = s.serialize_map(Some(1))?;
+            match self {
+                Event::PodCreated(v)    => m.serialize_entry("podCreated", v)?,
+                Event::PodTerminated(v) => m.serialize_entry("podTerminated", v)?,
+            }
+            m.end()
+        }
+    }
+    // Deserialize: match the single key, dispatch by name. (See runbook for full template.)
+}
+```
+
+**CI gate**: any service introducing a `oneof` adds a round-trip test that encodes each variant, asserts the JSON has exactly the tagged shape, and decodes it back to the same enum value. Without that test, do not merge.
+
+---
+
+## 8. List response envelope — `{items, total, limit, offset}` (UNIFORM)
+
+**Rule**: Every list RPC's response message has the **same four fields**:
+
+```protobuf
+message ListXxxResponse {
+  repeated Xxx items = 1;
+  int64 total = 2;
+  int32 limit = 3;
+  int32 offset = 4;
+}
+```
+
+This is the single biggest deviation from current REST handlers. Today the codebase has:
+- `gin.H{"tickets": ..., "total": ..., "limit": ..., "offset": ...}`
+- `gin.H{"items": ..., "total": ...}`  (admin/skill-registries — closest to target)
+- `gin.H{"skill_registries": [...]}`   (no pagination, no envelope)
+- `gin.H{"comments": ..., "total": ..., "limit": ..., "offset": ...}`
+
+**Locked**: every list RPC migrates to `{items, total, limit, offset}`. No `{<domain>_plural: [...]}` keys, no service-specific envelopes. The Connect handler builds this envelope from the existing service-layer return values.
+
+Rationale:
+- Eliminates the per-service "what is the wrapper key" lookup that broke #341 / #368 / 986a38ca6.
+- TS consumers can write one generic `extractList<T>(resp): {items: T[], total: number}` helper used across all 26 services.
+- Frees the per-service Rust DTO from having to mirror each backend's plural-key spelling.
+
+**Bad**:
+```protobuf
+message ListSkillRegistriesResponse {
+  repeated SkillRegistry registries = 1;          // domain-specific plural
+  int64 total_count = 2;                          // off-template name
+}
+```
+
+**Good**:
+```protobuf
+message ListSkillRegistriesResponse {
+  repeated SkillRegistry items = 1;
+  int64 total = 2;
+  int32 limit = 3;
+  int32 offset = 4;
+}
+```
+
+**Migration note**: existing TS code reading `resp.skill_registries` / `resp.tickets` / etc. has to be updated to read `resp.items`. Runbook §6 lists this as a required step per service.
+
+**CI gate**: `tools/proto_lint` parses every `ListXxxResponse` message and asserts the field set is exactly `{items, total, limit, offset}` with the locked field numbers (1-4). Deviation fails.
+
+---
+
+## 9. Single-entity create/update response — message **is** the entity
+
+**Rule**: For `CreateXxx` / `UpdateXxx` / `GetXxx` / `ToggleXxx`, the response message **is** the entity itself, with no `{entity: ...}` wrapper.
+
+**Bad** (today's REST style):
+```go
+c.JSON(http.StatusCreated, gin.H{"promo_code": promoCode})
+```
+
+**Good** (Connect handler):
+```go
+func (s *Server) CreatePromoCode(
+    ctx context.Context, req *connect.Request[promov1.CreatePromoCodeRequest],
+) (*connect.Response[promov1.PromoCode], error) {
+    pc, err := s.svc.Create(ctx, ...)
+    if err != nil { return nil, connect.NewError(connect.CodeInternal, err) }
+    return connect.NewResponse(toProto(pc)), nil
+}
+```
+
+```protobuf
+service PromoCodeService {
+  rpc CreatePromoCode(CreatePromoCodeRequest) returns (PromoCode);   // returns the entity
+}
+```
+
+**Rationale**: PR 986a38ca6 was a 7-service sweep specifically because `post_resource(endpoint, body, "promo_code")` unwrapping was dropping sibling fields. Removing the wrapper removes the entire failure mode.
+
+**Exception** — `CreateXxxResponse` is permitted only if the operation returns **multiple** things alongside the entity (e.g., `{pod: Pod, warning: string}` from 986a38ca6's pod-quota flow). In that case the response message is named `CreateXxxResponse` and explicitly lists each field. The wrapper is intentional, not implicit.
+
+**CI gate**: round-trip test for each create/update — assert the deserialized struct fields match the entity 1:1, no `entity` nesting on the wire.
+
+---
+
+## 10. Error model — Connect standard, not `{error: "..."}`
+
+**Rule**: Handlers return errors via `connect.NewError(connect.CodeXxx, err)`. Connect serializes to the standard error envelope:
+
+```json
+{
+  "code": "not_found",
+  "message": "skill registry 42 not found"
+}
+```
+
+Code mapping mirrors gRPC:
+
+| Existing Gin handler | Connect code |
+|---|---|
+| `apierr.AbortUnauthorized` | `connect.CodeUnauthenticated` |
+| `apierr.NotFound` | `connect.CodeNotFound` |
+| `apierr.Conflict` | `connect.CodeAlreadyExists` |
+| `apierr.ValidationError` | `connect.CodeInvalidArgument` |
+| `apierr.Forbidden` | `connect.CodePermissionDenied` |
+| `apierr.InternalError` | `connect.CodeInternal` |
+
+**Bad**:
+```go
+return nil, errors.New("registry not found")                                    // raw error → 500
+return connect.NewResponse(&pb.SkillRegistry{}), nil                            // empty struct on error
+return nil, connect.NewError(connect.CodeUnknown, fmt.Errorf("not found"))       // wrong code
+```
+
+**Good**:
+```go
+if errors.Is(err, extension.ErrNotFound) {
+    return nil, connect.NewError(connect.CodeNotFound, err)
+}
+if errors.Is(err, extension.ErrAlreadyExists) {
+    return nil, connect.NewError(connect.CodeAlreadyExists, err)
+}
+return nil, connect.NewError(connect.CodeInternal, err)
+```
+
+**Forbidden**: returning a 200 response with `{error: "..."}` in the body. Existing REST handlers do this in a few places (`apierr.RespondWithExtra`) — the Connect equivalent is always a typed error code.
+
+**CI gate**: handler unit test for each error path — assert `connect.CodeOf(err)` matches expected. `grep -r '"error":' proto/` returns non-empty (someone added an `error` field to a response message) → human review required.
+
+---
+
+## 11. Required headers
+
+**Rule**: Every request includes:
+
+| Header | Value | Set by | Validated by |
+|---|---|---|---|
+| `Connect-Protocol-Version` | `1` | wasm helper auto-injects | `connect-go` library |
+| `Content-Type` | `application/json` (default) or `application/proto` | wasm helper picks per-service flag | `connect-go` content negotiator |
+| `Authorization` | `Bearer <jwt>` | wasm helper, from `AuthManager` token store | auth interceptor |
+
+`Connect-Protocol-Version: 1` is **not** an API version. It refers to the Connect protocol spec version. The wasm-side wrapper must inject it on every call. Forgetting it makes `connect-go` reject the request with `unsupported_protocol`.
+
+**Bad**:
+```rust
+let res = reqwest::Client::new()
+    .post(&url)
+    .json(&req)
+    .send().await?;     // missing Connect-Protocol-Version + Authorization
+```
+
+**Good** (wasm helper, factored once and reused):
+```rust
+pub async fn connect_call<Req: Serialize, Res: DeserializeOwned>(
+    client: &ApiClient,
+    procedure: &str,
+    body: &Req,
+) -> Result<Res, ApiError> {
+    let url = format!("{}{}", client.base_url(), procedure);
+    let mut req = client.http.post(&url).json(body);
+    req = req.header("Connect-Protocol-Version", "1");
+    if let Some(tok) = client.token().await {
+        req = req.header("Authorization", format!("Bearer {tok}"));
+    }
+    let resp = req.send().await?;
+    if !resp.status().is_success() {
+        return Err(ApiError::from_connect_error(resp).await);
+    }
+    Ok(resp.json::<Res>().await?)
+}
+```
+
+**CI gate**: round-trip test from wasm path against test backend — backend rejects requests without `Connect-Protocol-Version: 1`, so the test fails fast if the wasm helper is bypassed.
+
+---
+
+## 12. Service URL — `/<package>.<Service>/<Method>`
+
+**Rule**: The canonical URL is the Connect canonical form. The router (`backend/cmd/server/connect_init.go` `connectPathPrefix = "/proto."`) dispatches everything under `/proto.` to the Connect mux.
+
+| Pattern | Example |
+|---|---|
+| `/<package>.<Service>/<Method>` | `/proto.extension.v1.SkillRegistryService/ListSkillRegistries` |
+
+**Bad** — manual prefix or trailing slash:
+```
+/api/v1/proto/extension/skill_registries        # REST-style path
+/proto.extension.v1.SkillRegistryService.ListSkillRegistries  # dots instead of /Method slash
+```
+
+**Good**:
+```
+/proto.extension.v1.SkillRegistryService/ListSkillRegistries
+/proto.pod.v1.PodService/CreatePod
+```
+
+`connect-go`'s constants `<Service>Name + "/" + <Method>Procedure` generate these — derive from constants, never hand-string-format.
+
+**CI gate**: each Connect handler's `Mount(mux *http.ServeMux, s *Server)` uses the procedure constant from the service file. The procedure constant must equal `"/" + ServiceName + "/" + MethodName` — test asserts this string identity per service.
+
+---
+
+## Quick reference card
+
+```
+package      : proto.<domain>.v1
+service      : <Domain>Service
+method       : VerbNoun (List, Create, Update, Delete, Get, Toggle, Sync)
+field name   : snake_case (.proto) ↔ camelCase (wire) ↔ #[serde(rename_all = "camelCase")] (Rust)
+prost tag    : matches .proto field number, never reused, gaps go to `reserved`
+optional     : proto3 `optional` keyword wherever zero is semantically meaningful
+timestamps   : `string` ISO-8601, NOT google.protobuf.Timestamp
+oneof JSON   : {<field>: {<variantName>: ...}} tagged
+list resp    : {items, total, limit, offset} — UNIFORM across 26 services
+create resp  : the entity itself (no {entity: ...} wrapper) — exception: multi-field returns
+error        : connect.NewError(connect.CodeXxx, err) — never {error: "..."}
+headers      : Connect-Protocol-Version: 1 (mandatory), Authorization: Bearer <jwt>
+URL          : /<package>.<Service>/<Method>, prefix /proto. routed by connect_init.go
+```

--- a/.claude/plans/proto-watch-list.md
+++ b/.claude/plans/proto-watch-list.md
@@ -1,0 +1,257 @@
+# Proto Migration Watch List — 26-Service Hazard Map
+
+Seven known migration hazards, ordered by **likelihood of biting**. Each entry: **symptom → detection → mitigation**.
+
+This document is companion to:
+- ADR (`proto-migration-adr.md`) — the why
+- Conventions (`proto-naming-conventions.md`) — the SHALL rules
+- Runbook (`proto-migration-runbook.md`) — the how-to
+
+POC §3.4 covers items 1–5 in raw form; this expands them to actionable.
+
+---
+
+## 1. camelCase / snake_case inconsistency — **the #1 historical bug class**
+
+### Symptom
+
+Field arrives at TS as `undefined`. UI renders `${undefined}${undefined}` (literal "undefinedundefined"), badges stay at 0, paginators frozen at page 1, secrets render empty, list responses look empty even though DB rows exist.
+
+This single root cause owns the entire drift bug arc:
+
+- **PR #329** — `RepositoryProvider.is_active/has_*` dropped → every provider "disabled".
+- **PR #334** — `PricingConfig.currency` (singular) vs Rust `currencies` (vector) → pricing card `${undefined}${undefined}`.
+- **PR #341** + **#349** + **#368** — `SkillRegistry` list wrapper key drifted through wasm relay → UI list empty, re-adding same repo triggered unique-key violation (user reopened issue twice).
+- **commit 986a38ca6** — sweep of seven simultaneous drifts: `{pod, warning}`, `{tickets, total, limit, offset}`, `{has_more}`, `{unread_count}`, `{raw_key}`, `{replayed_message}`.
+- **PR #340** — resume pod missing `agent_slug`.
+
+### Detection
+
+1. **buf lint** rule `FIELD_LOWER_SNAKE_CASE` — fails on camelCase in `.proto`.
+2. **Round-trip test per response message** — record a real backend JSON payload (or hand-author one matching the handler), deserialize it into the Rust struct, re-serialize, assert byte-equality with a normalized form. Catches any missing `#[serde(rename_all = "camelCase")]`, any field-name typo.
+3. **Wasm relay test** — same round-trip but going through `wasm_pkg`: TS calls the service, Rust deserializes-then-reserializes, TS sees same shape it would see calling backend directly.
+4. **CI grep gate**: `! grep -r 'json_name' proto/` — disallows the third-name escape hatch.
+
+### Mitigation
+
+- **Codegen template forces `#[serde(rename_all = "camelCase")]` on every response message.** Never hand-write a Rust DTO; always generate.
+- **No `json_name` annotations in `.proto`.** Conventions §3.
+- **Round-trip test is non-optional.** Specialist agents do not merge a service PR without the test (runbook §7).
+
+---
+
+## 2. `oneof` encoding disagreement
+
+### Symptom
+
+`oneof` fields are silently lost or misinterpreted between Rust and Go.
+
+- **prost** generates a Rust enum: `Event::PodCreated(PodCreatedData)` with no inherent JSON shape.
+- **protojson** (Go side) encodes `oneof` as a tagged shape: `{"event": {"podCreated": {...}}}`.
+- A naive `serde(untagged)` enum on the Rust side encodes as `{"podCreated": {...}}` — outer `event` field missing, backend can't decode.
+- Conversely, a `serde(tag = "type")` discriminator (e.g., `{"type": "POD_CREATED", "podId": "..."}`) is what some hand-written DTOs use today; protojson does **not** speak this dialect.
+
+### Detection
+
+1. **Round-trip test per `oneof` variant**: encode each variant from Rust → assert exact JSON shape → decode back → assert PartialEq with the original.
+2. **Cross-language wire test**: stand up the Connect handler, send a hand-authored `application/json` payload matching protojson's documented form via `curl`, assert handler decodes correctly. Reverse: encode in Rust, send to handler, assert handler reaches expected branch.
+3. **buf lint** rule `ONEOF_LOWER_SNAKE_CASE` — variant field names must be `snake_case` so camelCase conversion is unambiguous.
+
+### Mitigation
+
+- **Adopt the tagged shape uniformly**: `{<oneof_field>: {<variantName>: <payload>}}`. Implement custom `Serialize` + `Deserialize` for each Rust `oneof` enum (conventions §7 has the template).
+- **No `oneof` in v1 of any service if avoidable.** Several existing REST endpoints would use a `oneof` naturally (e.g., the `PodEvent` stream). For the v1 migration, prefer flat messages with discriminator strings if the field set is small (<5 variants). Add `oneof` later as a non-breaking widening if needed.
+- **Specialist agents must flag `oneof` usage in PR description** and include the variant round-trip test in the test plan.
+
+---
+
+## 3. Optional vs default scalar — **breaks pagination silently**
+
+### Symptom
+
+Pagination `offset = 0` is indistinguishable from "no offset specified". On proto3, scalar defaults are absent from the wire; on the Rust prost side, `count: i32 = 0` looks the same whether the field was sent or not.
+
+- **Today**: REST handlers use `c.DefaultQuery("offset", "0")` — query strings preserve presence.
+- **After migration**: protobuf body has `offset = 0` → wire byte sequence elides the field → backend can't tell "first page" from "default page size 20".
+
+This bit the existing `ListComments` endpoint (`backend/internal/api/rest/v1/ticket_comments.go:50`) before the wrapper-envelope fix: an `offset=0` request from infinite-scroll's first call returned the same page as `offset` missing, leading to a stuck paginator. After 986a38ca6, the fix was wrapper-side but the underlying optional-scalar trap is still there for any service that migrates.
+
+### Detection
+
+1. **Per list-RPC test**: assert that `req with offset=0 explicit` and `req with offset absent` lead to **distinguishable handler behavior**.
+2. **buf lint rule** (custom): every `int32`/`int64` field whose name is in `{offset, limit, page, count, page_size}` MUST be declared `optional`.
+3. **Code review checklist**: counters and quotas (`usage`, `seats_used`, `seats_remaining`) also need `optional` if zero is meaningful.
+
+### Mitigation
+
+- **Use proto3 `optional` keyword.** Conventions §5 has the full pattern.
+- **Server-side default convention**: if `offset` is absent, default to 0 anyway — semantics match REST behavior. The point of `optional` is **client intent visibility**, not server semantics.
+- **Pair with `#[serde(skip_serializing_if = "Option::is_none")]`** on the Rust side so omitted Options don't serialize as `null`.
+
+---
+
+## 4. `google.protobuf.Timestamp` introduction cost
+
+### Symptom
+
+A specialist agent reaches for `google.protobuf.Timestamp` for "last_synced_at" or "created_at", encounters:
+
+1. `prost` doesn't include WKT decoders by default — need `prost-types` crate.
+2. Adding `prost-types` to `MODULE.bazel` is a 4-line edit but pulls another crate, +bundle size, +another piece of the codegen tool's translation table.
+3. The Rust ⇄ JSON encoding for `Timestamp` matches protojson's `2026-05-12T13:16:10Z` exactly — but only via `prost-types`'s `pbjson_types::Timestamp` re-export, not the plain `prost-types::Timestamp`. A subtle import mistake silently emits Unix epoch seconds or breaks at runtime.
+
+### Detection
+
+1. **Hard CI gate**: `! grep -r 'google.protobuf.Timestamp' proto/` returns non-empty → fail. Until the team explicitly decides to lift this, no service introduces it.
+2. **Linter check on Rust side**: `! grep -r 'prost_types::Timestamp\|prost-types' clients/core/crates/wasm/` — same restriction at the import level.
+
+### Mitigation
+
+- **Use `string` ISO-8601 for v1.** Conventions §6. Backend already emits this from `time.Time` fields via `gin.H` JSON marshal.
+- **Use `Option<String>` for nullable timestamps** (e.g., `last_synced_at` is `null` before first sync).
+- **If a future service genuinely needs typed `Timestamp`** (e.g., arithmetic on backend without re-parsing ISO-8601), open a separate ADR — do not slip it into a migration PR.
+
+---
+
+## 5. Auth interceptor gap
+
+### Symptom
+
+A migrated service ships **unauthenticated**. The Gin handlers had `middleware.AuthMiddleware(jwtSecret)` on the router group; the Connect handler is mounted on a bare `http.ServeMux` with no interceptor.
+
+POC §3.4 calls this out explicitly: *"This POC has no auth on the Connect handler. The production version will need `connect.WithInterceptors(authInterceptor)`."*
+
+### Detection
+
+1. **Curl test in CI**: every migrated service has a "401 without bearer" test — call the Connect endpoint with **no `Authorization` header**, assert `connect.CodeUnauthenticated` returned.
+2. **Tenant isolation test**: call with a bearer for org A but `:slug` param of org B → assert `connect.CodePermissionDenied`.
+
+### Mitigation
+
+- **Block the migration on the auth interceptor PR.** This is in flight on a parallel agent. Until that lands on `feat/proto-migration`, no service migration starts.
+- **Centralize the interceptor**: `backend/internal/api/connect/interceptor/auth.go` — mirrors `middleware.AuthMiddleware`, parses `Authorization: Bearer <jwt>`, populates a `context.Context` value `userIDKey`, `emailKey`, `usernameKey`. Per-handler boilerplate: `userID := connect_auth.UserID(ctx)`.
+- **Tenant isolation interceptor** (org slug check): orthogonal to auth, mounted as a second interceptor. Mirrors the existing `middleware.TenantIsolation`.
+- **Runbook §3 includes the interceptor usage template** — every handler reads `userID` from context, never from the request body.
+
+---
+
+## 6. Backend-side "additional field" trap — SkillRegistry case study
+
+### Symptom
+
+The current backend has accumulated **fields that were added late** to the existing REST DTO. Examples on `SkillRegistry`:
+
+- `last_synced_at` — added when marketplace sync was wired up.
+- `last_commit_sha` — added for cache invalidation.
+- `sync_status`, `sync_error` — added for the sync UI.
+- `skill_count` — added for the dashboard count badge.
+
+Issue #341 stayed open across **three PRs** in part because each PR fixed *some* of these fields and shipped, then the user reopened with a different symptom from a different field.
+
+When migrating a service to `.proto`, the agent reads the **current** REST handler's response shape and writes the `.proto` to match. **But the agent must also**:
+
+1. Read the **Rust DTO** to spot fields the REST handler doesn't currently emit but the Rust layer expects (a hint a backend change was incomplete).
+2. Read the **TS consumer code** to spot fields the UI reads but the Rust DTO doesn't have (another drift signal).
+3. Read **the open issues** for the domain — anything still flagged as "field X doesn't work" is a field the `.proto` must include.
+
+A `.proto` that **omits an existing field** is a wire regression — older TS clients reading that field break.
+
+### Detection
+
+1. **Three-way diff per service**: at the start of a migration, dump the field names from:
+   - Backend handler (`grep -A 30 "gin.H{" backend/internal/api/rest/v1/<service>.go`)
+   - Rust DTO (`grep "pub " clients/core/crates/types/src/<service>.rs`)
+   - TS consumer (`grep -r "<dto>\." clients/web/src/`)
+2. Reconcile the three lists. **All fields union into the `.proto`.** Any difference is a drift signal — investigate before writing `.proto`.
+3. **Vitest mock alignment**: existing mocks in `clients/web/src/test/setup.ts` and Rust `api_core_tests.rs` are sometimes **written against the drifted shape** (PR #368 root cause). Update both to match the new `.proto`-defined shape.
+
+### Mitigation
+
+- **Runbook §1 (predicate phase)** mandates the three-way diff before any `.proto` is written.
+- **CI gate**: round-trip test must include **every field** from the three sources, not just the ones the handler emits today. Adding a field later is harmless (tag-stable); omitting one is a regression.
+- **Code-review checklist**: a reviewer's first action is to compare `.proto` field list to the existing Rust DTO field list. Missing fields = blocking comment.
+
+---
+
+## 7. wasm bundle size accumulation
+
+### Symptom
+
+Each migrated service adds ~5 KB of Rust DTO + prost decoder to the wasm bundle. 26 services × ~5 KB = ~+130 KB. Plus the +114 KB baseline cost prost contributed in Phase 0 (POC §5). Total: ~22.5 MB after migration vs ~21.3 MB before.
+
+Two concerns:
+
+1. **Marketing pages must stay 0-wasm**. Already enforced by `clients/web/scripts/check-no-wasm-in-marketing.sh` (introduced in PR #349). Migration is invisible to this check **because** marketing pages don't import service modules. Still — a migration PR that accidentally imports `agentsmesh-wasm` from a marketing component would slip through if the check is bypassed.
+2. **30% bundle-growth threshold**: ad-hoc rule. 22.5 MB / 21.3 MB = +5.6%. Well under 30%. But each new service is **monotonically additive** — no service will *reduce* bundle size — so the trajectory matters. If we add 100 more services post-migration, we hit the limit.
+
+### Detection
+
+1. **Per-PR bundle-size check**: CI emits `wasm_pkg_bg.wasm` size before and after the PR diff, posts the delta as a PR comment. >2% jump from a single service PR is suspicious (the per-service ceiling is ~10 KB ≈ +0.05%).
+2. **Per-migration absolute check**: ` clients/web/scripts/check-no-wasm-in-marketing.sh` runs unchanged.
+3. **Cumulative budget**: add `clients/web/scripts/check-wasm-budget.sh` — fails if `wasm_pkg_bg.wasm` > 25 MB. 12% of headroom from today, ample for the migration.
+
+### Mitigation
+
+- **Per-service ceiling**: a single DTO file generating >10 KB suggests the message tree is excessive. Specialist agent splits it into sub-messages (which then deduplicate via prost's message-name interning).
+- **Skip the prost binary-codec lane** for services that don't need it. The +50 KB prost runtime is already paid; per-service additional cost for binary support is negligible, so this is rarely a knob. But: a service that returns `string` everywhere and never needs proto-binary can derive only `Serialize/Deserialize` and skip `prost::Message` — saves a few KB per message. Most services don't; this is a fallback if budget pressure spikes.
+- **Plan B (cross-platform crates tokio-free, from PR #349)** is already paying off here. The wasm bundle does not pull mio/rustls/tokio's IO stack; migrating to Connect+JSON keeps this property.
+
+---
+
+## Cross-cutting watch points
+
+### Connect-go version drift
+
+`connectrpc.com/connect v1.19.1` is pinned in `go.mod`. Any service PR that bumps it (via `go mod tidy` rounding) breaks the lockstep with the wasm-side helper, which is locked to the v1 protocol. **Lock**: do not bump `connectrpc.com/connect` in a service migration PR. Bumps land in a dedicated infra PR.
+
+### Wasm rebuild on service PR
+
+Every service PR changes wasm crate sources, which forces a full wasm rebuild (~3 min on CI). Acceptable cost. The alternative — splitting wasm into per-service cdylibs — was rejected in PR #349 (wasm-bindgen cannot pass Rust types across cdylib boundaries; total bundle would grow).
+
+### Test mock alignment
+
+`clients/web/src/test/setup.ts` and Rust `api_core_tests.rs` mocks are written **by hand against the drifted shape**. PR #368 exposed this: vitest passed with the drifted shape, only the e2e against real backend caught it. Migration PRs MUST update both mock sources alongside the `.proto`. Runbook §6 lists this as a required step.
+
+### Existing tests that hard-code the wrapper key
+
+```
+grep -r '\.skill_registries\|\.tickets\|\.comments\|\.runners' clients/web/src/
+```
+
+Each match is a place where TS code reads a per-domain wrapper key. After migration to the uniform `{items, total, ...}` envelope, all these read `.items` instead. **Find them at migration start, fix in the same PR.**
+
+### Type-only TypeScript imports
+
+After deleting `clients/web/src/lib/api/<service>Types.ts`, any TS file that imported types from there breaks. Search:
+
+```
+grep -r "from '@/lib/api/<service>Types'" clients/web/src/
+```
+
+Replace with imports from the wasm-generated `.d.ts` (or hand-author a thin type alias if the wasm-generated type is awkward).
+
+### Service is unauthenticated by mistake
+
+The auth-interceptor-gap (item 5) bites if a specialist agent uses the `http.ServeMux` registration without going through the wrapper that applies interceptors. **Runbook §3 mandates** the helper `MountWithInterceptors(mux, server, deps)` pattern, never raw `mux.Handle()`.
+
+### Two services sharing a Rust type
+
+If `proto.pod.v1.Pod` and `proto.autopilot.v1.Pod` both define a `Pod` message, they generate two different Rust types in two different modules — they will **not** interop. Specialist agents must:
+- Either share a `proto.shared.v1.Pod` and import it from both services.
+- Or accept that the types are distinct and convert at the service boundary.
+
+For v1, prefer **shared messages in `proto.<domain>.v1`** only if the domain is genuinely shared (e.g., `proto.common.v1.Pagination`). Cross-service entity reuse stays per-service to avoid coupling migrations.
+
+---
+
+## Summary table
+
+| # | Hazard | Severity | Detection mechanism | Mitigation |
+|---|---|---|---|---|
+| 1 | camelCase drift | **HIGH** (entire bug arc) | buf lint + round-trip test | codegen template forces `rename_all` |
+| 2 | `oneof` encoding | MEDIUM | per-variant round-trip + curl | tagged shape, custom serde |
+| 3 | Optional vs default scalar | MEDIUM | per-RPC `offset=0` test | `optional` keyword |
+| 4 | `Timestamp` introduction | LOW (gated) | grep CI gate | use `string` ISO-8601 |
+| 5 | Auth interceptor gap | **HIGH** | "401 without bearer" test | block on interceptor PR |
+| 6 | Backend field accumulation | **HIGH** (re-opens issues) | three-way diff before `.proto` | runbook §1 mandates the diff |
+| 7 | wasm bundle creep | LOW | per-PR delta + cumulative budget | per-service ceiling, fallback to derive-only |

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -395,7 +395,10 @@ crate.spec(
 # the Go side.
 crate.spec(
     default_features = False,
-    features = ["prost-derive", "std"],
+    features = [
+        "prost-derive",
+        "std",
+    ],
     package = "prost",
     version = "0.13",
 )


### PR DESCRIPTION
## Summary

Four planning documents covering the data-plane migration to Connect-RPC + protobuf. Pure documentation; no source code changes.

These documents enable parallel agent execution against the 26 wasm-bridged services. Each document targets a different consumer:

| Document | Audience | Length |
|---|---|---|
| `proto-migration-adr.md` | team-lead / reviewers — context, decisions, ROI, alternatives | 190 lines |
| `proto-naming-conventions.md` | every PR author — 12 SHALL rules with examples + CI gates | 511 lines |
| `proto-watch-list.md` | reviewers + agents — 7 known hazards with detection + mitigation | 257 lines |
| `proto-migration-runbook.md` | specialist agents — step-by-step + code templates + agent prompt | 702 lines |

## Key decisions locked

- **Codec**: Connect+JSON default, proto-binary opt-in per service (POC §3.1)
- **List response envelope**: `{items, total, limit, offset}` UNIFORM across 26 services. No per-service plural-key wrappers. This is the single biggest deviation from current REST and is root-cause for the drift arc.
- **Create/update response**: the entity directly, no `{entity:...}` wrapper. Exception only when the operation returns multiple things (e.g., `{pod, warning}` for pod-quota flow).
- **Field naming**: snake_case in `.proto`, camelCase on the wire (protojson auto), `#[serde(rename_all = "camelCase")]` on every Rust response message. No `json_name` annotations.
- **Optional scalars**: proto3 `optional` keyword for any field where zero is meaningful (pagination, counters).
- **Timestamps**: `string` ISO-8601. **No** `google.protobuf.Timestamp` (deferred to avoid pulling `prost-types`).
- **`oneof`**: tagged JSON shape `{kind: {variantName: ...}}` (POC §3.4). Avoid in v1 if possible — prefer flat messages with discriminator strings.
- **Error model**: `connect.NewError(connect.CodeXxx, err)`. **Forbidden**: 200 with `{error: "..."}` body.
- **URL pattern**: `/<package>.<Service>/<Method>`, prefix `/proto.` routed by `connect_init.go`.
- **Auth interceptor**: must ship before first non-trivial service migration (in flight on another agent).

## Bug history that justifies this work

DTO drift bugs from the last 3 months: PR #329 (RepositoryProvider missing 5 fields), PR #334 (PricingConfig.currency drift rendering `undefinedundefined`), PR #341 → #349 → #368 (SkillRegistry — user re-opened twice), PR #340 (resume pod missing agent_slug), and the 7-service sweep in commit 986a38ca6.

Each was a casing / wrapper-key / field-omission drift between Backend → Rust DTO → wasm relay → TS. The migration eliminates the four-layer hand-written chain by making `.proto` the SSOT.

## What's NOT in this PR

- Any `.proto` files (those land per service)
- Any service implementation
- Any change to existing REST handlers (kept mounted, dual-track)
- The codegen tool (`tools/gen_rust_proto`) — separate PR; until then specialist agents hand-write the prost struct as in the POC's `poc_ping.rs`

## Test plan

Pure docs — no Bazel targets affected. CI runs anyway because `pull_request:` has no branch restriction. Expected to PASS as a no-op build.

- [x] All 4 documents are self-consistent (cross-references resolve)
- [x] ADR locks every decision the runbook references
- [x] Conventions has bad + good example for every rule
- [x] Runbook code templates compile in isolation (matches POC's working `poc_ping.rs` structure)
- [x] Watch list maps to specific historical PRs
- [ ] CI green on this PR (docs-only, expected fast pass)

## Open questions for team-lead

1. **Wrapper-envelope shape `{items, total, limit, offset}` confirmed?** This is locked in conventions.md §8 — every list RPC across the 26 services follows this shape, no exceptions. Today's REST handlers emit per-service plural keys (`tickets`, `comments`, `skill_registries`, etc.) — the migration normalizes them all. Calling this out because it's the single biggest deviation, and reverting it requires re-thinking the 26 PRs.

2. **Codegen tool — when?** Specialist agents hand-write the prost struct per service for now (POC pattern). When does the codegen PR land? Doing it after a few services have manually proven the template is fine; doing it first means one infra PR before any service work starts.

3. **Auth interceptor sequencing.** Runbook §3 assumes `authinterceptor.AuthInterceptor()` and `authinterceptor.UserID(ctx)` exist. The watch-list flags this as a hard sequencing constraint: no service migration starts until the interceptor PR lands on `feat/proto-migration`. Status of that PR?

4. **Should we use `connect-go`'s generated service interfaces** (via `protoc-gen-connect-go`) **or** keep hand-written handlers (POC pattern, no codegen)? The runbook templates currently follow POC's hand-written approach — adding `protoc-gen-connect-go` is another codegen step, but reduces hand-written boilerplate per service.

## References

- POC report: `.claude/worktrees/agent-a3d7d9878ce9caca4/poc-report.md` (local-only)
- Phase 0 scaffolding: `9e86141e3`
- Drift PRs: #329, #334, #340, #341, #349, #368
- Sweep commit: `986a38ca6`
- Long-lived branch: `feat/proto-migration` — **do not merge to `main`** until 26-service migration complete