### PR TITLE
fix(core): restore Ticket.id so spawn-pod-from-ticket carries context

### DIFF
--- a/clients/core/crates/ffi/src/dto/ticket.rs
+++ b/clients/core/crates/ffi/src/dto/ticket.rs
@@ -87,6 +87,7 @@ impl From<TicketPriorityDto> for TicketPriority {
 
 #[derive(Clone, Debug, uniffi::Record)]
 pub struct TicketDto {
+    pub id: i64,
     pub slug: String,
     pub title: String,
     pub content: Option<String>,
@@ -101,6 +102,7 @@ pub struct TicketDto {
 impl From<Ticket> for TicketDto {
     fn from(t: Ticket) -> Self {
         Self {
+            id: t.id,
             slug: t.slug,
             title: t.title,
             content: t.content,

--- a/clients/core/crates/persistence/src/repos/ticket_repo.rs
+++ b/clients/core/crates/persistence/src/repos/ticket_repo.rs
@@ -58,6 +58,7 @@ mod tests {
 
     fn make_ticket(slug: &str, status: TicketStatus, priority: TicketPriority) -> Ticket {
         Ticket {
+            id: 0,
             slug: slug.into(), title: slug.into(), content: None,
             status, priority, repository_id: None, parent_slug: None,
             created_at: None, updated_at: None,

--- a/clients/core/crates/state/src/ticket_state.rs
+++ b/clients/core/crates/state/src/ticket_state.rs
@@ -204,6 +204,7 @@ mod tests {
 
     fn make_ticket(slug: &str, status: TicketStatus, priority: TicketPriority) -> Ticket {
         Ticket {
+            id: 0,
             slug: slug.into(), title: format!("Ticket {slug}"), content: None,
             status, priority, repository_id: Some(1), parent_slug: None,
             created_at: None, updated_at: None,

--- a/clients/core/crates/state/src/ticket_state_tests.rs
+++ b/clients/core/crates/state/src/ticket_state_tests.rs
@@ -1,7 +1,7 @@
 use crate::ticket_state::{TicketState, ViewMode};
 use agentsmesh_types::*;
 
-fn tk(slug: &str, title: &str) -> Ticket { Ticket { slug: slug.into(), title: title.into(), content: None, status: TicketStatus::Todo, priority: TicketPriority::Medium, repository_id: None, parent_slug: None, created_at: None, updated_at: None } }
+fn tk(slug: &str, title: &str) -> Ticket { Ticket { id: 0, slug: slug.into(), title: title.into(), content: None, status: TicketStatus::Todo, priority: TicketPriority::Medium, repository_id: None, parent_slug: None, created_at: None, updated_at: None } }
 fn lbl(id: i64, name: &str) -> Label { Label { id, name: name.into(), color: "#000".into() } }
 
 #[test] fn new_state() { let s = TicketState::new(); assert!(s.get_tickets().is_empty()); assert!(s.get_labels().is_empty()); assert_eq!(s.get_view_mode(), ViewMode::List); }

--- a/clients/core/crates/types/src/ticket.rs
+++ b/clients/core/crates/types/src/ticket.rs
@@ -4,6 +4,11 @@ use crate::{TicketPriority, TicketStatus};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Ticket {
+    // Backend's primary key. Required by buildTicketContext (clients/web/src/components/tickets/buildTicketContext.ts:11),
+    // which short-circuits to undefined when falsy — breaking the ticket→spawn-pod flow.
+    // `default` keeps minimal-JSON tests deserializing; prod backend always sends a non-zero id.
+    #[serde(default)]
+    pub id: i64,
     pub slug: String,
     pub title: String,
     pub content: Option<String>,
@@ -95,6 +100,7 @@ mod tests {
     #[test]
     fn ticket_roundtrip() {
         let ticket = Ticket {
+            id: 1,
             slug: "TICKET-1".into(),
             title: "Fix login bug".into(),
             content: Some("Users can't login".into()),
@@ -128,6 +134,7 @@ mod tests {
         let col = BoardColumn {
             status: TicketStatus::InProgress,
             tickets: vec![Ticket {
+                id: 1,
                 slug: "T-1".into(),
                 title: "task".into(),
                 content: None,
@@ -179,5 +186,34 @@ mod tests {
         assert_eq!(parsed["total"], serde_json::json!(42));
         assert_eq!(parsed["limit"], serde_json::json!(20));
         assert_eq!(parsed["offset"], serde_json::json!(20));
+    }
+
+    // Regression: id must survive the backend → Rust → JS round-trip. Without
+    // `pub id` on Ticket, serde silently drops the field during from_str,
+    // and current_ticket_json() then emits a ticket without id. JS-side
+    // buildTicketContext returns undefined when !ticket.id, which collapses
+    // the spawn-pod-from-ticket flow into the workspace scenario (no prompt
+    // seeded, no ticket_slug sent). See TICKET-146.
+    #[test]
+    fn ticket_id_survives_backend_roundtrip() {
+        let backend_envelope = r#"{
+            "id": 123,
+            "organization_id": 5,
+            "number": 42,
+            "slug": "AM-42",
+            "title": "x",
+            "content": "body",
+            "status": "todo",
+            "priority": "high",
+            "repository_id": 7,
+            "reporter_id": 1,
+            "created_at": "2026-05-16T00:00:00Z",
+            "updated_at": "2026-05-16T00:00:00Z"
+        }"#;
+        let t: Ticket = serde_json::from_str(backend_envelope).unwrap();
+        assert_eq!(t.id, 123);
+        let relayed = serde_json::to_string(&t).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&relayed).unwrap();
+        assert_eq!(parsed["id"], serde_json::json!(123));
     }
 }


### PR DESCRIPTION
## Summary

Fixes TICKET-146 — on the desktop ticket detail page (and web too, via the same shared component), clicking **Spawn Pod** opened the modal with no ticket prompt seeded, and the created pod was not bound to the ticket.

## Root cause

`clients/core/crates/types/src/ticket.rs::Ticket` was missing `pub id: i64`. Backend sends `{\"id\":123,...}` but serde (without `deny_unknown_fields`) silently drops unknown fields during `from_str`. The state layer then re-serializes to JS *without* `id`. JS-side `buildTicketContext.ts:11` short-circuits to `undefined` when `!ticket.id` — `CreatePodModal` falls back to `scenario: \"workspace\"`, skipping the ticket prompt generator and never sending `ticket_slug` to backend.

The PR #338 fix (`buildTicketContext`) was correct in shape but never effective at runtime because its preconditions (id present) never held. Hidden by unit tests that mock `{ id: 1, ... }` directly.

Timeline:
- PR #305 (b01b6313, 2026-05-05): Rust SSOT migration introduces no-id Ticket
- PR #338 (51106b52, 2026-05-07): buildTicketContext added, never effective
- This PR: restore id

## Changes

- `Ticket` + `TicketDto`: add `pub id: i64` (with `#[serde(default)]` for backward compat with minimal-JSON deserialization tests).
- 4 test fixtures updated.
- New regression test `ticket_id_survives_backend_roundtrip` — feeds a real backend envelope through serde and asserts `id` survives. Fails without the fix.

## Out of scope (follow-ups)

- Rust `Ticket` still lacks `number / severity / estimate / due_date / labels / assignees / repository / reporter / parent_ticket` — affects right-rail rendering on ticket detail but not spawn-pod. Separate ticket.
- Add `#[serde(deny_unknown_fields)]` to core DTOs (prerequisite: cover all backend fields).
- Restore the `ticket-spawn-pod.spec.ts` e2e that PR #338 deleted due to modal-mount race.

## Test plan

- [x] `bazel test //clients/core/crates/types:types_test` — new regression test passes
- [x] `bazel test //clients/core/crates/state:state_test`
- [x] `bazel test //clients/core/crates/persistence:persistence_test`
- [x] `bazel test //clients/core/crates/api-client:api_client_test`
- [x] `bazel test //clients/core/crates/services:services_test`
- [x] `bazel test //clients/core/crates/auth:auth_test`
- [x] `bazel test //clients/web:unit` (1510 tests)
- [x] `bazel build //clients/core/crates/ffi:ffi`
- [x] `bazel build //clients/core/crates/wasm:wasm_lib`
- [x] `bazel build //clients/core/crates/node-bridge:node_bridge`
- [x] `bazel build //clients/core/crates/ffi:AgentsMeshCore` (iOS XCFramework)
- [ ] Manual: open ticket on desktop → Spawn Pod → prompt prefilled + create_pod request includes ticket_slug + pod appears in AgentPods rail

🤖 Generated with [Claude Code](https://claude.com/claude-code)