### PR TITLE
fix(runner+backend): channel @pod prompt now actually submits in PTY

### DIFF
--- a/backend/internal/service/channel/hook_pod_prompt.go
+++ b/backend/internal/service/channel/hook_pod_prompt.go
@@ -78,5 +78,11 @@ func stripPodMentions(content string, podKeys []string) string {
 
 func buildPodPrompt(content, channelName string, channelID int64, podKeys []string) string {
 	rawPrompt := stripPodMentions(content, podKeys)
-	return fmt.Sprintf("Message from channel(#%s, channel_id=%d): %s\n\nIf you finish it, please reply to this channel using send_channel_message(channel_id=%d).", channelName, channelID, rawPrompt, channelID)
+	// PTY submits via runner.OnSendPrompt's trailing \r write; any embedded
+	// \n/\r in the body either pre-submits a partial prompt or sinks the
+	// final \r into the TUI's paste buffer. Flatten to a single line.
+	rawPrompt = ptyPromptFlattener.Replace(rawPrompt)
+	return fmt.Sprintf("Message from channel(#%s, channel_id=%d): %s. If you finish it, please reply to this channel using send_channel_message(channel_id=%d).", channelName, channelID, rawPrompt, channelID)
 }
+
+var ptyPromptFlattener = strings.NewReplacer("\r\n", " ", "\n", " ", "\r", " ")

--- a/backend/internal/service/channel/hook_pod_prompt_test.go
+++ b/backend/internal/service/channel/hook_pod_prompt_test.go
@@ -1,6 +1,7 @@
 package channel
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -80,7 +81,7 @@ func TestBuildPodPrompt(t *testing.T) {
 			channelName: "dev-team",
 			channelID:   42,
 			podKeys:     []string{"abcd1234efgh5678"},
-			want:        "Message from channel(#dev-team, channel_id=42): fix the login bug\n\nIf you finish it, please reply to this channel using send_channel_message(channel_id=42).",
+			want:        "Message from channel(#dev-team, channel_id=42): fix the login bug. If you finish it, please reply to this channel using send_channel_message(channel_id=42).",
 		},
 		{
 			name:        "no mentions to strip",
@@ -88,7 +89,7 @@ func TestBuildPodPrompt(t *testing.T) {
 			channelName: "ops",
 			channelID:   7,
 			podKeys:     []string{"abcd1234efgh5678"},
-			want:        "Message from channel(#ops, channel_id=7): deploy to staging\n\nIf you finish it, please reply to this channel using send_channel_message(channel_id=7).",
+			want:        "Message from channel(#ops, channel_id=7): deploy to staging. If you finish it, please reply to this channel using send_channel_message(channel_id=7).",
 		},
 		{
 			name:        "multiple mentions stripped",
@@ -96,7 +97,7 @@ func TestBuildPodPrompt(t *testing.T) {
 			channelName: "code-review",
 			channelID:   100,
 			podKeys:     []string{"aabbccddxxxxxxxx", "eeffgghhyyyyyyyy"},
-			want:        "Message from channel(#code-review, channel_id=100): review PR #42\n\nIf you finish it, please reply to this channel using send_channel_message(channel_id=100).",
+			want:        "Message from channel(#code-review, channel_id=100): review PR #42. If you finish it, please reply to this channel using send_channel_message(channel_id=100).",
 		},
 	}
 
@@ -106,4 +107,32 @@ func TestBuildPodPrompt(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// PTY pods submit prompts with a single trailing Enter (\r) inside the
+// runner; any embedded \n/\r in the body breaks that. The hook is the only
+// place we control the body, so this invariant lives here.
+func TestBuildPodPrompt_NeverContainsNewlines(t *testing.T) {
+	cases := []string{
+		"single line",
+		"line1\nline2",
+		"line1\r\nline2",
+		"trailing\n",
+		"mixed\n\rstuff\r\nhere",
+		"@abcd1234 multi\nline\nmention",
+	}
+	for _, content := range cases {
+		t.Run(content, func(t *testing.T) {
+			got := buildPodPrompt(content, "ch", 1, []string{"abcd1234efgh5678"})
+			if strings.ContainsAny(got, "\n\r") {
+				t.Fatalf("buildPodPrompt must not emit \\n or \\r (breaks PTY Enter submit); got %q", got)
+			}
+		})
+	}
+}
+
+func TestBuildPodPrompt_FlattensUserNewlines(t *testing.T) {
+	got := buildPodPrompt("first line\nsecond line", "dev", 1, []string{"k"})
+	want := "Message from channel(#dev, channel_id=1): first line second line. If you finish it, please reply to this channel using send_channel_message(channel_id=1)."
+	assert.Equal(t, want, got)
 }

--- a/runner/internal/runner/message_handler_ops.go
+++ b/runner/internal/runner/message_handler_ops.go
@@ -3,11 +3,19 @@ package runner
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	runnerv1 "github.com/anthropics/agentsmesh/proto/gen/go/runner/v1"
 	"github.com/anthropics/agentsmesh/runner/internal/client"
 	"github.com/anthropics/agentsmesh/runner/internal/logger"
 )
+
+// ptySubmitGap separates the prompt-body Write from the Enter keystroke so
+// the TUI's read(2) loop ticks between them. Without this gap both writes
+// land in one read and the TUI treats the whole chunk (incl. trailing \r)
+// as a paste — the Enter never fires. MCP's two-RPC path gets this gap
+// implicitly via network round-trip; the in-process gRPC path does not.
+const ptySubmitGap = 80 * time.Millisecond
 
 // OnListRelayConnections returns current relay connections.
 func (h *RunnerMessageHandler) OnListRelayConnections() []client.RelayConnectionInfo {
@@ -121,9 +129,10 @@ func (h *RunnerMessageHandler) OnObservePod(req client.ObservePodRequest) error 
 
 // OnSendPrompt handles send_prompt command from server (gRPC control plane).
 // Mode-transparent submission: ACP submits via its structured SendPrompt RPC;
-// PTY writes the text to stdin then presses Enter as a *separate* write so the
-// TUI input editor sees a real keystroke (a combined "text\r" write lands
-// inside the editor's paste buffer and never submits).
+// PTY writes the body then issues a separate Enter keystroke via SendKeys
+// (the "press Enter" semantic — not SendInput which is "raw bytes"). A small
+// gap between the two writes is required so the TUI doesn't fold them into
+// a single paste.
 // For ACP mode, also echoes the user message via Relay so it appears in the
 // chat UI (consistent with the Relay command path in handleAcpRelayCommand).
 func (h *RunnerMessageHandler) OnSendPrompt(cmd *runnerv1.SendPromptCommand) error {
@@ -146,8 +155,9 @@ func (h *RunnerMessageHandler) OnSendPrompt(cmd *runnerv1.SendPromptCommand) err
 	if err := pod.IO.SendInput(cmd.Prompt); err != nil {
 		return err
 	}
-	if pod.IO.Mode() == InteractionModePTY {
-		return pod.IO.SendInput("\r")
+	if ta, ok := pod.IO.(TerminalAccess); ok {
+		time.Sleep(ptySubmitGap)
+		return ta.SendKeys([]string{"enter"})
 	}
 	return nil
 }

--- a/runner/internal/runner/message_handler_send_prompt_test.go
+++ b/runner/internal/runner/message_handler_send_prompt_test.go
@@ -3,18 +3,27 @@ package runner
 import (
 	"sync"
 	"testing"
+	"time"
 
 	runnerv1 "github.com/anthropics/agentsmesh/proto/gen/go/runner/v1"
 )
 
-// sendPromptMockIO is a minimal PodIO that records SendInput calls and lets
-// the test pick the interaction mode. It satisfies PodIO via embedded stubs.
+// sendPromptMockIO records SendInput and SendKeys calls (with timestamps so
+// tests can assert ordering and the post-text submission gap).
 type sendPromptMockIO struct {
 	stubPodIOZero
-	mu     sync.Mutex
-	mode   string
-	inputs []string
-	err    error
+	mu        sync.Mutex
+	mode      string
+	inputs    []timedCall
+	keys      []timedCall
+	inputErr  error
+	keysErr   error
+	hasTermAx bool
+}
+
+type timedCall struct {
+	payload string
+	at      time.Time
 }
 
 func (m *sendPromptMockIO) Mode() string { return m.mode }
@@ -22,12 +31,34 @@ func (m *sendPromptMockIO) Mode() string { return m.mode }
 func (m *sendPromptMockIO) SendInput(text string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.inputs = append(m.inputs, text)
-	return m.err
+	m.inputs = append(m.inputs, timedCall{payload: text, at: time.Now()})
+	return m.inputErr
 }
 
-// stubPodIOZero satisfies the rest of PodIO with no-ops so each test mock
-// only overrides the methods it cares about.
+// ptyTerminalMock satisfies TerminalAccess on top of sendPromptMockIO so the
+// PTY branch of OnSendPrompt resolves through SendKeys (the "press Enter"
+// path) instead of SendInput (the "raw bytes" path).
+type ptyTerminalMock struct {
+	*sendPromptMockIO
+}
+
+func (p *ptyTerminalMock) SendKeys(keys []string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, k := range keys {
+		p.keys = append(p.keys, timedCall{payload: k, at: time.Now()})
+	}
+	return p.keysErr
+}
+
+func (p *ptyTerminalMock) Resize(int, int) (bool, error)             { return true, nil }
+func (p *ptyTerminalMock) CursorPosition() (int, int)                { return 0, 0 }
+func (p *ptyTerminalMock) GetScreenSnapshot() string                 { return "" }
+func (p *ptyTerminalMock) Redraw() error                             { return nil }
+func (p *ptyTerminalMock) WriteOutput([]byte)                        {}
+
+// stubPodIOZero satisfies PodIO with no-ops so each test mock only overrides
+// the methods it cares about.
 type stubPodIOZero struct{}
 
 func (stubPodIOZero) GetSnapshot(int) (string, error)           { return "", nil }
@@ -42,8 +73,9 @@ func (stubPodIOZero) SetExitHandler(func(int))                  {}
 func (stubPodIOZero) SetIOErrorHandler(func(error))             {}
 func (stubPodIOZero) Detach()                                   {}
 
-func TestOnSendPrompt_PTY_AutoSubmitsEnter(t *testing.T) {
-	io := &sendPromptMockIO{mode: InteractionModePTY}
+func TestOnSendPrompt_PTY_PressesEnterViaSendKeys(t *testing.T) {
+	base := &sendPromptMockIO{mode: InteractionModePTY}
+	io := &ptyTerminalMock{sendPromptMockIO: base}
 	pod := &Pod{PodKey: "pty-pod", InteractionMode: InteractionModePTY, IO: io}
 
 	store := NewInMemoryPodStore()
@@ -54,20 +86,45 @@ func TestOnSendPrompt_PTY_AutoSubmitsEnter(t *testing.T) {
 		t.Fatalf("OnSendPrompt error: %v", err)
 	}
 
-	io.mu.Lock()
-	defer io.mu.Unlock()
-	if len(io.inputs) != 2 {
-		t.Fatalf("PTY mode must split into 2 writes (text + Enter); got %d: %v", len(io.inputs), io.inputs)
+	base.mu.Lock()
+	defer base.mu.Unlock()
+	if len(base.inputs) != 1 {
+		t.Fatalf("expected 1 SendInput for the body; got %d: %v", len(base.inputs), base.inputs)
 	}
-	if io.inputs[0] != "hello" {
-		t.Errorf("inputs[0] = %q, want %q", io.inputs[0], "hello")
+	if base.inputs[0].payload != "hello" {
+		t.Errorf("body payload = %q, want %q", base.inputs[0].payload, "hello")
 	}
-	if io.inputs[1] != "\r" {
-		t.Errorf("inputs[1] = %q, want \"\\r\"", io.inputs[1])
+	if len(base.keys) != 1 || base.keys[0].payload != "enter" {
+		t.Fatalf("expected one SendKeys([\"enter\"]); got %v", base.keys)
 	}
 }
 
-func TestOnSendPrompt_ACP_NoEnter(t *testing.T) {
+func TestOnSendPrompt_PTY_GapBetweenBodyAndEnter(t *testing.T) {
+	base := &sendPromptMockIO{mode: InteractionModePTY}
+	io := &ptyTerminalMock{sendPromptMockIO: base}
+	pod := &Pod{PodKey: "pty-pod", InteractionMode: InteractionModePTY, IO: io}
+
+	store := NewInMemoryPodStore()
+	store.Put(pod.PodKey, pod)
+	h := &RunnerMessageHandler{podStore: store}
+
+	if err := h.OnSendPrompt(&runnerv1.SendPromptCommand{PodKey: pod.PodKey, Prompt: "hello"}); err != nil {
+		t.Fatalf("OnSendPrompt error: %v", err)
+	}
+
+	base.mu.Lock()
+	defer base.mu.Unlock()
+	gap := base.keys[0].at.Sub(base.inputs[0].at)
+	// Allow a small floor under ptySubmitGap to absorb scheduler jitter, but
+	// require enough separation that the TUI's read loop can tick. Without
+	// this gap the trailing Enter is folded into the body paste.
+	const minGap = 50 * time.Millisecond
+	if gap < minGap {
+		t.Fatalf("gap between body and Enter = %v, want >= %v (TUI read-loop separation)", gap, minGap)
+	}
+}
+
+func TestOnSendPrompt_ACP_NoEnterKey(t *testing.T) {
 	io := &sendPromptMockIO{mode: InteractionModeACP}
 	pod := &Pod{PodKey: "acp-pod", InteractionMode: InteractionModeACP, IO: io}
 
@@ -82,9 +139,12 @@ func TestOnSendPrompt_ACP_NoEnter(t *testing.T) {
 	io.mu.Lock()
 	defer io.mu.Unlock()
 	if len(io.inputs) != 1 {
-		t.Fatalf("ACP mode must submit via SendPrompt only (1 write); got %d: %v", len(io.inputs), io.inputs)
+		t.Fatalf("ACP must submit via the ACP RPC only (1 SendInput); got %d: %v", len(io.inputs), io.inputs)
 	}
-	if io.inputs[0] != "hello" {
-		t.Errorf("inputs[0] = %q, want %q", io.inputs[0], "hello")
+	if io.inputs[0].payload != "hello" {
+		t.Errorf("body payload = %q, want %q", io.inputs[0].payload, "hello")
+	}
+	if len(io.keys) != 0 {
+		t.Fatalf("ACP must not press Enter via SendKeys; got %v", io.keys)
 	}
 }


### PR DESCRIPTION
## Summary

- **Runner**: `OnSendPrompt` PTY branch now uses `SendKeys(["enter"])` (the "press a key" API) instead of `SendInput("\r")`, with an 80ms gap between the body write and the Enter keystroke. The gap reproduces the implicit timing window MCP gets for free from RPC round-trips — without it, both writes land in one TUI `read(2)` and the trailing `\r` is consumed as paste-tail, not as a submit keystroke. This is the **actual** fix for the symptom #381 set out to solve.
- **Backend**: `buildPodPrompt` body is flattened to a single line — both the template (`\n\n` between user content and the reply hint) and any embedded `\n`/`\r` in user input. New `TestBuildPodPrompt_NeverContainsNewlines` pins the invariant.
- **Tests**: runner asserts `SendKeys(["enter"])` is called (not `SendInput("\r")`) and that ≥50ms separates body from Enter. Backend gets the new invariant + a `FlattensUserNewlines` case.

## Why #381 was not enough

#381 split the type+submit into two `SendInput` writes assuming the trailing `\r` would surface as a real keypress. But two writes inside the same handler are microseconds apart — kernel PTY doesn't preserve syscall boundaries, the TUI's `read(2)` loop folds them, and modern TUI frameworks (Ink, bubbletea) treat any `read` containing multiple chars + `\r` as paste. Enter never fires. MCP's `send_pod_input` text/keys path didn't hit this because two separate RPCs around the PTY write give the TUI read loop a natural tick.

## Test plan

- [x] `bazel test //runner/internal/runner:runner_test` — 3 new `TestOnSendPrompt_*` PASS (PTY test takes 0.08s, proving the sleep ran)
- [x] `bazel test //backend/internal/service/channel:channel_test` — 21/21 PASS including new invariant
- [x] End-to-end against dev: e2e-echo PTY pod + channel `@<podKey[:8]>` mention; agent transitions Idle → Executing and emits `got: Message from channel(#general...)` proving the full single-line prompt was read as one input line