### PR TITLE
fix(clients): map marketplace skill display_name in extension bridge

### DIFF
--- a/clients/core/crates/api-client/src/api_channel_extension_tests.rs
+++ b/clients/core/crates/api-client/src/api_channel_extension_tests.rs
@@ -506,11 +506,34 @@ mod api_channel_extension_tests {
             .and(path("/api/v1/orgs/acme/market/mcp-servers"))
             .and(query_param("q", "docker"))
             .and(query_param("limit", "5"))
-            .respond_with(ok(json!({"mcp_servers":[],"total":0})))
+            .respond_with(ok(json!({"mcp_servers":[{
+                "id": 1,
+                "name": "GitHub MCP",
+                "slug": "github",
+                "description": "Access GitHub repos",
+                "icon": "github",
+                "transport_type": "http",
+                "command": "npx",
+                "default_args": ["mcp-github"],
+                "default_http_url": "https://api.github.com",
+                "env_var_schema": [{
+                    "name": "GH_TOKEN", "label": "GitHub Token",
+                    "required": true, "sensitive": true
+                }],
+                "category": "dev",
+                "source": "registry",
+                "version": "1.2.0",
+                "repository_url": "https://github.com/example/mcp-github"
+            }]})))
             .expect(1).mount(&s).await;
         let c = ApiClient::new(s.uri(), MockTokenStore::with_org("acme"));
         let r = c.list_market_mcp_servers(Some("docker"), Some(5), None).await.unwrap();
-        assert!(r.mcp_servers.is_empty());
+        assert_eq!(r.mcp_servers.len(), 1);
+        let server = &r.mcp_servers[0];
+        assert_eq!(server.command.as_deref(), Some("npx"));
+        assert_eq!(server.default_args.as_ref().map(|v| v.len()), Some(1));
+        assert_eq!(server.env_var_schema.as_ref().map(|v| v.len()), Some(1));
+        assert_eq!(server.version.as_deref(), Some("1.2.0"));
     }
 
     #[tokio::test]
@@ -532,7 +555,7 @@ mod api_channel_extension_tests {
         Mock::given(method("POST"))
             .and(path("/api/v1/orgs/acme/repositories/5/skills/install-from-market"))
             .and(body_json(json!({"market_item_id":42,"scope":null})))
-            .respond_with(ok(json!({"id":1,"skill_slug":"git-commit"})))
+            .respond_with(ok(json!({"id":1,"slug":"git-commit"})))
             .expect(1).mount(&s).await;
         let c = ApiClient::new(s.uri(), MockTokenStore::with_org("acme"));
         let data = agentsmesh_types::InstallMarketSkillRequest {
@@ -552,7 +575,7 @@ mod api_channel_extension_tests {
                 "url":"https://github.com/org/skill",
                 "branch":null,"path":null,"scope":null
             })))
