### PR TITLE
fix(runner): SendPrompt completes PTY submission with separate Enter write

### DIFF
--- a/backend/internal/api/grpc/runner_adapter_mcp_pod_interaction.go
+++ b/backend/internal/api/grpc/runner_adapter_mcp_pod_interaction.go
@@ -112,9 +112,11 @@ func (a *GRPCRunnerAdapter) mcpSendPodInput(ctx context.Context, tc *middleware.
 		return nil, newMcpError(503, "pod router not available")
 	}
 
-	// Send text via mode-agnostic RoutePrompt (PTY: writes to stdin, ACP: sends prompt).
+	// Send text via RoutePodInput (raw write, no auto-submit). RoutePrompt
+	// now submits on PTY too — use it only when the caller intends submission.
+	// MCP exposes Enter as an explicit `keys: ["enter"]` opt-in.
 	if params.Text != "" {
-		if err := a.podRouter.RoutePrompt(params.PodKey, params.Text); err != nil {
+		if err := a.podRouter.RoutePodInput(params.PodKey, []byte(params.Text)); err != nil {
 			return nil, newMcpErrorf(500, "failed to send pod input text: %v", err)
 		}
 	}

--- a/backend/internal/service/channel/hook_pod_prompt.go
+++ b/backend/internal/service/channel/hook_pod_prompt.go
@@ -13,6 +13,9 @@ import (
 const podMentionTextLen = 8
 
 // PodPromptRouter sends prompts to a pod (mode-agnostic: PTY or ACP).
+// SendPrompt on both modes submits — PTY writes the body then presses Enter
+// inside the runner (see runner.OnSendPrompt); ACP submits via its structured
+// SendPrompt RPC.
 type PodPromptRouter interface {
 	RoutePrompt(podKey string, prompt string) error
 }
@@ -39,7 +42,7 @@ func NewPodPromptHook(router PodPromptRouter, msgWriter SystemMessageWriter) Pos
 				continue
 			}
 
-			if err := router.RoutePrompt(podKey, prompt+"\r"); err != nil {
+			if err := router.RoutePrompt(podKey, prompt); err != nil {
 				slog.WarnContext(ctx, "pod unreachable for prompt",
 					"pod_key", podKey,
 					"channel", mc.Channel.Name,

--- a/backend/internal/service/channel/hooks_coverage_test.go
+++ b/backend/internal/service/channel/hooks_coverage_test.go
@@ -73,6 +73,11 @@ func TestNewPodPromptHook_SendsPrompt(t *testing.T) {
 	if router.prompts[0].podKey != "abcd1234efgh5678" {
 		t.Errorf("PodKey = %s, want abcd1234efgh5678", router.prompts[0].podKey)
 	}
+	// Submission (Enter) is the runner's job inside OnSendPrompt; the hook
+	// must hand off a clean prompt body, not pre-append \r.
+	if router.prompts[0].prompt[len(router.prompts[0].prompt)-1] == '\r' {
+		t.Errorf("prompt body must not include trailing CR; got %q", router.prompts[0].prompt)
+	}
 }
 
 func TestNewPodPromptHook_SkipsSenderPod(t *testing.T) {

--- a/runner/internal/runner/BUILD.bazel
+++ b/runner/internal/runner/BUILD.bazel
@@ -131,6 +131,7 @@ go_test(
         "message_handler_relay_connections_test.go",
         "message_handler_relay_deadlock_test.go",
         "message_handler_relay_test.go",
+        "message_handler_send_prompt_test.go",
         "message_handler_terminal_test.go",
         "message_handler_upgrade_apply_test.go",
         "message_handler_upgrade_test.go",

--- a/runner/internal/runner/message_handler_ops.go
+++ b/runner/internal/runner/message_handler_ops.go
@@ -120,7 +120,10 @@ func (h *RunnerMessageHandler) OnObservePod(req client.ObservePodRequest) error 
 }
 
 // OnSendPrompt handles send_prompt command from server (gRPC control plane).
-// Routes through PodIO.SendInput — PTY writes to stdin, ACP sends prompt.
+// Mode-transparent submission: ACP submits via its structured SendPrompt RPC;
+// PTY writes the text to stdin then presses Enter as a *separate* write so the
+// TUI input editor sees a real keystroke (a combined "text\r" write lands
+// inside the editor's paste buffer and never submits).
 // For ACP mode, also echoes the user message via Relay so it appears in the
 // chat UI (consistent with the Relay command path in handleAcpRelayCommand).
 func (h *RunnerMessageHandler) OnSendPrompt(cmd *runnerv1.SendPromptCommand) error {
@@ -140,5 +143,11 @@ func (h *RunnerMessageHandler) OnSendPrompt(cmd *runnerv1.SendPromptCommand) err
 			"text": cmd.Prompt, "role": "user",
 		})
 	}
-	return pod.IO.SendInput(cmd.Prompt)
+	if err := pod.IO.SendInput(cmd.Prompt); err != nil {
+		return err
+	}
+	if pod.IO.Mode() == InteractionModePTY {
+		return pod.IO.SendInput("\r")
+	}
+	return nil
 }

--- a/runner/internal/runner/message_handler_send_prompt_test.go
+++ b/runner/internal/runner/message_handler_send_prompt_test.go
@@ -1,0 +1,90 @@
+package runner
+
+import (
+	"sync"
+	"testing"
+
+	runnerv1 "github.com/anthropics/agentsmesh/proto/gen/go/runner/v1"
+)
+
+// sendPromptMockIO is a minimal PodIO that records SendInput calls and lets
+// the test pick the interaction mode. It satisfies PodIO via embedded stubs.
+type sendPromptMockIO struct {
+	stubPodIOZero
+	mu     sync.Mutex
+	mode   string
+	inputs []string
+	err    error
+}
+
+func (m *sendPromptMockIO) Mode() string { return m.mode }
+
+func (m *sendPromptMockIO) SendInput(text string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.inputs = append(m.inputs, text)
+	return m.err
+}
+
+// stubPodIOZero satisfies the rest of PodIO with no-ops so each test mock
+// only overrides the methods it cares about.
+type stubPodIOZero struct{}
+
+func (stubPodIOZero) GetSnapshot(int) (string, error)           { return "", nil }
+func (stubPodIOZero) GetAgentStatus() string                    { return "idle" }
+func (stubPodIOZero) SubscribeStateChange(string, func(string)) {}
+func (stubPodIOZero) UnsubscribeStateChange(string)             {}
+func (stubPodIOZero) GetPID() int                               { return 0 }
+func (stubPodIOZero) Start() error                              { return nil }
+func (stubPodIOZero) Stop()                                     {}
+func (stubPodIOZero) Teardown() string                          { return "" }
+func (stubPodIOZero) SetExitHandler(func(int))                  {}
+func (stubPodIOZero) SetIOErrorHandler(func(error))             {}
+func (stubPodIOZero) Detach()                                   {}
+
+func TestOnSendPrompt_PTY_AutoSubmitsEnter(t *testing.T) {
+	io := &sendPromptMockIO{mode: InteractionModePTY}
+	pod := &Pod{PodKey: "pty-pod", InteractionMode: InteractionModePTY, IO: io}
+
+	store := NewInMemoryPodStore()
+	store.Put(pod.PodKey, pod)
+	h := &RunnerMessageHandler{podStore: store}
+
+	if err := h.OnSendPrompt(&runnerv1.SendPromptCommand{PodKey: pod.PodKey, Prompt: "hello"}); err != nil {
+		t.Fatalf("OnSendPrompt error: %v", err)
+	}
+
+	io.mu.Lock()
+	defer io.mu.Unlock()
+	if len(io.inputs) != 2 {
+		t.Fatalf("PTY mode must split into 2 writes (text + Enter); got %d: %v", len(io.inputs), io.inputs)
+	}
+	if io.inputs[0] != "hello" {
+		t.Errorf("inputs[0] = %q, want %q", io.inputs[0], "hello")
+	}
+	if io.inputs[1] != "\r" {
+		t.Errorf("inputs[1] = %q, want \"\\r\"", io.inputs[1])
+	}
+}
+
+func TestOnSendPrompt_ACP_NoEnter(t *testing.T) {
+	io := &sendPromptMockIO{mode: InteractionModeACP}
+	pod := &Pod{PodKey: "acp-pod", InteractionMode: InteractionModeACP, IO: io}
+
+	store := NewInMemoryPodStore()
+	store.Put(pod.PodKey, pod)
+	h := &RunnerMessageHandler{podStore: store}
+
+	if err := h.OnSendPrompt(&runnerv1.SendPromptCommand{PodKey: pod.PodKey, Prompt: "hello"}); err != nil {
+		t.Fatalf("OnSendPrompt error: %v", err)
+	}
+
+	io.mu.Lock()
+	defer io.mu.Unlock()
+	if len(io.inputs) != 1 {
+		t.Fatalf("ACP mode must submit via SendPrompt only (1 write); got %d: %v", len(io.inputs), io.inputs)
+	}
+	if io.inputs[0] != "hello" {
+		t.Errorf("inputs[0] = %q, want %q", io.inputs[0], "hello")
+	}
+}


### PR DESCRIPTION
## Summary

- Channel @-mentions to a terminal (PTY) pod typed the prompt but never pressed Enter — the message sat in the TUI's input box unsubmitted (TICKET-148).
- Root cause: the 6244e6e8 ACP refactor introduced a mode-transparent `SendPrompt`, but only finished the ACP half. PTY's `SendInput(text)` wrote the bytes and returned; combining `text + "\r"` into one PTY write lands inside the TUI's paste buffer instead of submitting.
- Fix lives in the abstraction's natural seam: `runner.OnSendPrompt` now writes the body and then issues a **separate** `SendInput("\r")` for PTY mode. ACP is unchanged.
- MCP `send_pod_input.text` switches from `RoutePrompt` to `RoutePodInput` so its explicit "type without submit" contract (Enter via `keys: ["enter"]`) survives the new auto-submit semantic. REST `POST /pods/:key/prompt` (same docstring promise of mode-transparency) inherits the fix for free.

## Test plan

- [x] `bazel test //runner/internal/runner/...` — new `TestOnSendPrompt_PTY_AutoSubmitsEnter` (2 writes: "hello", "\r") and `TestOnSendPrompt_ACP_NoEnter` (1 write).
- [x] `bazel test //backend/internal/service/channel/...` — hook tests assert prompt body has no trailing CR (submission is the runner's job).
- [x] `bazel test //backend/internal/api/grpc/...`.
- [x] `bazel build //backend/... //runner/...`.
- [ ] Manual: @-mention a PTY pod (Claude Code) in a Channel — confirm the prompt actually submits.

Closes TICKET-148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)