### PR TITLE
fix(runner+core+web): treat OS service status != registration status

### DIFF
--- a/clients/core/crates/local-runner/src/service.rs
+++ b/clients/core/crates/local-runner/src/service.rs
@@ -4,12 +4,21 @@ use crate::paths::InstallPaths;
 use serde::{Deserialize, Serialize};
 
 /// OS service status as reported by `agentsmesh-runner service status`.
+///
+/// `Stale` is the runner-CLI's own signal that the launchd/systemd job is
+/// installed but the runner config (`~/.agentsmesh/config.yaml`) is missing,
+/// so the daemon physically cannot run. The UI must treat this as "not
+/// registered" — the user needs to either re-register or
+/// `service uninstall` to clean up the orphan job. Without this state, a
+/// stale launchd job from an old registration would still report `Running`
+/// or `Stopped` and the UI would falsely claim the Mac is registered.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 pub enum ServiceStatus {
     Running,
     Stopped,
     Unknown,
     NotInstalled,
+    Stale,
 }
 
 pub async fn install(paths: &InstallPaths) -> Result<()> {
@@ -53,6 +62,7 @@ fn parse_status(stdout: &str) -> Result<ServiceStatus> {
             return Ok(match rest.trim() {
                 "Running" => ServiceStatus::Running,
                 "Stopped" => ServiceStatus::Stopped,
+                "Stale" => ServiceStatus::Stale,
                 "Unknown" => ServiceStatus::Unknown,
                 _ => ServiceStatus::Unknown,
             });
@@ -73,6 +83,11 @@ mod tests {
     #[test]
     fn parses_stopped() {
         assert_eq!(parse_status("Service Status: Stopped\n").unwrap(), ServiceStatus::Stopped);
+    }
+
+    #[test]
+    fn parses_stale() {
+        assert_eq!(parse_status("Service Status: Stale\n").unwrap(), ServiceStatus::Stale);
     }
 
     #[test]

--- a/clients/core/crates/node-bridge/src/commands/local_runner.rs
+++ b/clients/core/crates/node-bridge/src/commands/local_runner.rs
@@ -83,7 +83,7 @@ impl AppState {
     }
 
     /// Returns the service status as a stable string token —
-    /// "running" | "stopped" | "unknown" | "not_installed".
+    /// "running" | "stopped" | "unknown" | "not_installed" | "stale".
     /// String form keeps the IPC contract stable across napi enum-codegen
     /// drift; the renderer maps it back to a typed enum on the TS side.
     #[napi]
@@ -94,6 +94,7 @@ impl AppState {
             agentsmesh_local_runner::ServiceStatus::Stopped => "stopped",
             agentsmesh_local_runner::ServiceStatus::Unknown => "unknown",
             agentsmesh_local_runner::ServiceStatus::NotInstalled => "not_installed",
+            agentsmesh_local_runner::ServiceStatus::Stale => "stale",
         }
         .to_string())
     }

--- a/clients/desktop/e2e/global.setup.ts
+++ b/clients/desktop/e2e/global.setup.ts
@@ -52,7 +52,12 @@ setup("authenticate as test user (Electron)", async () => {
     await expectHashMatches(
       page,
       new RegExp(`/${TEST_ORG_SLUG}/|/onboarding|/workspace`),
-      30_000
+      // macmini-03 cold-starts the renderer + backs the login request through
+      // the full docker stack — same reason firstWindow above bumps to 90s on
+      // CI. The 30s post-login redirect ceiling tripped TICKET-145's PR twice
+      // before any spec ran (login succeeded; renderer just hadn't hydrated +
+      // routed yet). Use the same CI bump.
+      isCi() ? 90_000 : 30_000,
     );
 
     const snap = await captureStorage(page);

--- a/clients/web/src/components/infra/ThisMacSection.tsx
+++ b/clients/web/src/components/infra/ThisMacSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { Laptop, Loader2 } from "lucide-react";
+import { Laptop, Loader2, AlertTriangle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useCurrentOrg } from "@/stores/auth";
 import { useRunners, getRunnerStatusInfo } from "@/stores/runner";
@@ -10,16 +10,8 @@ import { STEP_LABELS, useLocalRunnerOnboarding } from "@/hooks/useLocalRunnerOnb
 
 const SECTION_HEADER = "px-3 pt-3 pb-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground";
 
-/**
- * Sidebar footer section for the user's own machine. Shows either an
- * onboarding card (when this Mac isn't registered) or a row that mirrors
- * normal runners but is keyed off the local-runner config — clicking jumps
- * to the matching runner detail.
- *
- * Renders nothing on web (no electron adapter → no local runner service).
- */
 export function ThisMacSection() {
-  const { unsupported, localNodeId, phase, onRegister } = useLocalRunnerOnboarding();
+  const { unsupported, isRegistered, localNodeId, phase, onRegister } = useLocalRunnerOnboarding();
   const router = useRouter();
   const currentOrg = useCurrentOrg();
   const runners = useRunners();
@@ -40,7 +32,12 @@ export function ThisMacSection() {
   const matchingRunner = localNodeId
     ? runners.find((r) => r.node_id === localNodeId) ?? null
     : null;
-  const isRegistered = phase.kind === "idle" && phase.status === "running" && !!localNodeId;
+  // Orphaned: backend list has been loaded (has other runners) but doesn't
+  // include this node_id — it was deleted server-side. Empty list is treated
+  // as "still syncing" because we can't distinguish "never fetched" from
+  // "truly empty" here without coupling to the store's loading flag.
+  const orphaned = isRegistered && !matchingRunner && runners.length > 0;
+  const isStale = phase.kind === "idle" && phase.status === "stale";
 
   return (
     <div className="border-t border-border">
@@ -48,14 +45,16 @@ export function ThisMacSection() {
       {isRegistered && matchingRunner ? (
         <RegisteredRow
           runner={matchingRunner}
+          serviceRunning={phase.kind === "idle" && phase.status === "running"}
           onClick={() => {
             if (currentOrg) {
               router.push(`/${currentOrg.slug}/infra?tab=runners&id=${matchingRunner.id}`);
             }
           }}
         />
-      ) : isRegistered && !matchingRunner ? (
-        // Registered locally but backend list hasn't picked it up yet (heartbeat in flight).
+      ) : orphaned ? (
+        <OrphanedBlock onReRegister={onRegister} />
+      ) : isRegistered ? (
         <div
           data-testid="this-mac-syncing"
           className="px-3 pb-3 text-xs text-muted-foreground"
@@ -65,6 +64,7 @@ export function ThisMacSection() {
       ) : (
         <OnboardingBlock
           phase={phase}
+          isStale={isStale}
           onRegister={onRegister}
         />
       )}
@@ -74,9 +74,11 @@ export function ThisMacSection() {
 
 function RegisteredRow({
   runner,
+  serviceRunning,
   onClick,
 }: {
   runner: ReturnType<typeof useRunners>[number];
+  serviceRunning: boolean;
   onClick: () => void;
 }) {
   const statusInfo = getRunnerStatusInfo(runner.status);
@@ -102,18 +104,44 @@ function RegisteredRow({
             </>
           )}
           <span>·</span>
-          <span className="text-green-600 dark:text-green-400">active</span>
+          {serviceRunning ? (
+            <span className="text-green-600 dark:text-green-400">active</span>
+          ) : (
+            <span className="text-yellow-600 dark:text-yellow-400">service stopped</span>
+          )}
         </div>
       </div>
     </div>
   );
 }
 
+function OrphanedBlock({ onReRegister }: { onReRegister: () => void }) {
+  return (
+    <div className="px-3 pb-3" data-testid="this-mac-orphaned">
+      <div className="mb-2 flex items-start gap-1.5 text-xs text-yellow-600 dark:text-yellow-400">
+        <AlertTriangle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+        <p>Server doesn&apos;t recognize this runner. It may have been removed remotely.</p>
+      </div>
+      <Button
+        data-testid="this-mac-reregister-btn"
+        size="sm"
+        variant="default"
+        className="h-8 w-full text-xs"
+        onClick={onReRegister}
+      >
+        Re-register This Mac
+      </Button>
+    </div>
+  );
+}
+
 function OnboardingBlock({
   phase,
+  isStale,
   onRegister,
 }: {
   phase: ReturnType<typeof useLocalRunnerOnboarding>["phase"];
+  isStale: boolean;
   onRegister: () => void;
 }) {
   const busy = phase.kind === "installing";
@@ -127,7 +155,9 @@ function OnboardingBlock({
   return (
     <div className="px-3 pb-3">
       <p className="mb-2 text-xs text-muted-foreground">
-        Run pods locally with no cloud relay round-trip.
+        {isStale
+          ? "Old Runner service is installed but registration config is missing."
+          : "Run pods locally with no cloud relay round-trip."}
       </p>
       <Button
         data-testid="this-mac-register-btn"
@@ -137,7 +167,13 @@ function OnboardingBlock({
         onClick={onRegister}
         disabled={busy}
       >
-        {busy ? "Working…" : phase.kind === "error" ? "Retry" : "Register This Mac"}
+        {busy
+          ? "Working…"
+          : phase.kind === "error"
+            ? "Retry"
+            : isStale
+              ? "Re-register This Mac"
+              : "Register This Mac"}
       </Button>
       {stepLabel && (
         <p className="mt-2 truncate text-[11px] text-muted-foreground" title={stepLabel}>

--- a/clients/web/src/components/infra/__tests__/ThisMacSection.test.tsx
+++ b/clients/web/src/components/infra/__tests__/ThisMacSection.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { UseLocalRunnerOnboarding } from "@/hooks/useLocalRunnerOnboarding";
+import type { Runner } from "@/stores/runner";
+import { ThisMacSection } from "../ThisMacSection";
+
+const hookReturn: { current: UseLocalRunnerOnboarding } = {
+  current: {} as UseLocalRunnerOnboarding,
+};
+const runnersList: { current: Runner[] } = { current: [] };
+
+vi.mock("@/hooks/useLocalRunnerOnboarding", async () => {
+  const actual = await vi.importActual<typeof import("@/hooks/useLocalRunnerOnboarding")>(
+    "@/hooks/useLocalRunnerOnboarding",
+  );
+  return { ...actual, useLocalRunnerOnboarding: () => hookReturn.current };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn(), forward: vi.fn(), refresh: vi.fn(), prefetch: vi.fn() }),
+}));
+
+vi.mock("@/stores/auth", () => ({
+  useCurrentOrg: () => ({ slug: "acme" }),
+}));
+
+vi.mock("@/stores/runner", async () => {
+  const actual = await vi.importActual<typeof import("@/stores/runner")>("@/stores/runner");
+  return { ...actual, useRunners: () => runnersList.current };
+});
+
+function setHook(overrides: Partial<UseLocalRunnerOnboarding>) {
+  hookReturn.current = {
+    unsupported: false,
+    localNodeId: null,
+    isRegistered: false,
+    phase: { kind: "idle", status: "not_installed" },
+    onRegister: vi.fn(),
+    refresh: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeRunner(node_id: string): Runner {
+  return {
+    id: 1,
+    node_id,
+    organization_id: 1,
+    status: "online",
+    is_enabled: true,
+    visibility: "private",
+    current_pods: 0,
+    max_concurrent_pods: 4,
+    registered_by_user_id: 1,
+    description: "",
+    tags: [],
+    host_info: { os: "darwin", arch: "arm64", cpu_cores: 8, memory: 16_000_000_000 },
+  } as unknown as Runner;
+}
+
+describe("ThisMacSection", () => {
+  beforeEach(() => {
+    runnersList.current = [];
+    setHook({});
+  });
+
+  it("renders nothing when service is unsupported (web bundle)", () => {
+    setHook({ unsupported: true });
+    const { container } = render(<ThisMacSection />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  // Reverse of TICKET-145: registered+stopped should NOT fall to the
+  // onboarding "Register This Mac" button — that made users think they
+  // weren't registered when in fact only the service was down.
+  it("renders the registered row (not the Register CTA) when service is stopped", () => {
+    runnersList.current = [makeRunner("macmini-03")];
+    setHook({
+      isRegistered: true,
+      localNodeId: "macmini-03",
+      phase: { kind: "idle", status: "stopped" },
+    });
+    render(<ThisMacSection />);
+    expect(screen.getByText("macmini-03")).toBeDefined();
+    expect(screen.getByText(/service stopped/i)).toBeDefined();
+    expect(screen.queryByTestId("this-mac-register-btn")).toBeNull();
+  });
+
+  it("renders the registered row with 'active' label when service is running", () => {
+    runnersList.current = [makeRunner("macmini-03")];
+    setHook({
+      isRegistered: true,
+      localNodeId: "macmini-03",
+      phase: { kind: "idle", status: "running" },
+    });
+    render(<ThisMacSection />);
+    expect(screen.getByText(/^active$/i)).toBeDefined();
+  });
+
+  it("renders orphaned block when registered locally but backend list excludes it", () => {
+    runnersList.current = [makeRunner("other-runner")];
+    setHook({
+      isRegistered: true,
+      localNodeId: "macmini-03",
+      phase: { kind: "idle", status: "running" },
+    });
+    render(<ThisMacSection />);
+    expect(screen.getByTestId("this-mac-orphaned")).toBeDefined();
+    expect(screen.getByTestId("this-mac-reregister-btn")).toBeDefined();
+    expect(screen.queryByTestId("this-mac-syncing")).toBeNull();
+  });
+
+  it("renders syncing block when registered locally but list is empty (still loading)", () => {
+    runnersList.current = [];
+    setHook({
+      isRegistered: true,
+      localNodeId: "macmini-03",
+      phase: { kind: "idle", status: "running" },
+    });
+    render(<ThisMacSection />);
+    expect(screen.getByTestId("this-mac-syncing")).toBeDefined();
+  });
+
+  it("renders onboarding Register CTA when not registered", () => {
+    setHook({
+      isRegistered: false,
+      localNodeId: null,
+      phase: { kind: "idle", status: "not_installed" },
+    });
+    render(<ThisMacSection />);
+    expect(screen.getByTestId("this-mac-register-btn")).toBeDefined();
+    expect(screen.getByText(/Run pods locally/i)).toBeDefined();
+  });
+
+  it("renders stale-recovery CTA when phase.status is 'stale'", () => {
+    setHook({
+      isRegistered: false,
+      localNodeId: null,
+      phase: { kind: "idle", status: "stale" },
+    });
+    render(<ThisMacSection />);
+    expect(screen.getByText(/Old Runner service is installed/i)).toBeDefined();
+    expect(screen.getByRole("button", { name: /Re-register This Mac/i })).toBeDefined();
+  });
+});

--- a/clients/web/src/components/onboarding/RegisterLocalRunnerCard.tsx
+++ b/clients/web/src/components/onboarding/RegisterLocalRunnerCard.tsx
@@ -3,18 +3,24 @@
 import { STEP_LABELS, useLocalRunnerOnboarding } from "@/hooks/useLocalRunnerOnboarding";
 
 export function RegisterLocalRunnerCard() {
-  const { unsupported, phase, onRegister } = useLocalRunnerOnboarding();
+  const { unsupported, isRegistered, phase, onRegister } = useLocalRunnerOnboarding();
   if (unsupported) return null;
 
-  if (phase.kind === "idle" && phase.status === "running") {
+  if (phase.kind === "idle" && isRegistered) {
+    const running = phase.status === "running";
     return (
       <div className="rounded-lg border border-border bg-accent px-4 py-3 text-[13px] text-accent-foreground">
         <div className="font-medium">This Mac is registered as a Runner</div>
-        <div className="mt-0.5 text-muted-foreground">Pods will run locally and skip the cloud relay.</div>
+        <div className="mt-0.5 text-muted-foreground">
+          {running
+            ? "Pods will run locally and skip the cloud relay."
+            : "Service is not running — pods will fall back to the cloud relay until it starts."}
+        </div>
       </div>
     );
   }
 
+  const isStale = phase.kind === "idle" && phase.status === "stale";
   const busy = phase.kind === "installing";
   const stepLabel = phase.kind === "installing" ? STEP_LABELS[phase.step] : null;
   const errorLine = phase.kind === "error"
@@ -25,10 +31,13 @@ export function RegisterLocalRunnerCard() {
 
   return (
     <div className="rounded-lg border border-border bg-card p-4 text-[13px]">
-      <div className="font-semibold text-foreground">Register this Mac as a Runner</div>
+      <div className="font-semibold text-foreground">
+        {isStale ? "Stale Runner service detected" : "Register this Mac as a Runner"}
+      </div>
       <p className="mt-1 max-w-prose text-muted-foreground">
-        Run pods locally with no cloud relay round-trip. Installs the agentsmesh-runner binary
-        and starts it as a background OS service.
+        {isStale
+          ? "An old Runner service is installed but the registration config is missing. Re-register to restore it."
+          : "Run pods locally with no cloud relay round-trip. Installs the agentsmesh-runner binary and starts it as a background OS service."}
       </p>
       <div className="mt-3 flex items-center gap-3">
         <button
@@ -37,7 +46,7 @@ export function RegisterLocalRunnerCard() {
           disabled={busy}
           className="h-9 rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground disabled:cursor-progress disabled:opacity-60 hover:bg-primary-hover"
         >
-          {busy ? "Working…" : phase.kind === "error" ? "Retry" : "Register"}
+          {busy ? "Working…" : phase.kind === "error" ? "Retry" : isStale ? "Re-register" : "Register"}
         </button>
         {stepLabel && <span className="text-muted-foreground">{stepLabel}</span>}
         {errorLine && <span className="text-destructive">{errorLine}</span>}

--- a/clients/web/src/components/onboarding/__tests__/RegisterLocalRunnerCard.test.tsx
+++ b/clients/web/src/components/onboarding/__tests__/RegisterLocalRunnerCard.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { UseLocalRunnerOnboarding } from "@/hooks/useLocalRunnerOnboarding";
+import { RegisterLocalRunnerCard } from "../RegisterLocalRunnerCard";
+
+const hookReturn: { current: UseLocalRunnerOnboarding } = {
+  current: {} as UseLocalRunnerOnboarding,
+};
+
+vi.mock("@/hooks/useLocalRunnerOnboarding", async () => {
+  const actual = await vi.importActual<typeof import("@/hooks/useLocalRunnerOnboarding")>(
+    "@/hooks/useLocalRunnerOnboarding",
+  );
+  return {
+    ...actual,
+    useLocalRunnerOnboarding: () => hookReturn.current,
+  };
+});
+
+function setHook(overrides: Partial<UseLocalRunnerOnboarding>) {
+  hookReturn.current = {
+    unsupported: false,
+    localNodeId: null,
+    isRegistered: false,
+    phase: { kind: "idle", status: "not_installed" },
+    onRegister: vi.fn(),
+    refresh: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("RegisterLocalRunnerCard", () => {
+  beforeEach(() => {
+    setHook({});
+  });
+
+  it("renders nothing when service is unsupported (web bundle)", () => {
+    setHook({ unsupported: true });
+    const { container } = render(<RegisterLocalRunnerCard />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  // TICKET-145 regression: must not claim "registered" based on service status.
+  it("does NOT claim registered when service is running but no localNodeId", () => {
+    setHook({
+      isRegistered: false,
+      localNodeId: null,
+      phase: { kind: "idle", status: "running" },
+    });
+    render(<RegisterLocalRunnerCard />);
+    expect(screen.queryByText(/This Mac is registered as a Runner/i)).toBeNull();
+    expect(screen.getByRole("button", { name: /register/i })).toBeDefined();
+  });
+
+  it("claims registered when localNodeId is set + service running", () => {
+    setHook({
+      isRegistered: true,
+      localNodeId: "macmini-03",
+      phase: { kind: "idle", status: "running" },
+    });
+    render(<RegisterLocalRunnerCard />);
+    expect(screen.getByText(/This Mac is registered as a Runner/i)).toBeDefined();
+    expect(screen.getByText(/Pods will run locally/i)).toBeDefined();
+  });
+
+  it("claims registered but warns when service is stopped", () => {
+    setHook({
+      isRegistered: true,
+      localNodeId: "macmini-03",
+      phase: { kind: "idle", status: "stopped" },
+    });
+    render(<RegisterLocalRunnerCard />);
+    expect(screen.getByText(/This Mac is registered as a Runner/i)).toBeDefined();
+    expect(screen.getByText(/Service is not running/i)).toBeDefined();
+  });
+
+  it("shows stale-service recovery CTA when phase.status is 'stale'", () => {
+    setHook({
+      isRegistered: false,
+      localNodeId: null,
+      phase: { kind: "idle", status: "stale" },
+    });
+    render(<RegisterLocalRunnerCard />);
+    expect(screen.getByText(/Stale Runner service detected/i)).toBeDefined();
+    expect(screen.getByRole("button", { name: /Re-register/i })).toBeDefined();
+  });
+});

--- a/clients/web/src/hooks/__tests__/useLocalRunnerOnboarding.test.ts
+++ b/clients/web/src/hooks/__tests__/useLocalRunnerOnboarding.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useLocalRunnerOnboarding } from "../useLocalRunnerOnboarding";
 
-type Status = "running" | "stopped" | "unknown" | "not_installed";
+type Status = "running" | "stopped" | "unknown" | "not_installed" | "stale";
 
 interface FakeService {
   state: {
@@ -221,5 +221,43 @@ describe("useLocalRunnerOnboarding", () => {
     await act(async () => { await result.current.onRegister(); });
     expect(result.current.phase.kind).toBe("idle");
     expect(result.current.phase).toEqual({ kind: "idle", status: "running" });
+  });
+
+  // Regression for TICKET-145: isRegistered is the SSOT for "this Mac is
+  // registered as a runner" — it must be derived from localNodeId (i.e.
+  // ~/.agentsmesh/config.yaml exists with node_id) NOT from service status.
+  // Earlier the card read phase.status === "running" directly and a stale
+  // launchd job from a previous registration falsely claimed registration.
+  it("isRegistered is false when localNodeId is null, regardless of service status", async () => {
+    svc!.state.installed = true;
+    svc!.state.running = true;
+    svc!.state.registered = false;
+    svc!.state.nodeId = null;
+    const { result } = renderHook(() => useLocalRunnerOnboarding());
+    await waitFor(() => expect(result.current.phase.kind).toBe("idle"));
+    expect(result.current.isRegistered).toBe(false);
+  });
+
+  it("isRegistered is true once localNodeId is populated", async () => {
+    svc!.state.installed = true;
+    svc!.state.registered = true;
+    svc!.state.nodeId = "macmini-03";
+    svc!.state.running = false;
+    svc!.state.serviceInstalled = true;
+    const { result } = renderHook(() => useLocalRunnerOnboarding());
+    await waitFor(() => expect(result.current.phase.kind).toBe("idle"));
+    expect(result.current.isRegistered).toBe(true);
+    expect(result.current.localNodeId).toBe("macmini-03");
+    expect(result.current.phase).toEqual({ kind: "idle", status: "stopped" });
+  });
+
+  it("surfaces the new 'stale' service status from the IPC contract", async () => {
+    const fake = makeService();
+    fake.service_status = async () => "stale" as Status;
+    svc = fake;
+    const { result } = renderHook(() => useLocalRunnerOnboarding());
+    await waitFor(() => expect(result.current.phase.kind).toBe("idle"));
+    expect(result.current.phase).toEqual({ kind: "idle", status: "stale" });
+    expect(result.current.isRegistered).toBe(false);
   });
 });

--- a/clients/web/src/hooks/useLocalRunnerOnboarding.ts
+++ b/clients/web/src/hooks/useLocalRunnerOnboarding.ts
@@ -61,6 +61,16 @@ export interface UseLocalRunnerOnboarding {
   unsupported: boolean;
   /** Cached node_id of the locally registered runner; null when not registered. */
   localNodeId: string | null;
+  /**
+   * SSOT for "is this Mac registered as a runner?". True iff the local
+   * `~/.agentsmesh/config.yaml` exists and parses out a `node_id`. Independent
+   * of OS-service status — a registered runner with the service stopped is
+   * still registered. Components must derive their "registered" UI from this,
+   * NOT from `phase.status === "running"` (which is what caused TICKET-145:
+   * a stale launchd job reported Running even after the user removed the
+   * config, and the workspace falsely claimed the Mac was registered).
+   */
+  isRegistered: boolean;
   phase: Phase;
   onRegister: () => Promise<void>;
   refresh: () => Promise<void>;
@@ -163,5 +173,5 @@ export function useLocalRunnerOnboarding(): UseLocalRunnerOnboarding {
     }
   }, [svc, refresh]);
 
-  return { unsupported: !svc, localNodeId, phase, onRegister, refresh };
+  return { unsupported: !svc, localNodeId, isRegistered: localNodeId !== null, phase, onRegister, refresh };
 }

--- a/packages/electron-adapter/src/local_runner.ts
+++ b/packages/electron-adapter/src/local_runner.ts
@@ -9,6 +9,7 @@ const VALID_STATUSES = new Set<LocalRunnerStatus>([
   "stopped",
   "unknown",
   "not_installed",
+  "stale",
 ]);
 
 export class ElectronLocalRunnerService implements ILocalRunnerService {

--- a/packages/service-interface/src/index.ts
+++ b/packages/service-interface/src/index.ts
@@ -342,7 +342,7 @@ export interface IInvitationService {
   revoke(id: bigint): Promise<void>;
 }
 
-export type LocalRunnerStatus = "running" | "stopped" | "unknown" | "not_installed";
+export type LocalRunnerStatus = "running" | "stopped" | "unknown" | "not_installed" | "stale";
 
 export interface ILocalRunnerService {
   binary_path(): Promise<string>;

--- a/runner/cmd/runner/BUILD.bazel
+++ b/runner/cmd/runner/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("//build_defs/docker:go_oci_image.bzl", "go_oci_image")
 load("//build_defs/release:release_bundle.bzl", "runner_release_bundle")
 
@@ -72,4 +72,10 @@ runner_release_bundle(
         "//:README.md",
         "//:LICENSE",
     ],
+)
+
+go_test(
+    name = "runner_test",
+    srcs = ["service_test.go"],
+    embed = [":runner_lib"],
 )

--- a/runner/cmd/runner/service.go
+++ b/runner/cmd/runner/service.go
@@ -145,5 +145,22 @@ func runServiceStatus() {
 		statusText = "Unknown"
 	}
 
-	fmt.Printf("Service Status: %s\n", statusText)
+	fmt.Printf("Service Status: %s\n", reconcileServiceStatus(statusText, svc.GetDefaultConfigPath()))
+}
+
+// reconcileServiceStatus promotes the OS-reported status to "Stale" when the
+// launchd/systemd job is loaded but the registration config is gone. The
+// daemon physically cannot run without config, so reporting Running/Stopped
+// to the desktop UI used to cause TICKET-145 — a leftover launchd job from
+// an old registration made the workspace falsely claim "This Mac is
+// registered as a Runner". Centralized so it's unit-testable without
+// shelling out to a real service.
+func reconcileServiceStatus(rawStatus, configPath string) string {
+	if rawStatus == "Unknown" {
+		return rawStatus
+	}
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		return "Stale"
+	}
+	return rawStatus
 }

--- a/runner/cmd/runner/service_test.go
+++ b/runner/cmd/runner/service_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReconcileServiceStatus_PromotesToStaleWhenConfigMissing(t *testing.T) {
+	tmp := t.TempDir()
+	missing := filepath.Join(tmp, "does-not-exist.yaml")
+
+	if got := reconcileServiceStatus("Running", missing); got != "Stale" {
+		t.Errorf("Running + missing config: got %q, want Stale", got)
+	}
+	if got := reconcileServiceStatus("Stopped", missing); got != "Stale" {
+		t.Errorf("Stopped + missing config: got %q, want Stale", got)
+	}
+}
+
+func TestReconcileServiceStatus_PassesThroughWhenConfigExists(t *testing.T) {
+	tmp := t.TempDir()
+	cfg := filepath.Join(tmp, "config.yaml")
+	if err := os.WriteFile(cfg, []byte("node_id: foo\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if got := reconcileServiceStatus("Running", cfg); got != "Running" {
+		t.Errorf("Running + config exists: got %q, want Running", got)
+	}
+	if got := reconcileServiceStatus("Stopped", cfg); got != "Stopped" {
+		t.Errorf("Stopped + config exists: got %q, want Stopped", got)
+	}
+}
+
+func TestReconcileServiceStatus_UnknownIsNeverPromoted(t *testing.T) {
+	tmp := t.TempDir()
+	missing := filepath.Join(tmp, "does-not-exist.yaml")
+	if got := reconcileServiceStatus("Unknown", missing); got != "Unknown" {
+		t.Errorf("Unknown should never be reclassified, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes **TICKET-145**: Desktop 工作区显示 "This Mac is registered as a Runner" 但实际未注册。

根因：UI 把 launchd/systemd "service running" 当成 "runner is registered with backend"。stale launchd job + 缺 `~/.agentsmesh/config.yaml` 时，前者仍报 Running，后者实际为 false → UI 撒谎。

## Systemic fix (4 layers)

1. **Runner CLI (`service status`)** — 新增 `reconcileServiceStatus` helper：launchd 上报 Running/Stopped 但 config 不存在时，提升为新 token `Stale`。守住数据源头。
2. **跨语言契约** — `ServiceStatus::Stale` 加到 Rust local-runner crate → node-bridge IPC 字符串 `"stale"` → TS `LocalRunnerStatus` union → electron-adapter VALID_STATUSES。
3. **Hook SSOT** — `useLocalRunnerOnboarding` 暴露 `isRegistered`（= `localNodeId !== null`），JSDoc 显式禁止用 `phase.status === "running"` 当注册判定。
4. **两处同源 bug 一起修**：
   - `RegisterLocalRunnerCard`（正向 bug）：服务跑着但没注册 → 之前误显示 "registered"。
   - `ThisMacSection`（反向 bug）：已注册但服务停了 → 之前掉进 OnboardingBlock 显示 "Register This Mac"。
   - Stale 状态新增 "Re-register" 恢复 CTA。
   - Backend cross-check 区分 orphaned（list 有其它 runner 但不含本机 → 服务端删了）vs syncing（list 空 → 还没拉完）。

## Test plan

- [x] `bazel test //clients/core/crates/local-runner:local_runner_test` — Stale 解析
- [x] `bazel test //clients/web:unit` — 含新增 15 个用例（hook +3，RegisterLocalRunnerCard +5，ThisMacSection +7）
- [x] `bazel test //runner/cmd/runner:runner_test` — `reconcileServiceStatus` +3 用例
- [x] `bazel build //clients/web:src` — tsc 通过
- [x] `bazel build //clients/web:lint` — eslint 通过
- [x] `bazel build //packages/{service-interface,electron-adapter,service-runtime}:*` — 类型契约编译
- [x] `bazel build //clients/core/crates/node-bridge:node_bridge //runner/cmd/runner:runner` — Rust + Go binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)