### PR TITLE
fix(backend): unblock DeleteOrganization + bump runner token TTL to 24h

### DIFF
--- a/backend/internal/api/rest/v1/BUILD.bazel
+++ b/backend/internal/api/rest/v1/BUILD.bazel
@@ -229,6 +229,7 @@ go_test(
         "files_benchmark_test.go",
         "files_setup_test.go",
         "files_upload_test.go",
+        "organizations_delete_test.go",
         "organizations_reserved_test.go",
         "pod_commands_test.go",
         "pod_create_integration_test.go",

--- a/backend/internal/api/rest/v1/organizations_delete_test.go
+++ b/backend/internal/api/rest/v1/organizations_delete_test.go
@@ -1,0 +1,135 @@
+package v1_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/anthropics/agentsmesh/backend/internal/api/rest/v1"
+	orgDomain "github.com/anthropics/agentsmesh/backend/internal/domain/organization"
+	"github.com/anthropics/agentsmesh/backend/internal/service/organization"
+	"github.com/anthropics/agentsmesh/backend/internal/service/user"
+)
+
+// deleteOrgRepoStub is a configurable Repository fake for DeleteOrganization
+// scenarios. Unlike orgRepoStub (which panics by design — used to assert that
+// reserved-slug short-circuits *before* any repo call), this one lets each
+// test program GetBySlug / GetMember / DeleteWithCleanup outcomes to cover the
+// 200 / 403 / 404 / 500 branches of the handler.
+type deleteOrgRepoStub struct {
+	orgRepoStub
+	org              *orgDomain.Organization
+	getBySlugErr     error
+	member           *orgDomain.Member
+	getMemberErr     error
+	deleteErr        error
+	deleteWithCleanupCalls int
+}
+
+func (s *deleteOrgRepoStub) GetBySlug(context.Context, string) (*orgDomain.Organization, error) {
+	return s.org, s.getBySlugErr
+}
+func (s *deleteOrgRepoStub) GetMember(context.Context, int64, int64) (*orgDomain.Member, error) {
+	return s.member, s.getMemberErr
+}
+func (s *deleteOrgRepoStub) DeleteWithCleanup(context.Context, int64) error {
+	s.deleteWithCleanupCalls++
+	return s.deleteErr
+}
+
+func setupDeleteTestRouter(t *testing.T, repo *deleteOrgRepoStub) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(gin.RecoveryWithWriter(io.Discard))
+
+	orgSvc := organization.NewService(repo)
+	userSvc := user.NewService(nil)
+	handler := v1.NewOrganizationHandler(orgSvc, userSvc)
+
+	g := r.Group("/api/v1/orgs")
+	g.Use(func(c *gin.Context) { c.Set("user_id", int64(42)); c.Next() })
+	g.DELETE("/:slug", handler.DeleteOrganization)
+	return r
+}
+
+func decodeBody(t *testing.T, body io.Reader) map[string]any {
+	t.Helper()
+	var m map[string]any
+	require.NoError(t, json.NewDecoder(body).Decode(&m))
+	return m
+}
+
+func TestDeleteOrganization_Success_200(t *testing.T) {
+	repo := &deleteOrgRepoStub{
+		org:    &orgDomain.Organization{ID: 213, Slug: "acme", Name: "Acme"},
+		member: &orgDomain.Member{OrganizationID: 213, UserID: 42, Role: orgDomain.RoleOwner},
+	}
+	r := setupDeleteTestRouter(t, repo)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("DELETE", "/api/v1/orgs/acme", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 1, repo.deleteWithCleanupCalls)
+	assert.Equal(t, "Organization deleted", decodeBody(t, w.Body)["message"])
+}
+
+func TestDeleteOrganization_NotOwner_403(t *testing.T) {
+	repo := &deleteOrgRepoStub{
+		org:    &orgDomain.Organization{ID: 213, Slug: "acme"},
+		member: &orgDomain.Member{OrganizationID: 213, UserID: 42, Role: orgDomain.RoleMember},
+	}
+	r := setupDeleteTestRouter(t, repo)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("DELETE", "/api/v1/orgs/acme", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Equal(t, "OWNER_REQUIRED", decodeBody(t, w.Body)["code"])
+	assert.Zero(t, repo.deleteWithCleanupCalls, "non-owner must not reach repo")
+}
+
+func TestDeleteOrganization_NotFound_404(t *testing.T) {
+	repo := &deleteOrgRepoStub{getBySlugErr: orgDomain.ErrNotFound}
+	r := setupDeleteTestRouter(t, repo)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("DELETE", "/api/v1/orgs/no-such-org", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, "RESOURCE_NOT_FOUND", decodeBody(t, w.Body)["code"])
+	assert.Zero(t, repo.deleteWithCleanupCalls)
+}
+
+// Regression guard for the production bug (DeleteWithCleanup hitting SQLSTATE
+// 42703 on pod_bindings.channel_id): a repo-level failure must surface as a
+// 500 INTERNAL_ERROR, *not* be silently dropped. If the handler ever changes
+// to ignore Delete errors or returns 2xx on failure, this test catches it.
+func TestDeleteOrganization_ServiceFailure_500(t *testing.T) {
+	repo := &deleteOrgRepoStub{
+		org:       &orgDomain.Organization{ID: 213, Slug: "acme"},
+		member:    &orgDomain.Member{OrganizationID: 213, UserID: 42, Role: orgDomain.RoleOwner},
+		deleteErr: errors.New("simulated db failure"),
+	}
+	r := setupDeleteTestRouter(t, repo)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("DELETE", "/api/v1/orgs/acme", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, "INTERNAL_ERROR", decodeBody(t, w.Body)["code"])
+	assert.Equal(t, 1, repo.deleteWithCleanupCalls)
+}

--- a/backend/internal/infra/BUILD.bazel
+++ b/backend/internal/infra/BUILD.bazel
@@ -105,6 +105,7 @@ go_test(
         "loop_run_repo_test.go",
         "loop_run_repo_trigger_test.go",
         "loop_test_setup_test.go",
+        "organization_repo_test.go",
         "token_usage_repo_aggregation_test.go",
         "token_usage_repo_filter_test.go",
         "token_usage_repo_test.go",
@@ -112,6 +113,7 @@ go_test(
     embed = [":infra"],
     deps = [
         "//backend/internal/domain/loop",
+        "//backend/internal/domain/organization",
         "//backend/internal/domain/tokenusage",
         "//backend/internal/testkit",
         "@com_github_stretchr_testify//assert",

--- a/backend/internal/infra/organization_repo.go
+++ b/backend/internal/infra/organization_repo.go
@@ -111,9 +111,9 @@ func (r *organizationRepo) DeleteWithCleanup(ctx context.Context, id int64) erro
 		if err := tx.Exec("DELETE FROM channel_access WHERE channel_id IN ("+subq+")", id).Error; err != nil {
 			return err
 		}
-		if err := tx.Exec("DELETE FROM pod_bindings WHERE channel_id IN ("+subq+")", id).Error; err != nil {
-			return err
-		}
+		// pod_bindings is cleaned up by FK CASCADE on organization_id (see migration 000001);
+		// it has no channel_id column — referencing one used to crash DeleteWithCleanup with
+		// SQLSTATE 42703, blocking *every* org deletion in production.
 		if err := tx.Exec("DELETE FROM channels WHERE organization_id = ?", id).Error; err != nil {
 			return err
 		}

--- a/backend/internal/infra/organization_repo_test.go
+++ b/backend/internal/infra/organization_repo_test.go
@@ -1,0 +1,136 @@
+package infra
+
+import (
+	"context"
+	"testing"
+
+	"github.com/anthropics/agentsmesh/backend/internal/domain/organization"
+	"github.com/anthropics/agentsmesh/backend/internal/testkit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func seedOrganization(t *testing.T, db *gorm.DB, slug string) int64 {
+	t.Helper()
+	org := organization.Organization{Name: "Test", Slug: slug}
+	require.NoError(t, db.Create(&org).Error)
+	return org.ID
+}
+
+func countWhereOrg(t *testing.T, db *gorm.DB, table string, orgID int64) int64 {
+	t.Helper()
+	var n int64
+	require.NoError(t, db.Table(table).Where("organization_id = ?", orgID).Count(&n).Error)
+	return n
+}
+
+func assertOrgDeleted(t *testing.T, db *gorm.DB, id int64) {
+	t.Helper()
+	var org organization.Organization
+	err := db.First(&org, id).Error
+	assert.ErrorIs(t, err, gorm.ErrRecordNotFound)
+}
+
+func TestOrganizationRepo_DeleteWithCleanup_EmptyOrg(t *testing.T) {
+	db := testkit.SetupTestDB(t)
+	repo := NewOrganizationRepository(db)
+
+	id := seedOrganization(t, db, "empty-org")
+
+	require.NoError(t, repo.DeleteWithCleanup(context.Background(), id))
+
+	assertOrgDeleted(t, db, id)
+}
+
+func TestOrganizationRepo_DeleteWithCleanup_WithChannels(t *testing.T) {
+	db := testkit.SetupTestDB(t)
+	repo := NewOrganizationRepository(db)
+
+	id := seedOrganization(t, db, "chan-org")
+
+	require.NoError(t, db.Exec(
+		"INSERT INTO channels (id, organization_id, name) VALUES (?, ?, ?), (?, ?, ?)",
+		1, id, "general", 2, id, "random",
+	).Error)
+	require.NoError(t, db.Exec(
+		"INSERT INTO channel_messages (channel_id, body) VALUES (1, 'hi'), (1, 'bye'), (2, 'yo')",
+	).Error)
+	require.NoError(t, db.Exec(
+		"INSERT INTO channel_members (channel_id, user_id) VALUES (1, 100), (2, 100)",
+	).Error)
+	require.NoError(t, db.Exec(
+		"INSERT INTO channel_read_states (channel_id, user_id) VALUES (1, 100)",
+	).Error)
+	require.NoError(t, db.Exec(
+		"INSERT INTO channel_pods (channel_id, pod_key) VALUES (1, 'pod-a')",
+	).Error)
+	require.NoError(t, db.Exec(
+		"INSERT INTO channel_access (channel_id) VALUES (1)",
+	).Error)
+
+	require.NoError(t, repo.DeleteWithCleanup(context.Background(), id))
+
+	assertOrgDeleted(t, db, id)
+	for _, tbl := range []string{
+		"channels", "channel_messages", "channel_members",
+		"channel_read_states", "channel_pods", "channel_access",
+	} {
+		var n int64
+		require.NoError(t, db.Table(tbl).Count(&n).Error)
+		assert.Zerof(t, n, "%s should be empty after org cleanup", tbl)
+	}
+}
+
+// Regression guard for the production bug fixed in this PR.
+//
+// pod_bindings has no channel_id column (see migration 000001) — the old
+// DeleteWithCleanup tried `DELETE FROM pod_bindings WHERE channel_id IN (...)`
+// and crashed every org deletion with SQLSTATE 42703. We rely on the
+// organization_id FK CASCADE to clean the table now.
+//
+// The testkit schema previously included a spurious `channel_id` column that
+// hid the bug; with that fixed, this test would have failed on the old code.
+func TestOrganizationRepo_DeleteWithCleanup_WithPodBindings(t *testing.T) {
+	db := testkit.SetupTestDB(t)
+	repo := NewOrganizationRepository(db)
+
+	id := seedOrganization(t, db, "bindings-org")
+
+	require.NoError(t, db.Exec(
+		"INSERT INTO pod_bindings (organization_id, initiator_pod, target_pod) VALUES (?, 'pod-a', 'pod-b'), (?, 'pod-c', 'pod-d')",
+		id, id,
+	).Error)
+	require.Equal(t, int64(2), countWhereOrg(t, db, "pod_bindings", id))
+
+	require.NoError(t, repo.DeleteWithCleanup(context.Background(), id))
+
+	assertOrgDeleted(t, db, id)
+	// testkit's in-memory SQLite has FKs disabled, so CASCADE doesn't fire.
+	// What matters is that DeleteWithCleanup does NOT touch pod_bindings.channel_id —
+	// the test passes purely because the buggy SQL is gone. Production Postgres
+	// has the real ON DELETE CASCADE on pod_bindings.organization_id (see
+	// migration 000001) so the actual cleanup happens there.
+}
+
+func TestOrganizationRepo_DeleteWithCleanup_WithLoops(t *testing.T) {
+	db := testkit.SetupTestDB(t)
+	repo := NewOrganizationRepository(db)
+
+	id := seedOrganization(t, db, "loops-org")
+
+	require.NoError(t, db.Exec(
+		"INSERT INTO loops (id, organization_id, name, slug, prompt_template) VALUES (1, ?, 'L1', 'l1', 'p')",
+		id,
+	).Error)
+	require.NoError(t, db.Exec(
+		"INSERT INTO loop_runs (organization_id, loop_id, run_number) VALUES (?, 1, 1), (?, 1, 2)",
+		id, id,
+	).Error)
+
+	require.NoError(t, repo.DeleteWithCleanup(context.Background(), id))
+
+	assertOrgDeleted(t, db, id)
+	assert.Zero(t, countWhereOrg(t, db, "loops", id), "loops missing application-level cleanup")
+	assert.Zero(t, countWhereOrg(t, db, "loop_runs", id), "loop_runs missing application-level cleanup")
+}

--- a/backend/internal/service/runner/registration_token.go
+++ b/backend/internal/service/runner/registration_token.go
@@ -31,7 +31,10 @@ func (s *Service) GenerateGRPCRegistrationToken(ctx context.Context, orgID, user
 	// Set defaults
 	expiresIn := req.ExpiresIn
 	if expiresIn <= 0 {
-		expiresIn = 3600 // 1 hour default
+		// 24h default — 1h was too short for the realistic "copy token → install
+		// runner on laptop → run register" flow; users routinely hit expired-token
+		// errors after stepping away briefly.
+		expiresIn = 86400
 	}
 	maxUses := req.MaxUses
 	if maxUses <= 0 {

--- a/backend/internal/testkit/schema_business.go
+++ b/backend/internal/testkit/schema_business.go
@@ -65,7 +65,6 @@ func channelTableDDLs() []string {
 		`CREATE TABLE IF NOT EXISTS pod_bindings (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			organization_id INTEGER NOT NULL,
-			channel_id INTEGER,
 			initiator_pod TEXT NOT NULL, target_pod TEXT NOT NULL,
 			granted_scopes TEXT DEFAULT '[]', pending_scopes TEXT DEFAULT '[]',
 			status TEXT NOT NULL DEFAULT 'pending',

--- a/clients/web/e2e-playwright/tests/settings/org-delete.spec.ts
+++ b/clients/web/e2e-playwright/tests/settings/org-delete.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from "../../fixtures/index";
+import { uniqueSuffix } from "../../helpers/test-data";
+
+/**
+ * Regression for the production bug where DELETE /api/v1/orgs/:slug always
+ * returned 500 due to `DELETE FROM pod_bindings WHERE channel_id IN (...)` —
+ * pod_bindings has no channel_id column (see migration 000001). Every user
+ * attempting to delete an organization hit "An internal error occurred".
+ *
+ * Three layers of guard now cover the fix: repo-level cleanup test in
+ * backend/internal/infra/organization_repo_test.go, handler integration test
+ * in backend/internal/api/rest/v1/organizations_delete_test.go, and this
+ * full-stack flow.
+ */
+test.describe("Organization Deletion", () => {
+  test("owner deletes org via API and the row is gone", async ({ api, db }) => {
+    const slug = `e2e-delete-${uniqueSuffix()}`.toLowerCase().replace(/_/g, "-");
+
+    const createRes = await api.post("/api/v1/orgs", {
+      name: "E2E Delete Target",
+      slug,
+    });
+    expect(createRes.status, await createRes.text()).toBe(201);
+
+    const delRes = await api.delete(`/api/v1/orgs/${slug}`);
+    expect(delRes.status, await delRes.text()).toBe(200);
+
+    const getRes = await api.get(`/api/v1/orgs/${slug}`);
+    expect(getRes.status).toBe(404);
+
+    // Belt-and-suspenders teardown in case the test failed mid-way.
+    db.cleanup(`DELETE FROM organizations WHERE slug = '${slug}'`);
+  });
+
+  test("UI: clicking Delete Organization on settings page deletes and redirects", async ({
+    page,
+    api,
+    db,
+  }) => {
+    const slug = `e2e-uidel-${uniqueSuffix()}`.toLowerCase().replace(/_/g, "-");
+
+    const createRes = await api.post("/api/v1/orgs", {
+      name: "E2E UI Delete",
+      slug,
+    });
+    expect(createRes.status, await createRes.text()).toBe(201);
+
+    try {
+      await page.goto(`/${slug}/settings?scope=organization&tab=general`);
+      await page.waitForLoadState("networkidle");
+
+      // Danger Zone "Delete Organization" button — case-insensitive to be
+      // resilient against locale shifts (the button label is i18n-driven).
+      await page.getByRole("button", { name: /delete organization/i }).click();
+
+      // The project's Dialog component (clients/web/src/components/ui/dialog.tsx)
+      // does NOT set role="dialog" — it just renders a portal with
+      // `data-dialog-overlay`. Use that attribute instead of getByRole.
+      const dialog = page.locator("[data-dialog-overlay]");
+      await expect(dialog).toBeVisible();
+      // Two "Delete Organization" buttons exist once the dialog opens: the
+      // Danger Zone trigger and the confirm action. Pick the one inside the
+      // overlay to avoid re-clicking the trigger.
+      await dialog
+        .getByRole("button", { name: /delete organization/i })
+        .click();
+
+      // UI feedback: either a success toast or sidebar/URL no longer shows the
+      // deleted org. The post-delete redirect can be "/" or another org slug
+      // depending on the user's other memberships — assert the deleted slug is
+      // gone instead of pinning the destination.
+      await expect(page).not.toHaveURL(new RegExp(`/${slug}(/|$|\\?)`), {
+        timeout: 10_000,
+      });
+
+      const getRes = await api.get(`/api/v1/orgs/${slug}`);
+      expect(getRes.status).toBe(404);
+    } finally {
+      db.cleanup(`DELETE FROM organizations WHERE slug = '${slug}'`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Two production bugs surfaced while a user tried to install a runner. Root-caused via the on-prod backend logs + traefik access log.

### 🔴 Bug 1 — DeleteOrganization returns 500 for every user (P0)

\`backend/internal/infra/organization_repo.go\` line 114 ran:
\`\`\`sql
DELETE FROM pod_bindings WHERE channel_id IN (SELECT id FROM channels WHERE organization_id = ?)
\`\`\`

But \`pod_bindings\` has **no \`channel_id\` column** (see migration 000001 — it associates via \`initiator_pod\`/\`target_pod\` + \`organization_id\` FK CASCADE). Postgres rejects the statement at parse-time with \`SQLSTATE 42703 column \"channel_id\" does not exist\`, the cleanup transaction rolls back, and **every** org deletion returns 500 → frontend shows \"An internal error occurred. Please try again later.\"

Traefik access log on US West confirms this is **global**:
\`\`\`
[03/May/2026:03:17:48] DELETE /api/v1/orgs/rsunilkumar92-workspace HTTP/2.0 500
[12/May/2026:14:56:28] DELETE /api/v1/orgs/appfab-technology HTTP/2.0   500
... 5 more 500s for appfab-technology over 19 minutes
\`\`\`

No 200 response for \`DELETE /api/v1/orgs/:slug\` has ever been recorded.

**Fix**: Drop the buggy statement. \`pod_bindings.organization_id\` has \`ON DELETE CASCADE\`, so the final \`tx.Delete(org)\` cleans it up automatically.

### 🟡 Bug 2 — Runner token expires in 1h (UX)

\`registration_token.go:34\` defaulted token TTL to 3600 seconds. The realistic \"generate token in UI → copy → walk to a laptop → install runner → run \`agentsmesh-runner register\`\" flow easily exceeds an hour; users routinely come back to expired tokens.

**Fix**: Default 24h (86400s). Frontend currently sends \`{}\` so it always hits the default — that's the value end users see.

### 🟢 Side fix — testkit schema drift

\`backend/internal/testkit/schema_business.go\`'s \`pod_bindings\` DDL **fabricated a \`channel_id INTEGER\` column** that doesn't exist in production. This is exactly why no existing test caught Bug 1: the testkit was hiding the missing column. Dropped it so testkit matches migration 000001.

## Three-layer regression coverage

| Layer | File | Cases |
|---|---|---|
| **Repo** | \`backend/internal/infra/organization_repo_test.go\` | EmptyOrg / WithChannels / **WithPodBindings** / WithLoops |
| **Handler** | \`backend/internal/api/rest/v1/organizations_delete_test.go\` | Success_200 / NotOwner_403 / NotFound_404 / **ServiceFailure_500** |
| **E2E** | \`clients/web/e2e-playwright/tests/settings/org-delete.spec.ts\` | API-only round-trip + UI confirm-dialog flow |

\`TestOrganizationRepo_DeleteWithCleanup_WithPodBindings\` is the regression guard for Bug 1; it can only meaningfully verify the fix after the testkit schema drift is corrected.

\`TestDeleteOrganization_ServiceFailure_500\` guards against a future regression where the handler silently swallows repo errors (the current squash already loses the underlying message — a related cleanup, not done here).

## Verification

\`\`\`bash
bazel test //backend/internal/infra:infra_test --test_filter=TestOrganizationRepo_DeleteWithCleanup
# → 4/4 PASSED

bazel test //backend/internal/api/rest/v1:rest_test --test_filter=TestDeleteOrganization
# → 4/4 PASSED

bazel test //backend/...
# → 80/80 PASSED (no schema-drift regression elsewhere)

bazel test //clients/web/e2e-playwright:e2e --test_tag_filters=e2e \\
  --test_env=WEB_PORT=... HTTP_PORT=... POSTGRES_PORT=... COMPOSE_PROJECT_NAME=... \\
  --test_arg=--grep --test_arg="Organization Deletion"
# → 2/2 PASSED (live against dev stack)
\`\`\`

## Out of scope (separate follow-ups)

- Field-name mismatch: frontend Rust types send \`expires_in_days\`, backend expects \`expires_in\` (seconds). User-unreachable today because frontend always sends \`{}\`, but worth aligning when a custom-TTL UI lands.
- \`organizations_crud.go:160\` squashes all service errors into a single laggy 500 — should map to specific error codes so the frontend can surface real reasons.
- Frontend \`Dialog\` component (\`clients/web/src/components/ui/dialog.tsx\`) lacks \`role="dialog"\` — found while debugging the e2e selector. Accessibility issue.

## Test plan

- [x] Repo unit tests pass
- [x] Handler integration tests pass
- [x] All backend tests pass (regression sweep)
- [x] E2E pass against live dev stack
- [ ] After merge: \`paolo@appfabtech.com\` (org \`appfab-technology\`) can finally delete the org or generate a new 24h token and install the runner