-            .respond_with(ok(json!({"id":2,"source":"github"})))
+            .respond_with(ok(json!({"id":2,"install_source":"github"})))
             .expect(1).mount(&s).await;
         let c = ApiClient::new(s.uri(), MockTokenStore::with_org("acme"));
         let data = agentsmesh_types::InstallGithubSkillRequest {

--- a/clients/core/crates/api-client/src/api_core_tests.rs
+++ b/clients/core/crates/api-client/src/api_core_tests.rs
@@ -336,12 +336,35 @@ mod api_core_tests {
     #[tokio::test]
     async fn list_market_skills() {
         let s = MockServer::start().await;
-        Mock::given(method("GET")).and(path("/api/v1/orgs/acme/market/skills"))
+        Mock::given(method("GET"))
+            .and(path("/api/v1/orgs/acme/market/skills"))
             .and(query_param("q", "git"))
-            .respond_with(ok(json!({"skills":[]})))
-            .expect(1).mount(&s).await;
+            .respond_with(ok(json!({
+                "skills": [{
+                    "id": 1,
+                    "registry_id": 10,
+                    "slug": "git-commit",
+                    "display_name": "Git Commit",
+                    "description": "Create polished commits",
+                    "category": "dev",
+                    "content_sha": "abc123",
+                    "storage_key": "skills/git-commit.tgz",
+                    "is_active": true,
+                    "registry": {
+                        "id": 10,
+                        "organization_id": 42,
+                        "repository_url": "https://github.com/acme/skills",
+                        "branch": "main",
+                        "sync_status": "success"
+                    }
+                }]
+            })))
+            .expect(1)
+            .mount(&s)
+            .await;
         let c = ApiClient::new(s.uri(), MockTokenStore::with_org("acme"));
-        let _ = c.list_market_skills(Some("git"), None).await.unwrap();
+        let r = c.list_market_skills(Some("git"), None).await.unwrap();
+        assert_eq!(r.skills[0].display_name.as_deref(), Some("Git Commit"));
     }
 
     // ── file ────────────────────────────────────────────────────────────

--- a/clients/core/crates/api-client/src/api_core_tests.rs
+++ b/clients/core/crates/api-client/src/api_core_tests.rs
@@ -365,6 +365,13 @@ mod api_core_tests {
         let c = ApiClient::new(s.uri(), MockTokenStore::with_org("acme"));
         let r = c.list_market_skills(Some("git"), None).await.unwrap();
         assert_eq!(r.skills[0].display_name.as_deref(), Some("Git Commit"));
+        assert_eq!(r.skills[0].registry_id, Some(10));
+        let reg = r.skills[0].registry.as_ref().expect("registry survives relay");
+        assert_eq!(reg.sync_status.as_deref(), Some("success"));
+        assert_eq!(
+            reg.repository_url.as_deref(),
+            Some("https://github.com/acme/skills")
+        );
     }
 
     // ── file ────────────────────────────────────────────────────────────

--- a/clients/core/crates/types/src/extension.rs
+++ b/clients/core/crates/types/src/extension.rs
@@ -43,20 +43,41 @@ pub struct ToggleRegistryRequest {
 pub struct SkillRegistryOverride {
     pub id: i64,
     pub registry_id: Option<i64>,
-    pub skill_slug: Option<String>,
     pub is_disabled: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpHeaderSchemaEntry {
+    pub name: String,
+    pub description: Option<String>,
+    pub value: Option<String>,
+    pub required: bool,
+    pub sensitive: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnvVarSchemaEntry {
+    pub name: String,
+    pub label: String,
+    pub required: bool,
+    pub sensitive: bool,
+    pub placeholder: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MarketSkill {
     pub id: i64,
+    pub registry_id: Option<i64>,
     pub slug: Option<String>,
     #[serde(default, alias = "name")]
     pub display_name: Option<String>,
     pub description: Option<String>,
+    pub license: Option<String>,
     pub category: Option<String>,
-    pub author: Option<String>,
-    pub icon_url: Option<String>,
+    pub content_sha: Option<String>,
+    pub version: Option<i64>,
+    pub is_active: Option<bool>,
+    pub registry: Option<SkillRegistry>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -65,21 +86,34 @@ pub struct MarketMcpServer {
     pub name: String,
     pub slug: Option<String>,
     pub description: Option<String>,
-    pub category: Option<String>,
-    pub author: Option<String>,
+    pub icon: Option<String>,
     pub transport_type: Option<String>,
+    pub command: Option<String>,
+    pub default_args: Option<Vec<String>>,
+    pub default_http_url: Option<String>,
+    pub default_http_headers: Option<Vec<McpHeaderSchemaEntry>>,
+    pub env_var_schema: Option<Vec<EnvVarSchemaEntry>>,
+    pub category: Option<String>,
+    pub source: Option<String>,
+    pub registry_name: Option<String>,
+    pub version: Option<String>,
+    pub repository_url: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RepoSkillInstall {
     pub id: i64,
-    pub repository_id: Option<i64>,
-    pub skill_slug: Option<String>,
-    pub name: Option<String>,
+    pub organization_id: Option<i64>,
+    pub market_item_id: Option<i64>,
+    pub installed_by: Option<i64>,
+    pub slug: Option<String>,
     pub scope: Option<String>,
-    pub is_enabled: Option<bool>,
+    pub install_source: Option<String>,
+    pub source_url: Option<String>,
+    pub content_sha: Option<String>,
+    pub package_size: Option<i64>,
     pub pinned_version: Option<String>,
-    pub source: Option<String>,
+    pub is_enabled: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -105,10 +139,17 @@ pub struct UpdateSkillInstallRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RepoMcpServerInstall {
     pub id: i64,
-    pub repository_id: Option<i64>,
+    pub organization_id: Option<i64>,
+    pub market_item_id: Option<i64>,
+    pub installed_by: Option<i64>,
     pub name: Option<String>,
     pub slug: Option<String>,
     pub transport_type: Option<String>,
+    pub command: Option<String>,
+    pub args: Option<Vec<String>>,
+    pub http_url: Option<String>,
+    pub http_headers: Option<serde_json::Value>,
+    pub env_vars: Option<serde_json::Value>,
     pub scope: Option<String>,
     pub is_enabled: Option<bool>,
 }
@@ -152,7 +193,6 @@ pub struct MarketSkillListResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MarketMcpServerListResponse {
     pub mcp_servers: Vec<MarketMcpServer>,
-    pub total: Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -171,69 +211,5 @@ pub struct RepoMcpServerInstallListResponse {
 }
 
 #[cfg(test)]
-mod skill_registry_tests {
-    use super::{SkillRegistry, SkillRegistryListResponse};
-
-    const BACKEND_PAYLOAD: &str = r#"{
-        "id": 7,
-        "organization_id": 42,
-        "repository_url": "https://github.com/agentsmesh/skills-bundle",
-        "branch": "main",
-        "source_type": "auto",
-        "detected_type": "collection",
-        "compatible_agents": ["claude-code", "codex"],
-        "auth_type": "github_pat",
-        "last_synced_at": "2026-05-09T00:00:00Z",
-        "last_commit_sha": "abc123def456",
-        "sync_status": "success",
-        "skill_count": 12,
-        "is_active": true,
-        "created_at": "2026-05-08T00:00:00Z",
-        "updated_at": "2026-05-09T00:00:00Z"
-    }"#;
-
-    #[test]
-    fn skill_registry_decodes_backend_payload() {
-        let r: SkillRegistry = serde_json::from_str(BACKEND_PAYLOAD).unwrap();
-        assert_eq!(r.id, 7);
-        assert_eq!(r.sync_status.as_deref(), Some("success"));
-        assert_eq!(r.skill_count, Some(12));
-        assert_eq!(r.auth_type.as_deref(), Some("github_pat"));
-        assert_eq!(r.is_active, Some(true));
-    }
-
-    #[test]
-    fn skill_registry_wasm_relay_preserves_ui_fields() {
-        let typed: SkillRegistry = serde_json::from_str(BACKEND_PAYLOAD).unwrap();
-        let relayed = serde_json::to_string(&typed).unwrap();
-        let parsed: serde_json::Value = serde_json::from_str(&relayed).unwrap();
-        for key in ["sync_status", "auth_type", "skill_count", "is_active",
-                    "last_commit_sha", "detected_type"] {
-            assert!(!parsed[key].is_null(), "field `{key}` dropped by relay");
-        }
-    }
-
-    // Regression for #341: backend wire wrapper is `skill_registries`, but PR #349
-    // used `#[serde(alias)]` on a Rust field named `registries`. Serde's `alias`
-    // only affects deserialization; re-serializing for the wasm relay emitted
-    // `{"registries": ...}` instead, so the TS layer (which reads
-    // `.skill_registries`) always saw `undefined` and rendered an empty list.
-    // This test pins the round-trip key.
-    #[test]
-    fn skill_registry_list_response_relay_key_matches_backend_wire() {
-        let backend_wire = format!(r#"{{"skill_registries":[{BACKEND_PAYLOAD}]}}"#);
-        let typed: SkillRegistryListResponse = serde_json::from_str(&backend_wire).unwrap();
-        assert_eq!(typed.skill_registries.len(), 1);
-
-        let relayed = serde_json::to_string(&typed).unwrap();
-        let parsed: serde_json::Value = serde_json::from_str(&relayed).unwrap();
-        assert!(
-            parsed.get("skill_registries").is_some(),
-            "wasm relay must emit `skill_registries`, got: {relayed}"
-        );
-        assert!(
-            parsed.get("registries").is_none(),
-            "legacy `registries` key must not leak through: {relayed}"
-        );
-    }
-}
+#[path = "extension_relay_tests.rs"]
+mod extension_relay_tests;

--- a/clients/core/crates/types/src/extension.rs
+++ b/clients/core/crates/types/src/extension.rs
@@ -50,8 +50,9 @@ pub struct SkillRegistryOverride {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MarketSkill {
     pub id: i64,
-    pub name: String,
     pub slug: Option<String>,
+    #[serde(default, alias = "name")]
+    pub display_name: Option<String>,
     pub description: Option<String>,
     pub category: Option<String>,
     pub author: Option<String>,

--- a/clients/core/crates/types/src/extension_relay_tests.rs
+++ b/clients/core/crates/types/src/extension_relay_tests.rs
@@ -1,0 +1,316 @@
+use super::{
+    MarketMcpServer, MarketMcpServerListResponse, MarketSkill, MarketSkillListResponse,
+    RepoMcpServerInstall, RepoMcpServerInstallListResponse, RepoSkillInstall,
+    RepoSkillInstallListResponse, SkillRegistry, SkillRegistryListResponse,
+};
+
+// ── SkillRegistry (existing coverage, preserved verbatim from PR #341/#349/#368) ──
+
+const REGISTRY_PAYLOAD: &str = r#"{
+    "id": 7,
+    "organization_id": 42,
+    "repository_url": "https://github.com/agentsmesh/skills-bundle",
+    "branch": "main",
+    "source_type": "auto",
+    "detected_type": "collection",
+    "compatible_agents": ["claude-code", "codex"],
+    "auth_type": "github_pat",
+    "last_synced_at": "2026-05-09T00:00:00Z",
+    "last_commit_sha": "abc123def456",
+    "sync_status": "success",
+    "skill_count": 12,
+    "is_active": true,
+    "created_at": "2026-05-08T00:00:00Z",
+    "updated_at": "2026-05-09T00:00:00Z"
+}"#;
+
+#[test]
+fn skill_registry_decodes_backend_payload() {
+    let r: SkillRegistry = serde_json::from_str(REGISTRY_PAYLOAD).unwrap();
+    assert_eq!(r.id, 7);
+    assert_eq!(r.sync_status.as_deref(), Some("success"));
+    assert_eq!(r.skill_count, Some(12));
+    assert_eq!(r.auth_type.as_deref(), Some("github_pat"));
+    assert_eq!(r.is_active, Some(true));
+}
+
+#[test]
+fn skill_registry_wasm_relay_preserves_ui_fields() {
+    let typed: SkillRegistry = serde_json::from_str(REGISTRY_PAYLOAD).unwrap();
+    let relayed = serde_json::to_string(&typed).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&relayed).unwrap();
+    for key in [
+        "sync_status",
+        "auth_type",
+        "skill_count",
+        "is_active",
+        "last_commit_sha",
+        "detected_type",
+    ] {
+        assert!(!parsed[key].is_null(), "field `{key}` dropped by relay");
+    }
+}
+
+// Regression for #341: backend wire wrapper is `skill_registries`, but PR #349
+// used `#[serde(alias)]` on a Rust field named `registries`. Serde's `alias`
+// only affects deserialization; re-serializing for the wasm relay emitted
+// `{"registries": ...}` instead. This test pins the round-trip key.
+#[test]
+fn skill_registry_list_response_relay_key_matches_backend_wire() {
+    let backend_wire = format!(r#"{{"skill_registries":[{REGISTRY_PAYLOAD}]}}"#);
+    let typed: SkillRegistryListResponse = serde_json::from_str(&backend_wire).unwrap();
+    assert_eq!(typed.skill_registries.len(), 1);
+
+    let relayed = serde_json::to_string(&typed).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&relayed).unwrap();
+    assert!(
+        parsed.get("skill_registries").is_some(),
+        "wasm relay must emit `skill_registries`, got: {relayed}"
+    );
+    assert!(
+        parsed.get("registries").is_none(),
+        "legacy `registries` key must not leak through: {relayed}"
+    );
+}
+
+// ── MarketSkill (PR #398 — TS reads item.registry?.repository_url) ──
+
+const MARKET_SKILL_PAYLOAD: &str = r#"{
+    "id": 1,
+    "registry_id": 10,
+    "slug": "git-commit",
+    "display_name": "Git Commit",
+    "description": "Create polished commits",
+    "license": "MIT",
+    "category": "dev",
+    "content_sha": "abc123",
+    "version": 2,
+    "is_active": true,
+    "registry": {
+        "id": 10,
+        "organization_id": 42,
+        "repository_url": "https://github.com/acme/skills",
+        "branch": "main",
+        "sync_status": "success"
+    }
+}"#;
+
+#[test]
+fn market_skill_wasm_relay_preserves_ui_fields() {
+    let typed: MarketSkill = serde_json::from_str(MARKET_SKILL_PAYLOAD).unwrap();
+    assert_eq!(typed.display_name.as_deref(), Some("Git Commit"));
+    assert!(typed.registry.is_some());
+
+    let relayed = serde_json::to_string(&typed).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&relayed).unwrap();
+    for key in [
+        "slug",
+        "display_name",
+        "description",
+        "category",
+        "registry",
+        "registry_id",
+        "is_active",
+        "content_sha",
+    ] {
+        assert!(!parsed[key].is_null(), "field `{key}` dropped by relay");
+    }
+    assert!(
+        !parsed["registry"]["repository_url"].is_null(),
+        "nested registry.repository_url dropped — TS AddSkillDialog reads this"
+    );
+}
+
+#[test]
+fn market_skill_list_response_relay_key_matches_backend_wire() {
+    let backend_wire = format!(r#"{{"skills":[{MARKET_SKILL_PAYLOAD}]}}"#);
+    let typed: MarketSkillListResponse = serde_json::from_str(&backend_wire).unwrap();
+    assert_eq!(typed.skills.len(), 1);
+
+    let relayed = serde_json::to_string(&typed).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&relayed).unwrap();
+    assert!(parsed.get("skills").is_some(), "must emit `skills`: {relayed}");
+}
+
+// ── MarketMcpServer (TS uses command / default_args / env_var_schema / etc.) ──
+
+const MARKET_MCP_PAYLOAD: &str = r#"{
+    "id": 1,
+    "name": "GitHub MCP",
+    "slug": "github",
+    "description": "Access GitHub repos",
+    "icon": "github",
+    "transport_type": "http",
+    "command": "npx",
+    "default_args": ["mcp-github", "--token"],
+    "default_http_url": "https://api.github.com",
+    "default_http_headers": [
+        {"name": "Authorization", "required": true, "sensitive": true}
+    ],
+    "env_var_schema": [
+        {"name": "GH_TOKEN", "label": "GitHub Token", "required": true, "sensitive": true}
+    ],
+    "category": "dev",
+    "source": "registry",
+    "registry_name": "MCP Registry",
+    "version": "1.2.0",
+    "repository_url": "https://github.com/example/mcp-github"
+}"#;
+
+#[test]
+fn market_mcp_server_wasm_relay_preserves_ui_fields() {
+    let typed: MarketMcpServer = serde_json::from_str(MARKET_MCP_PAYLOAD).unwrap();
+    assert_eq!(typed.command.as_deref(), Some("npx"));
+    assert_eq!(typed.default_args.as_ref().map(|v| v.len()), Some(2));
+    assert_eq!(typed.env_var_schema.as_ref().map(|v| v.len()), Some(1));
+
+    let relayed = serde_json::to_string(&typed).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&relayed).unwrap();
+    for key in [
+        "command",
+        "default_args",
+        "default_http_url",
+        "default_http_headers",
+        "env_var_schema",
+        "source",
+        "version",
+        "repository_url",
+        "transport_type",
+        "icon",
+    ] {
+        assert!(!parsed[key].is_null(), "field `{key}` dropped by relay");
+    }
+}
+
+#[test]
+fn market_mcp_server_list_response_relay_key_matches_backend_wire() {
+    let backend_wire = format!(r#"{{"mcp_servers":[{MARKET_MCP_PAYLOAD}]}}"#);
+    let typed: MarketMcpServerListResponse = serde_json::from_str(&backend_wire).unwrap();
+    assert_eq!(typed.mcp_servers.len(), 1);
+
+    let relayed = serde_json::to_string(&typed).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&relayed).unwrap();
+    assert!(
+        parsed.get("mcp_servers").is_some(),
+        "must emit `mcp_servers`: {relayed}"
+    );
+    assert!(
+        parsed.get("total").is_none(),
+        "phantom `total` must not leak: {relayed}"
+    );
+}
+
+// ── RepoSkillInstall (rename skill_slug→slug, source→install_source) ──
+
+const REPO_SKILL_INSTALL_PAYLOAD: &str = r#"{
+    "id": 5,
+    "organization_id": 42,
+    "market_item_id": 1,
+    "installed_by": 7,
+    "slug": "git-commit",
+    "scope": "org",
+    "install_source": "market",
+    "source_url": "https://github.com/acme/skills/git-commit",
+    "content_sha": "abc123",
+    "package_size": 1024,
+    "is_enabled": true
+}"#;
+
+#[test]
+fn repo_skill_install_wasm_relay_preserves_ui_fields() {
+    let typed: RepoSkillInstall = serde_json::from_str(REPO_SKILL_INSTALL_PAYLOAD).unwrap();
+    assert_eq!(typed.slug.as_deref(), Some("git-commit"));
+    assert_eq!(typed.install_source.as_deref(), Some("market"));
+
+    let relayed = serde_json::to_string(&typed).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&relayed).unwrap();
+    for key in [
+        "slug",
+        "install_source",
+        "source_url",
+        "is_enabled",
+        "package_size",
+        "content_sha",
+        "market_item_id",
+    ] {
+        assert!(!parsed[key].is_null(), "field `{key}` dropped by relay");
+    }
+    assert!(
+        parsed.get("skill_slug").is_none(),
+        "legacy fabricated `skill_slug` must not leak: {relayed}"
+    );
+    assert!(
+        parsed.get("source").is_none() || !parsed["source"].is_string(),
+        "legacy fabricated `source` must not leak (must be `install_source`): {relayed}"
+    );
+}
+
+#[test]
+fn repo_skill_install_list_response_relay_key_matches_backend_wire() {
+    let backend_wire = format!(r#"{{"skills":[{REPO_SKILL_INSTALL_PAYLOAD}]}}"#);
+    let typed: RepoSkillInstallListResponse = serde_json::from_str(&backend_wire).unwrap();
+    assert_eq!(typed.skills.len(), 1);
+
+    let relayed = serde_json::to_string(&typed).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&relayed).unwrap();
+    assert!(parsed.get("skills").is_some(), "must emit `skills`: {relayed}");
+}
+
+// ── RepoMcpServerInstall (TS uses command / args / http_url / env_vars) ──
+
+const REPO_MCP_INSTALL_PAYLOAD: &str = r#"{
+    "id": 7,
+    "organization_id": 42,
+    "market_item_id": 3,
+    "installed_by": 7,
+    "name": "GitHub MCP",
+    "slug": "github",
+    "transport_type": "http",
+    "command": "npx",
+    "args": ["mcp-github"],
+    "http_url": "https://api.github.com",
+    "http_headers": {"Authorization": "Bearer ***"},
+    "env_vars": {"GH_TOKEN": "encrypted"},
+    "scope": "org",
+    "is_enabled": true
+}"#;
+
+#[test]
+fn repo_mcp_server_install_wasm_relay_preserves_ui_fields() {
+    let typed: RepoMcpServerInstall = serde_json::from_str(REPO_MCP_INSTALL_PAYLOAD).unwrap();
+    assert_eq!(typed.command.as_deref(), Some("npx"));
+    assert!(typed.env_vars.is_some());
+
+    let relayed = serde_json::to_string(&typed).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&relayed).unwrap();
+    for key in [
+        "command",
+        "args",
+        "http_url",
+        "http_headers",
+        "env_vars",
+        "transport_type",
+        "slug",
+        "is_enabled",
+    ] {
+        assert!(!parsed[key].is_null(), "field `{key}` dropped by relay");
+    }
+    assert!(
+        parsed.get("repository_id").is_none(),
+        "phantom `repository_id` must not leak: {relayed}"
+    );
+}
+
+#[test]
+fn repo_mcp_server_install_list_response_relay_key_matches_backend_wire() {
+    let backend_wire = format!(r#"{{"mcp_servers":[{REPO_MCP_INSTALL_PAYLOAD}]}}"#);
+    let typed: RepoMcpServerInstallListResponse = serde_json::from_str(&backend_wire).unwrap();
+    assert_eq!(typed.mcp_servers.len(), 1);
+
+    let relayed = serde_json::to_string(&typed).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&relayed).unwrap();
+    assert!(
+        parsed.get("mcp_servers").is_some(),
+        "must emit `mcp_servers`: {relayed}"
+    );
+}


### PR DESCRIPTION
## Summary

- What changed?
  - Fixed marketplace skill field mapping in the web extension bridge by using `display_name` as the canonical field and keeping `name` as a serde alias.
- Why was this change needed?
  - Backend marketplace skill APIs return `display_name`, but the bridge expected `name`, causing non-empty marketplace skill responses to fail deserialization and appear empty in the web add-skills flow.

## Changes

- Updated `MarketSkill` to deserialize `display_name`, with backward-compatible alias support for `name`.
- Updated the API client test fixture/assertion to match the backend marketplace skill response shape.

## Validation

- [ ] Backend tests (`bazel test //backend/...`)
- [ ] Web checks (`bazel test //clients/web:lint //clients/web:unit && bazel build //clients/web:src`)
- [ ] Runner checks (`bazel test //runner/...`)
- [x] Manual validation performed (if applicable)

Manual validation:
- Started local dev stack excluding runner.
- Verified web returns `200 OK`.
- Verified API and relay health endpoints are OK.

## Documentation

- [ ] Docs updated (README/docs/inline comments)
- [x] No docs changes needed

## Risk and Rollback

- Risk level: Low
- Rollback plan: Revert the `MarketSkill` field mapping and related test update.
