### PR TITLE
ci(deploy): gate migrate-up on a --check pre-flight per region

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -217,8 +217,18 @@ jobs:
     if: always() && needs.changes.outputs.migrations == 'true' && needs.deploy-uswest.result == 'success'
     runs-on: [self-hosted, deploy]
     steps:
-      - run: |
-          ssh aliyun-us-west-001 "cd /opt/agentsmesh && ./migrate.sh uswest-prod --direction up"
+      # Pre-flight: scan for identifier blockers (dirty migration state,
+      # users.username / channels.slug / api_keys.slug / agents.slug
+      # violations). Failing fast here beats partial-state migrate up:
+      # PR #403 shipped 0141..0144 VALIDATE migrations that hit a 0141
+      # failure on both regions because the backfill hadn't run; that
+      # left schema_migrations dirty at 0141 with the CHECK still
+      # NOT VALID. --check exits non-zero with a checklist before any
+      # writes happen, so the operator runs the backfill SQL and retries.
+      - name: Pre-flight check
+        run: ssh aliyun-us-west-001 "cd /opt/agentsmesh && ./migrate.sh uswest-prod --check"
+      - name: Apply migrations
+        run: ssh aliyun-us-west-001 "cd /opt/agentsmesh && ./migrate.sh uswest-prod --direction up"
 
   # ===========================================================================
   # Deploy China production — same single-full-stack model as us-west.
@@ -249,5 +259,7 @@ jobs:
     if: always() && needs.changes.outputs.migrations == 'true' && needs.deploy-cn.result == 'success'
     runs-on: [self-hosted, deploy]
     steps:
-      - run: |
-          ssh aliyun-s001 "cd /opt/agentsmesh && ./migrate.sh cn-prod --direction up"
+      - name: Pre-flight check
+        run: ssh aliyun-s001 "cd /opt/agentsmesh && ./migrate.sh cn-prod --check"
+      - name: Apply migrations
+        run: ssh aliyun-s001 "cd /opt/agentsmesh && ./migrate.sh cn-prod --direction up"


### PR DESCRIPTION
## Summary

- Adds a `Pre-flight check` step to both `migrate-uswest` and `migrate-cn` jobs in `deploy.yml`, running `migrate.sh ... --check` before `--direction up`.
- The `--check` mode itself ships in the [deploy repo](https://gitlab.corp.signalrender.com:2222/aio/deploy/agentsmesh) commit `54b8c6b` and is already deployed to both prod hosts.
- `--check` scans `schema_migrations.dirty` + every identifier column (`users.username`, `channels.slug`, `api_keys.slug`, `agents.slug`) and exits non-zero with a per-category checklist when any blocker is present.

## Why

PR #403 (identifier contract refactor) shipped migrations `000141..0144` that promote slug CHECK constraints from NOT VALID to enforced. Both US West and CN hit `0141`'s `ALTER TABLE VALIDATE` against still-dirty user rows because the backfill program hadn't been run, and `schema_migrations` parked in dirty state.

`--check` turns the silent "VALIDATE → dirty" failure into an explicit "backfill required" prompt before any writes happen.

## Test plan

- [x] `migrate.sh --check` smoke-tested on US West (clean state → exit 0, ✅)
- [x] `migrate.sh --check` smoke-tested on CN (clean state → exit 0, ✅)
- [x] Injected one `users.username` violation on US West → `--check` exited 3 with `❌ pre-deploy check failed`; reverted the row after
- [x] Both prod hosts already running the new `migrate.sh` (host-side change is durable on its own; this PR only wires CI)
- [ ] Next merge that bumps `backend/migrations/**` will exercise the gate naturally

## Related

- AgentsMesh#403 (identifier contract refactor — the regression source)
- aio/deploy/agentsmesh@54b8c6b (host-side `--check` impl)