### PR TITLE
fix(core+web): restore agent credentials dialog fields + profile list

### DIFF
--- a/clients/core/crates/api-client/src/api_core_tests.rs
+++ b/clients/core/crates/api-client/src/api_core_tests.rs
@@ -581,7 +581,7 @@ mod api_core_tests {
     async fn list_user_agent_credentials() {
         let s = MockServer::start().await;
         Mock::given(method("GET")).and(path("/api/v1/users/agent-credentials"))
-            .respond_with(ok(json!({"profiles":[]})))
+            .respond_with(ok(json!({"items":[]})))
             .expect(1).mount(&s).await;
         let c = ApiClient::new(s.uri(), MockTokenStore::no_org());
         let _ = c.list_user_agent_credentials().await.unwrap();

--- a/clients/core/crates/api-client/src/modules/user_agent_credential.rs
+++ b/clients/core/crates/api-client/src/modules/user_agent_credential.rs
@@ -12,7 +12,7 @@ impl ApiClient {
     pub async fn list_user_agent_credentials_for_agent(
         &self,
         agent_slug: &str,
-    ) -> Result<AgentCredentialProfileListResponse, ApiError> {
+    ) -> Result<AgentCredentialProfilesForAgentResponse, ApiError> {
         self.get(&format!(
             "/api/v1/users/agent-credentials/agents/{agent_slug}"
         ))

--- a/clients/core/crates/types/src/user_credential.rs
+++ b/clients/core/crates/types/src/user_credential.rs
@@ -75,9 +75,32 @@ pub struct UpdateAgentCredentialProfileRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AgentCredentialProfileListResponse {
-    #[serde(alias = "items", default)]
+pub struct CredentialProfilesByAgent {
+    pub agent_slug: String,
+    #[serde(default)]
+    pub agent_name: Option<String>,
+    #[serde(default)]
     pub profiles: Vec<AgentCredentialProfile>,
+}
+
+// Backend wire format: `GET /api/v1/users/agent-credentials` returns
+// `{ "items": [{ agent_slug, agent_name, profiles: [...] }] }` — a grouped
+// view across all agents. Distinct from the per-agent endpoint below.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentCredentialProfileListResponse {
+    #[serde(default)]
+    pub items: Vec<CredentialProfilesByAgent>,
+}
+
+// Backend wire format: `GET /api/v1/users/agent-credentials/agents/:slug`
+// returns `{ "profiles": [...], "runner_host": {...} }` — a flat list for a
+// single agent plus the virtual RunnerHost descriptor.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentCredentialProfilesForAgentResponse {
+    #[serde(default)]
+    pub profiles: Vec<AgentCredentialProfile>,
+    #[serde(default)]
+    pub runner_host: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -152,6 +175,87 @@ pub struct ProviderRepositoryListResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn agent_credential_list_decodes_backend_grouped_shape() {
+        // Wire shape produced by ListProfiles handler — grouped by agent.
+        // Regression: prior type modelled this as a flat profiles list which
+        // failed reverse-serialization (missing `id` on group items) and
+        // collapsed the renderer's credential list to empty.
+        let backend_json = r#"{
+            "items": [
+                {
+                    "agent_slug": "claude",
+                    "agent_name": "Claude",
+                    "profiles": [
+                        {
+                            "id": 7,
+                            "agent_slug": "claude",
+                            "name": "personal",
+                            "description": "my key",
+                            "is_runner_host": false,
+                            "is_default": true,
+                            "credentials": null,
+                            "created_at": "2026-05-01T00:00:00Z",
+                            "updated_at": "2026-05-01T00:00:00Z"
+                        }
+                    ]
+                },
+                { "agent_slug": "codex", "agent_name": "Codex", "profiles": [] }
+            ]
+        }"#;
+
+        let resp: AgentCredentialProfileListResponse =
+            serde_json::from_str(backend_json).unwrap();
+        assert_eq!(resp.items.len(), 2);
+        assert_eq!(resp.items[0].agent_slug, "claude");
+        assert_eq!(resp.items[0].profiles.len(), 1);
+        assert_eq!(resp.items[0].profiles[0].id, 7);
+        assert_eq!(resp.items[0].profiles[0].is_default, Some(true));
+        assert_eq!(resp.items[1].agent_slug, "codex");
+        assert!(resp.items[1].profiles.is_empty());
+
+        // Re-serialize: front-end relays the JSON unchanged, so the renderer
+        // must still see `items`, not `profiles`.
+        let relayed = serde_json::to_value(&resp).unwrap();
+        assert!(relayed.get("items").is_some());
+        assert!(relayed.get("profiles").is_none());
+    }
+
+    #[test]
+    fn agent_credential_list_tolerates_empty_items() {
+        let resp: AgentCredentialProfileListResponse =
+            serde_json::from_str(r#"{"items":[]}"#).unwrap();
+        assert!(resp.items.is_empty());
+    }
+
+    #[test]
+    fn agent_credential_for_agent_decodes_flat_shape() {
+        // Wire shape produced by ListProfilesForAgent handler — flat profiles
+        // list plus the virtual RunnerHost descriptor.
+        let backend_json = r#"{
+            "profiles": [
+                {
+                    "id": 11,
+                    "agent_slug": "claude",
+                    "name": "work",
+                    "description": null,
+                    "is_runner_host": false,
+                    "is_default": false,
+                    "credentials": null,
+                    "created_at": "2026-05-01T00:00:00Z",
+                    "updated_at": "2026-05-01T00:00:00Z"
+                }
+            ],
+            "runner_host": { "available": true, "description": "Use Runner machine" }
+        }"#;
+
+        let resp: AgentCredentialProfilesForAgentResponse =
+            serde_json::from_str(backend_json).unwrap();
+        assert_eq!(resp.profiles.len(), 1);
+        assert_eq!(resp.profiles[0].id, 11);
+        assert!(resp.runner_host.is_some());
+    }
 
     #[test]
     fn repository_provider_preserves_backend_fields() {

--- a/clients/desktop/e2e/tests/settings/personal-agents-credentials.spec.ts
+++ b/clients/desktop/e2e/tests/settings/personal-agents-credentials.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from "../../fixtures";
+import { TEST_ORG_SLUG, TEST_USER } from "../../helpers/env";
+import { gotoHash } from "../../helpers/nav";
+
+// Desktop counterpart of
+// clients/web/e2e-playwright/tests/settings/personal-agents-credentials.spec.ts.
+//
+// The renderer reuses AgentConfigPage + AgentCredentialsSettings from the
+// web tree, and Desktop ships the same Rust Core (via node-bridge). Both
+// regressions (Bug A: dialog missing ENV fields; Bug B: list empty after
+// load and after a successful POST) must be verified on the Electron
+// build too — the data path runs through the native dylib here, not the
+// browser wasm artifact, so a fix that only landed in the wasm bridge
+// would still leak through.
+
+const AGENT_SLUG = "claude-code";
+const NAME_PREFIX = "Desktop E2E Credential";
+
+function unique(label: string): string {
+  return `${NAME_PREFIX} ${label} ${Date.now()}`;
+}
+
+async function gotoAgentSettings(page: import("@playwright/test").Page): Promise<void> {
+  await gotoHash(
+    page,
+    `/${TEST_ORG_SLUG}/settings?scope=personal&tab=agents/${AGENT_SLUG}`
+  );
+}
+
+test.describe("Desktop · Personal Agent Credentials", () => {
+  // Bug A regression.
+  test("add-credential dialog renders ENV-derived secret + text fields", async ({ page }) => {
+    await gotoAgentSettings(page);
+
+    await page.getByRole("button", { name: /Add Custom Credentials|添加自定义凭据/i })
+      .first().click();
+
+    await expect(page.locator("#cred-name")).toBeVisible();
+    await expect(page.locator("#cred-desc")).toBeVisible();
+
+    await expect(page.locator("#cred-ANTHROPIC_API_KEY")).toBeVisible();
+    await expect(page.locator("#cred-ANTHROPIC_API_KEY")).toHaveAttribute("type", "password");
+    await expect(page.locator("#cred-ANTHROPIC_AUTH_TOKEN")).toBeVisible();
+    await expect(page.locator("#cred-ANTHROPIC_AUTH_TOKEN")).toHaveAttribute("type", "password");
+    await expect(page.locator("#cred-ANTHROPIC_BASE_URL")).toBeVisible();
+    await expect(page.locator("#cred-ANTHROPIC_BASE_URL")).toHaveAttribute("type", "text");
+  });
+
+  // Bug B regression — seeded profile must appear in the list.
+  test("seeded credential profile renders in the list", async ({ page, api, db }) => {
+    const profileName = unique("seeded");
+    db.cleanup(
+      `DELETE FROM user_agent_credential_profiles WHERE name LIKE '${NAME_PREFIX}%'`
+    );
+
+    await api.login(TEST_USER.email, TEST_USER.password);
+    const res = await api.post(`/api/v1/users/agent-credentials/agents/${AGENT_SLUG}`, {
+      name: profileName,
+      description: "seeded by desktop e2e",
+      credentials: { ANTHROPIC_API_KEY: "sk-ant-desktop-seeded" },
+    });
+    expect([200, 201]).toContain(res.status);
+
+    try {
+      await gotoAgentSettings(page);
+      await expect(page.getByText(profileName, { exact: true })).toBeVisible({
+        timeout: 15_000,
+      });
+    } finally {
+      db.cleanup(
+        `DELETE FROM user_agent_credential_profiles WHERE name LIKE '${NAME_PREFIX}%'`
+      );
+    }
+  });
+
+  // Bug A + Bug B end-to-end — full UI create flow.
+  test("UI create flow: new credential appears in the list after submit", async ({ page, db }) => {
+    const profileName = unique("ui-create");
+    db.cleanup(
+      `DELETE FROM user_agent_credential_profiles WHERE name LIKE '${NAME_PREFIX}%'`
+    );
+
+    try {
+      await gotoAgentSettings(page);
+
+      await page.getByRole("button", { name: /Add Custom Credentials|添加自定义凭据/i })
+        .first().click();
+      await expect(page.locator("#cred-ANTHROPIC_API_KEY")).toBeVisible();
+
+      await page.locator("#cred-name").fill(profileName);
+      await page.locator("#cred-desc").fill("created via desktop UI");
+      await page.locator("#cred-ANTHROPIC_API_KEY").fill("sk-ant-desktop-ui-created");
+
+      await page.getByRole("button", { name: /^(Create|创建)$/ }).click();
+
+      await expect(page.getByText(profileName, { exact: true })).toBeVisible({
+        timeout: 15_000,
+      });
+    } finally {
+      db.cleanup(
+        `DELETE FROM user_agent_credential_profiles WHERE name LIKE '${NAME_PREFIX}%'`
+      );
+    }
+  });
+});

--- a/clients/web/e2e-playwright/tests/settings/personal-agents-credentials.spec.ts
+++ b/clients/web/e2e-playwright/tests/settings/personal-agents-credentials.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect } from "../../fixtures/index";
+import { SettingsNavPage } from "../../pages/settings/settings-nav.page";
+import { TEST_ORG_SLUG, TEST_USER } from "../../helpers/env";
+import { clearAuthRateLimit } from "../../helpers/redis";
+
+// Regression guard for the May 2026 credentials breakage:
+//
+//   Bug A — Add Credentials dialog rendered only Name + Description
+//           (ENV-derived secret/text fields were swallowed because the
+//           renderer accessed `.schema?.credential_fields` on a payload
+//           that the wasm bridge already un-wrapped).
+//
+//   Bug B — The credentials list stayed empty after navigation AND after
+//           a successful POST, because the Rust list-response type modelled
+//           the grouped `{items:[{agent_slug,profiles}]}` payload as a flat
+//           profile list and reverse-serialisation failed silently.
+//
+// These cases run against the dev stack (`bazel run //deploy/dev:up`) and
+// drive the real renderer + real backend through the wasm bridge — the only
+// layer where the regression actually surfaced.
+
+const AGENT_SLUG = "claude-code";
+const NAME_PREFIX = "E2E Credential";
+
+function unique(label: string): string {
+  return `${NAME_PREFIX} ${label} ${Date.now()}`;
+}
+
+test.describe("Personal Agent Credentials", () => {
+  test.beforeEach(async () => {
+    clearAuthRateLimit();
+  });
+
+  // Bug A regression.
+  test("add-credential dialog renders ENV-derived secret + text fields", async ({ page }) => {
+    const nav = new SettingsNavPage(page, TEST_ORG_SLUG);
+    await nav.goto("personal", `agents/${AGENT_SLUG}`);
+
+    await page.getByRole("button", { name: /Add Custom Credentials|添加自定义凭据/i })
+      .first().click();
+
+    // Static fields — present even when the schema is empty. Asserting them
+    // first keeps the failure message useful when the dialog itself fails
+    // to mount.
+    await expect(page.locator("#cred-name")).toBeVisible();
+    await expect(page.locator("#cred-desc")).toBeVisible();
+
+    // ENV-derived fields from the built-in claude-code AgentFile. If any of
+    // these three goes missing, the dialog is silently degraded to the
+    // pre-fix two-field state and the user can't enter their key.
+    await expect(page.locator("#cred-ANTHROPIC_API_KEY")).toBeVisible();
+    await expect(page.locator("#cred-ANTHROPIC_API_KEY")).toHaveAttribute("type", "password");
+    await expect(page.locator("#cred-ANTHROPIC_AUTH_TOKEN")).toBeVisible();
+    await expect(page.locator("#cred-ANTHROPIC_AUTH_TOKEN")).toHaveAttribute("type", "password");
+    await expect(page.locator("#cred-ANTHROPIC_BASE_URL")).toBeVisible();
+    await expect(page.locator("#cred-ANTHROPIC_BASE_URL")).toHaveAttribute("type", "text");
+  });
+
+  // Bug B regression — seeded profile must appear in the list.
+  test("seeded credential profile renders in the list", async ({ page, api, db }) => {
+    const profileName = unique("seeded");
+    db.cleanup(
+      `DELETE FROM user_agent_credential_profiles WHERE name LIKE '${NAME_PREFIX}%'`
+    );
+
+    await api.login(TEST_USER.email, TEST_USER.password);
+    const res = await api.post(`/api/v1/users/agent-credentials/agents/${AGENT_SLUG}`, {
+      name: profileName,
+      description: "seeded by e2e",
+      credentials: { ANTHROPIC_API_KEY: "sk-ant-e2e-seeded" },
+    });
+    expect([200, 201]).toContain(res.status);
+
+    try {
+      const nav = new SettingsNavPage(page, TEST_ORG_SLUG);
+      await nav.goto("personal", `agents/${AGENT_SLUG}`);
+
+      // The CredentialsSection renders each profile's name in a span;
+      // getByText pins to the actual DOM node, not the page-level text dump
+      // the legacy spec used.
+      await expect(page.getByText(profileName, { exact: true })).toBeVisible({
+        timeout: 15_000,
+      });
+    } finally {
+      db.cleanup(
+        `DELETE FROM user_agent_credential_profiles WHERE name LIKE '${NAME_PREFIX}%'`
+      );
+    }
+  });
+
+  // Bug A + Bug B end-to-end — full UI create flow.
+  test("UI create flow: new credential appears in the list after submit", async ({ page, db }) => {
+    const profileName = unique("ui-create");
+    db.cleanup(
+      `DELETE FROM user_agent_credential_profiles WHERE name LIKE '${NAME_PREFIX}%'`
+    );
+
+    try {
+      const nav = new SettingsNavPage(page, TEST_ORG_SLUG);
+      await nav.goto("personal", `agents/${AGENT_SLUG}`);
+
+      await page.getByRole("button", { name: /Add Custom Credentials|添加自定义凭据/i })
+        .first().click();
+      await expect(page.locator("#cred-ANTHROPIC_API_KEY")).toBeVisible();
+
+      await page.locator("#cred-name").fill(profileName);
+      await page.locator("#cred-desc").fill("created via UI");
+      await page.locator("#cred-ANTHROPIC_API_KEY").fill("sk-ant-e2e-ui-created");
+
+      await page.getByRole("button", { name: /^(Create|创建)$/ }).click();
+
+      // After submit the dialog closes and loadData() refreshes the list.
+      // Pre-fix this is where the regression surfaced — the POST succeeded
+      // but the refreshed list was still empty.
+      await expect(page.getByText(profileName, { exact: true })).toBeVisible({
+        timeout: 15_000,
+      });
+    } finally {
+      db.cleanup(
+        `DELETE FROM user_agent_credential_profiles WHERE name LIKE '${NAME_PREFIX}%'`
+      );
+    }
+  });
+});

--- a/clients/web/src/components/ide/hooks/useConfigOptions.ts
+++ b/clients/web/src/components/ide/hooks/useConfigOptions.ts
@@ -67,7 +67,7 @@ export function useConfigOptions(
 
         if (cancelled) return;
 
-        const schema = schemaResponse.schema || { fields: [] };
+        const schema = schemaResponse || { fields: [] };
         const baseFields = schema.fields || [];
 
         // Step 1: Initialize config with ConfigSchema defaults

--- a/clients/web/src/components/settings/AgentConfigPage/useAgentConfig.ts
+++ b/clients/web/src/components/settings/AgentConfigPage/useAgentConfig.ts
@@ -58,16 +58,16 @@ export function useAgentConfig(
 
       // Load data in parallel
       const [schemaRes, credentialsRes] = await Promise.all([
-        getAgentService().get_config_schema(foundAgent.slug).then((j: string) => JSON.parse(j)).catch(() => ({ schema: { fields: [], credential_fields: [] } })),
+        getAgentService().get_config_schema(foundAgent.slug).then((j: string) => JSON.parse(j)).catch(() => ({ fields: [], credential_fields: [] })),
         getUserCredentialService().list_agent_credentials().then((j: string) => JSON.parse(j)).catch(() => ({ items: [] })),
       ]);
 
       // Set config schema fields
-      const fields = schemaRes.schema?.fields || [];
+      const fields = schemaRes.fields || [];
       setConfigFields(fields);
 
       // Set credential fields from AgentFile ENV SECRET/TEXT declarations
-      setCredentialFields(schemaRes.schema?.credential_fields || []);
+      setCredentialFields(schemaRes.credential_fields || []);
 
       // Initialize config values with defaults from schema
       const defaultValues: Record<string, unknown> = {};

--- a/clients/web/src/components/settings/AgentCredentialsSettings/useAgentCredentials.ts
+++ b/clients/web/src/components/settings/AgentCredentialsSettings/useAgentCredentials.ts
@@ -53,7 +53,7 @@ export function useAgentCredentials(
       agentList.forEach((a: AgentData, i: number) => {
         const result = schemaResults[i];
         if (result.status === "fulfilled") {
-          fieldsMap.set(a.slug, result.value.schema?.credential_fields || []);
+          fieldsMap.set(a.slug, result.value.credential_fields || []);
         }
       });
       setCredentialFieldsByAgent(fieldsMap);


### PR DESCRIPTION
## Summary

Restores the Agent API-credentials UI that was silently broken after the Rust-SSOT migration. Affects both web and desktop renderers.

### Bug A — "Add Credential" dialog dropped every ENV-derived field

The wasm bridge's `get_resource(url, "schema")` already strips the `{schema: {...}}` envelope. But `useAgentConfig` / `useAgentCredentials` / `useConfigOptions` still walked `.schema.fields` and `.schema.credential_fields`; the `?.` short circuit returned `[]`, so `CredentialFormFields` rendered nothing. Users saw only Name + Description and couldn't enter their API key.

### Bug B — Credential list stayed empty (before and after a successful POST)

Backend `GET /api/v1/users/agent-credentials` returns a **grouped** shape:
```json
{ "items": [ { "agent_slug": "claude-code", "agent_name": "Claude", "profiles": [...] } ] }
```
But `AgentCredentialProfileListResponse` was modelled as a **flat** `Vec<AgentCredentialProfile>`. Deserialisation failed silently (group items have no `id`/`name`), the front-end's `.catch(() => ({items:[]}))` swallowed the error, and even a freshly-created profile never appeared in the refreshed list.

## Fix

- `clients/core/crates/types/src/user_credential.rs` — split the type:
  - grouped `AgentCredentialProfileListResponse { items: Vec<CredentialProfilesByAgent> }`
  - flat `AgentCredentialProfilesForAgentResponse { profiles, runner_host }`
  - 3 new unit tests pin the actual backend wire shapes.
- `clients/core/crates/api-client/src/modules/user_agent_credential.rs` — `list-for-agent` decodes into the flat type.
- `clients/core/crates/api-client/src/api_core_tests.rs` — align mock body with real backend output (`{items:[]}` instead of the also-wrong `{profiles:[]}`).
- 3 web hooks drop the obsolete `.schema?.` layer when reading `fields` / `credential_fields`.

## Regression coverage

New Playwright suites on both web (Chromium / wasm) and desktop (Electron / napi node-bridge):
- `clients/web/e2e-playwright/tests/settings/personal-agents-credentials.spec.ts`
- `clients/desktop/e2e/tests/settings/personal-agents-credentials.spec.ts`

Three cases per suite (Bug A, Bug B, full UI create end-to-end), selectors anchored on stable input ids (`#cred-name`, `#cred-ANTHROPIC_API_KEY`, …).

## Verified locally

- `bazel test //clients/core/crates/types:types_test //clients/core/crates/api-client:api_client_test` — all green (3 new Rust unit tests included)
- `bazel build //clients/core/crates/services //clients/core/crates/wasm:wasm_lib //clients/core/crates/node-bridge:node_bridge` — clean compile
- `bazel test //clients/web:unit //clients/web:lint` — pass; `bazel build //clients/web:src` (tsc) clean
- `bazel test //clients/desktop:lint` — pass
- `bazel test //clients/web/e2e-playwright:e2e --test_arg=tests/settings/personal-agents-credentials.spec.ts` — **4 passed (43.2s)**
- `bazel test //clients/desktop:e2e --test_arg=tests/settings/personal-agents-credentials.spec.ts` — **4 passed (4.7s)**

> E2E runs need the worktree's port/project env piped through (env.ts's `findProjectRoot` cannot see `.env` inside the bazel sandbox):
> ```
> --test_env=HTTP_PORT=… --test_env=WEB_PORT=… --test_env=POSTGRES_PORT=…
> --test_env=REDIS_PORT=… --test_env=COMPOSE_PROJECT_NAME=agentsmesh-<worktree>
> ```

## Test plan

- [ ] CI green
- [ ] Manual sanity in desktop dev build: open `Settings → Personal → Agents → Claude Code → API Credentials`, confirm the Add Credential dialog renders API Key / Auth Token / Base URL fields, create one, confirm it appears in the list and survives reload.