### PR TITLE
fix(desktop-e2e): bump electron.launch CI timeout to 240s

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -793,6 +793,28 @@ jobs:
           fi
           ibazel -h | head -3 || true
 
+      - name: Isolate bazel server from GitLab CI
+        # macmini-03 is also a GitLab CI runner sharing the same `stone`
+        # user. ~/.bazelrc pins `startup --output_base=/Users/stone/.bazel`,
+        # so both pipelines hit a single bazel server and serialize on its
+        # lock — last observation: a GitLab pipeline held the lock for 55+
+        # min, busting the 60-min job timeout three runs in a row.
+        #
+        # Shim `bazel` ahead of the homebrew binary on PATH so every
+        # invocation in this job (including ibazel-spawned `bazel build`
+        # inside deploy/dev:backend_only) lands on this job's private
+        # output base. The outer `bazel --output_base=...` flags on the
+        # explicit commands are kept as belt-and-suspenders.
+        run: |
+          REAL_BAZEL="$(command -v bazel)"
+          mkdir -p "$HOME/.gha-bin"
+          cat > "$HOME/.gha-bin/bazel" <<EOF
+          #!/usr/bin/env bash
+          exec "$REAL_BAZEL" --output_base="\$HOME/.bazel-github" "\$@"
+          EOF
+          chmod +x "$HOME/.gha-bin/bazel"
+          echo "$HOME/.gha-bin" >> "$GITHUB_PATH"
+
       - name: Pre-clean lingering host processes
         # Self-hosted runner: previous failed runs may have left stale
         # backend/relay binaries holding worktree-allocated ports
@@ -800,12 +822,18 @@ jobs:
         # parent PID, not its bazel-spawned children). Run the canonical
         # cleanup once before bring-up so this run starts on a clean
         # host. Idempotent on a clean box.
+        #
+        # `--output_base` pins this job to its own bazel server so it
+        # never blocks on the GitLab CI server that shares the default
+        # `/Users/stone/.bazel` output base on macmini-03 (those two
+        # workloads previously serialized through the same lock, burning
+        # 55+ min waiting and busting the 60-min job timeout).
         run: |
-          bazel run //deploy/dev:clean || true
+          bazel --output_base="$HOME/.bazel-github" run //deploy/dev:clean || true
 
       - name: Bring up dev backend stack
         run: |
-          bazel run //deploy/dev:backend_only
+          bazel --output_base="$HOME/.bazel-github" run //deploy/dev:backend_only
           sleep 10
 
       - name: Resolve worktree-allocated ports
@@ -827,7 +855,7 @@ jobs:
           echo "backend never reported healthy"; exit 1
 
       - name: Build desktop bundle
-        run: bazel build //clients/desktop:out
+        run: bazel --output_base="$HOME/.bazel-github" build //clients/desktop:out
 
       - name: Run Desktop Playwright e2e
         env:
@@ -835,7 +863,7 @@ jobs:
           POSTGRES_PORT: ${{ steps.ports.outputs.POSTGRES_PORT }}
           COMPOSE_PROJECT_NAME: ${{ steps.ports.outputs.COMPOSE_PROJECT_NAME }}
         run: |
-          bazel test //clients/desktop:e2e \
+          bazel --output_base="$HOME/.bazel-github" test //clients/desktop:e2e \
             --test_tag_filters=e2e \
             --test_output=errors \
             --test_env=HTTP_PORT \

--- a/clients/desktop/e2e/global.setup.ts
+++ b/clients/desktop/e2e/global.setup.ts
@@ -33,7 +33,12 @@ setup("authenticate as test user (Electron)", async () => {
       NODE_ENV: "test",
       ELECTRON_DISABLE_SECURITY_WARNINGS: "true",
     },
-    timeout: isCi() ? 120_000 : 30_000,
+    // macmini-03 cold-starts the Electron renderer in 30-60s under normal
+    // load, but the shared CI box drifts to load avg 5-8 when dev residue
+    // accumulates (Simulators, Chrome). 120s was tripping electron.launch
+    // before firstWindow could even open. Match the firstWindow 90s bump
+    // + headroom for the Electron process to spawn.
+    timeout: isCi() ? 240_000 : 30_000,
   });
 
   try {

--- a/clients/desktop/e2e/global.setup.ts
+++ b/clients/desktop/e2e/global.setup.ts
@@ -13,6 +13,13 @@ import { expectHashMatches } from "./helpers/nav";
 import { captureStorage, saveStorageFile } from "./helpers/storage-state";
 
 setup("authenticate as test user (Electron)", async () => {
+  // Worst-case CI budget: electron.launch 240s + firstWindow 90s +
+  // login/redirect 90s + small overhead. Playwright's global 180s
+  // (playwright.config.ts) is per-test and would trip before the
+  // bumped launch+window timeouts could ever apply. Override locally
+  // so other specs keep the tighter default.
+  if (isCi()) setup.setTimeout(480_000);
+
   // Reset userData so login always starts fresh — avoids leaking dev-profile session.
   const userDataDir = getUserDataDir();
   rmSync(userDataDir, { recursive: true, force: true });

--- a/clients/desktop/src/renderer/router.tsx
+++ b/clients/desktop/src/renderer/router.tsx
@@ -1,4 +1,5 @@
 import { createHashRouter as createBrowserRouter, Navigate, Outlet, useParams } from "react-router-dom";
+import { useEffect } from "react";
 import { DashboardShell } from "@/pages/layouts/DashboardShell";
 import { useAuthStore, useCurrentOrg, useAuthOrganizations, useIsAuthenticated } from "@/stores/auth";
 import { RequireAuth } from "@/components/auth/RequireAuth";
@@ -50,15 +51,27 @@ import { PopoutTerminalPage } from "@/pages/popout/terminal/PopoutTerminalPage";
 // the whole window (HashRouter has no server-side fallback in Electron).
 import { RouteErrorBoundary } from "@/pages/RouteErrorBoundary";
 
-// react-router v7's `<Navigate to="../infra?tab=runners">` drops the query
-// string when resolved against a hash-router parent (verified against the
-// repositories-nav / runners-nav specs: hash settles on /infra, then
-// InfraPage's "default tab" effect rewrites it to ?tab=repositories,
-// shadowing ?tab=runners). Build an absolute path with the live :org param
-// so the search string survives navigation.
+// react-router v7's `<Navigate to="../infra?tab=runners">` and even its
+// absolute-path equivalent drop the search string intermittently when the
+// HashRouter is the active history — runners-nav.spec failed deterministically
+// (3 retries), repositories-nav.spec failed flakily (1 retry recovered). The
+// same hash-write fallback `replaceWithHashFallback` uses in
+// shims/next-navigation.ts is the proven workaround: write the full
+// `#/{org}/infra?tab=...` to window.location.hash directly so HashRouter
+// picks up both pathname and search atomically. InfraPage's "default tab"
+// effect then sees `tab` already set and won't overwrite it.
 function LegacyInfraTabRedirect({ tab }: { tab: "runners" | "repositories" }) {
   const { org } = useParams<{ org: string }>();
-  return <Navigate to={`/${org}/infra?tab=${tab}`} replace />;
+  useEffect(() => {
+    if (!org) return;
+    const target = `#/${org}/infra?tab=${tab}`;
+    if (window.location.hash !== target) {
+      const base = window.location.href.split("#")[0];
+      window.history.replaceState(null, "", base + target);
+      window.dispatchEvent(new HashChangeEvent("hashchange"));
+    }
+  }, [org, tab]);
+  return null;
 }
 
 export const router = createBrowserRouter([

--- a/clients/desktop/src/renderer/router.tsx
+++ b/clients/desktop/src/renderer/router.tsx
@@ -1,4 +1,4 @@
-import { createHashRouter as createBrowserRouter, Navigate, Outlet } from "react-router-dom";
+import { createHashRouter as createBrowserRouter, Navigate, Outlet, useParams } from "react-router-dom";
 import { DashboardShell } from "@/pages/layouts/DashboardShell";
 import { useAuthStore, useCurrentOrg, useAuthOrganizations, useIsAuthenticated } from "@/stores/auth";
 import { RequireAuth } from "@/components/auth/RequireAuth";
@@ -50,6 +50,17 @@ import { PopoutTerminalPage } from "@/pages/popout/terminal/PopoutTerminalPage";
 // the whole window (HashRouter has no server-side fallback in Electron).
 import { RouteErrorBoundary } from "@/pages/RouteErrorBoundary";
 
+// react-router v7's `<Navigate to="../infra?tab=runners">` drops the query
+// string when resolved against a hash-router parent (verified against the
+// repositories-nav / runners-nav specs: hash settles on /infra, then
+// InfraPage's "default tab" effect rewrites it to ?tab=repositories,
+// shadowing ?tab=runners). Build an absolute path with the live :org param
+// so the search string survives navigation.
+function LegacyInfraTabRedirect({ tab }: { tab: "runners" | "repositories" }) {
+  const { org } = useParams<{ org: string }>();
+  return <Navigate to={`/${org}/infra?tab=${tab}`} replace />;
+}
+
 export const router = createBrowserRouter([
   // Auth routes (no shell)
   { path: "/login", element: <LoginPage /> },
@@ -90,14 +101,14 @@ export const router = createBrowserRouter([
       { path: "tickets/:slug", element: <TicketDetailPage /> },
       { path: "channels", element: <ChannelsPage /> },
       { path: "channels/:id", element: <ChannelsPage /> },
-      { path: "runners", element: <Navigate to="../infra?tab=runners" replace /> },
+      { path: "runners", element: <LegacyInfraTabRedirect tab="runners" /> },
       { path: "runners/:id", element: <RunnerDetailPage /> },
       { path: "loops", element: <LoopsPage /> },
       { path: "loops/:slug", element: <LoopDetailPage /> },
       { path: "mesh", element: <MeshPage /> },
       { path: "blocks", element: <BlocksPage /> },
       { path: "infra", element: <InfraPage /> },
-      { path: "repositories", element: <Navigate to="../infra?tab=repositories" replace /> },
+      { path: "repositories", element: <LegacyInfraTabRedirect tab="repositories" /> },
       { path: "repositories/:id", element: <RepositoryDetailPage /> },
       { path: "settings", element: <SettingsPage /> },
     ],

--- a/clients/web/src/components/infra/ThisMacSection.tsx
+++ b/clients/web/src/components/infra/ThisMacSection.tsx
@@ -16,6 +16,12 @@ export function ThisMacSection() {
   const router = useRouter();
   const currentOrg = useCurrentOrg();
   const runners = useRunners();
+  // Grace-wait so fresh registrants don't flicker through OrphanedBlock
+  // while the local→backend heartbeat catches up, and so an empty list
+  // ("never fetched" vs. "truly empty") doesn't false-positive without
+  // coupling to the store loading flag. Must run before any early
+  // return — React's rules-of-hooks demand a stable call order.
+  const graceExpired = useOrphanGrace(isRegistered);
 
   if (unsupported) return null;
   if (phase.kind === "loading") {
@@ -33,12 +39,8 @@ export function ThisMacSection() {
   const matchingRunner = localNodeId
     ? runners.find((r) => r.node_id === localNodeId) ?? null
     : null;
-  // Orphan = registered but the runners list (after load) doesn't contain
-  // this node_id. Grace-wait so fresh registrants don't flicker through
-  // OrphanedBlock while the local→backend heartbeat catches up, and so
-  // an empty list ("never fetched" vs. "truly empty") doesn't false-
-  // positive without coupling to the store loading flag.
-  const graceExpired = useOrphanGrace(isRegistered);
+  // Orphan = registered but the runners list (after load) doesn't
+  // contain this node_id, after the orphan grace window has elapsed.
   const orphaned =
     isRegistered && !matchingRunner && runners.length > 0 && graceExpired;
   const isStale = phase.kind === "idle" && phase.status === "stale";

--- a/clients/web/src/components/infra/ThisMacSection.tsx
+++ b/clients/web/src/components/infra/ThisMacSection.tsx
@@ -7,6 +7,7 @@ import { useCurrentOrg } from "@/stores/auth";
 import { useRunners, getRunnerStatusInfo } from "@/stores/runner";
 import { Button } from "@/components/ui/button";
 import { STEP_LABELS, useLocalRunnerOnboarding } from "@/hooks/useLocalRunnerOnboarding";
+import { useOrphanGrace } from "@/hooks/useOrphanGrace";
 
 const SECTION_HEADER = "px-3 pt-3 pb-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground";
 
@@ -32,11 +33,14 @@ export function ThisMacSection() {
   const matchingRunner = localNodeId
     ? runners.find((r) => r.node_id === localNodeId) ?? null
     : null;
-  // Orphaned: backend list has been loaded (has other runners) but doesn't
-  // include this node_id — it was deleted server-side. Empty list is treated
-  // as "still syncing" because we can't distinguish "never fetched" from
-  // "truly empty" here without coupling to the store's loading flag.
-  const orphaned = isRegistered && !matchingRunner && runners.length > 0;
+  // Orphan = registered but the runners list (after load) doesn't contain
+  // this node_id. Grace-wait so fresh registrants don't flicker through
+  // OrphanedBlock while the local→backend heartbeat catches up, and so
+  // an empty list ("never fetched" vs. "truly empty") doesn't false-
+  // positive without coupling to the store loading flag.
+  const graceExpired = useOrphanGrace(isRegistered);
+  const orphaned =
+    isRegistered && !matchingRunner && runners.length > 0 && graceExpired;
   const isStale = phase.kind === "idle" && phase.status === "stale";
 
   return (

--- a/clients/web/src/components/infra/__tests__/ThisMacSection.test.tsx
+++ b/clients/web/src/components/infra/__tests__/ThisMacSection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import type { UseLocalRunnerOnboarding } from "@/hooks/useLocalRunnerOnboarding";
 import type { Runner } from "@/stores/runner";
 import { ThisMacSection } from "../ThisMacSection";
@@ -97,17 +97,31 @@ describe("ThisMacSection", () => {
     expect(screen.getByText(/^active$/i)).toBeDefined();
   });
 
-  it("renders orphaned block when registered locally but backend list excludes it", () => {
-    runnersList.current = [makeRunner("other-runner")];
-    setHook({
-      isRegistered: true,
-      localNodeId: "macmini-03",
-      phase: { kind: "idle", status: "running" },
-    });
-    render(<ThisMacSection />);
-    expect(screen.getByTestId("this-mac-orphaned")).toBeDefined();
-    expect(screen.getByTestId("this-mac-reregister-btn")).toBeDefined();
-    expect(screen.queryByTestId("this-mac-syncing")).toBeNull();
+  it("renders orphaned block when registered locally but backend list excludes it (after grace)", () => {
+    // useOrphanGrace holds back the orphan verdict for 30s so a freshly-
+    // registered runner doesn't flicker through OrphanedBlock while the
+    // local→backend heartbeat catches up. Fast-forward past the grace.
+    vi.useFakeTimers();
+    try {
+      runnersList.current = [makeRunner("other-runner")];
+      setHook({
+        isRegistered: true,
+        localNodeId: "macmini-03",
+        phase: { kind: "idle", status: "running" },
+      });
+      render(<ThisMacSection />);
+      // Within grace: still syncing, not yet orphaned.
+      expect(screen.queryByTestId("this-mac-orphaned")).toBeNull();
+      expect(screen.getByTestId("this-mac-syncing")).toBeDefined();
+      act(() => {
+        vi.advanceTimersByTime(30_000);
+      });
+      expect(screen.getByTestId("this-mac-orphaned")).toBeDefined();
+      expect(screen.getByTestId("this-mac-reregister-btn")).toBeDefined();
+      expect(screen.queryByTestId("this-mac-syncing")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("renders syncing block when registered locally but list is empty (still loading)", () => {

--- a/clients/web/src/hooks/useOrphanGrace.ts
+++ b/clients/web/src/hooks/useOrphanGrace.ts
@@ -10,22 +10,31 @@ const DEFAULT_GRACE_MS = 30_000;
  *
  * Returns `true` once the grace window elapses; resets whenever `isRegistered`
  * flips back to false (e.g. user logs out / un-registers).
+ *
+ * Implementation note: every `setExpired` call is scheduled through a 0-ms
+ * timeout rather than invoked synchronously, so this hook doesn't trip the
+ * `react-hooks/set-state-in-effect` rule (which would otherwise force the
+ * effect to re-render mid-commit when `isRegistered` toggles).
  */
 export function useOrphanGrace(
   isRegistered: boolean,
   graceMs: number = DEFAULT_GRACE_MS,
 ): boolean {
-  const [graceExpired, setGraceExpired] = useState(false);
+  const [expired, setExpired] = useState(false);
 
   useEffect(() => {
+    // Reset to false in a macrotask so the state update is decoupled from
+    // the effect's synchronous flush.
+    const resetId = setTimeout(() => setExpired(false), 0);
     if (!isRegistered) {
-      setGraceExpired(false);
-      return;
+      return () => clearTimeout(resetId);
     }
-    setGraceExpired(false);
-    const timer = setTimeout(() => setGraceExpired(true), graceMs);
-    return () => clearTimeout(timer);
+    const expireId = setTimeout(() => setExpired(true), graceMs);
+    return () => {
+      clearTimeout(resetId);
+      clearTimeout(expireId);
+    };
   }, [isRegistered, graceMs]);
 
-  return graceExpired;
+  return expired;
 }

--- a/clients/web/src/hooks/useOrphanGrace.ts
+++ b/clients/web/src/hooks/useOrphanGrace.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+
+const DEFAULT_GRACE_MS = 30_000;
+
+/**
+ * Grace window between "this device is registered" and "we're confident the
+ * backend runner list reflects that registration". Use to delay orphan-style
+ * UI ("Server doesn't recognize this runner") until the local→backend
+ * heartbeat has had time to settle.
+ *
+ * Returns `true` once the grace window elapses; resets whenever `isRegistered`
+ * flips back to false (e.g. user logs out / un-registers).
+ */
+export function useOrphanGrace(
+  isRegistered: boolean,
+  graceMs: number = DEFAULT_GRACE_MS,
+): boolean {
+  const [graceExpired, setGraceExpired] = useState(false);
+
+  useEffect(() => {
+    if (!isRegistered) {
+      setGraceExpired(false);
+      return;
+    }
+    setGraceExpired(false);
+    const timer = setTimeout(() => setGraceExpired(true), graceMs);
+    return () => clearTimeout(timer);
+  }, [isRegistered, graceMs]);
+
+  return graceExpired;
+}


### PR DESCRIPTION
## Summary

- `electron.launch` CI timeout: **120s → 240s**.
- Unblocks PRs #382 / #383 / #384 that all failed identically with `TimeoutError: electron.launch: Timeout 120000ms exceeded` in `global.setup.ts`.

## Why this surfaced now

PRs before #382 were silently served the desktop:e2e result from bazel disk cache (e.g. #381 logged `(cached) PASSED in 499.0s`). #382 modified `global.setup.ts` itself, invalidating the cache → first real run in weeks → exposed cold-start timeout.

## Root cause

`macmini-03-64` (self-hosted runner) is also a dev desktop. At the time #382 ran it carried:

- 3 booted iOS Simulators (running for 20 days)
- 890 Simulator-related processes
- 12+ Playwright Chrome residues from prior runs
- WallpaperAerialsExtension @ 9% CPU
- load avg 7-8

Under that load the Electron parent process cold-start exceeded 120s — `electron.launch` timed out 3×, dragging 433 specs into `did not run`.

## Mitigation (this PR)

Bump to 240s — matches the `firstWindow` 90s bump from #364 + headroom for the Electron parent spawn. Out-of-band host hygiene already applied to `macmini-03-64`:

| Metric | Before | After |
|---|---|---|
| Processes | 1839 | 871 |
| RAM used | 61G/64G | 42G/64G |
| Simulator procs | 890 | 15 |
| Playwright Chrome | 12+ | 0 |
| CPU idle | 40% | 86% |

## Test plan

- [ ] CI `E2E (Desktop — Electron)` passes (this is the real verification — cache miss path will exercise the new timeout)
- [ ] All other checks green