### PR TITLE
ci(macmini): evict Bazel JVM daemon between desktop-e2e runs (root-cause)

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -842,12 +842,30 @@ jobs:
         # cleanup once before bring-up so this run starts on a clean
         # host. Idempotent on a clean box.
         #
+        # Order matters: kill detached binaries + the Bazel JVM daemon
+        # FIRST via shell, then let `dev:clean` tear down docker/runtime.
+        # The previous version called `bazel run` first, which paradoxically
+        # spawned a fresh daemon to clean up the prior daemon's residue.
+        #
         # `--output_base` pins this job to its own bazel server so it
         # never blocks on the GitLab CI server that shares the default
         # `/Users/stone/.bazel` output base on macmini-03 (those two
         # workloads previously serialized through the same lock, burning
         # 55+ min waiting and busting the 60-min job timeout).
         run: |
+          # 1. Kill detached backend/relay/runner binaries from prior runs.
+          #    They reparent to init (ppid=1) once ibazel exits, so pkill
+          #    by command-line path is the only reliable identifier.
+          pkill -f "bazel-bin/backend/cmd/server" 2>/dev/null || true
+          pkill -f "bazel-bin/relay/cmd/relay" 2>/dev/null || true
+          pkill -f "bazel-bin/runner/cmd/runner" 2>/dev/null || true
+          # 2. Kill the Bazel JVM daemon pinned to this job's output_base.
+          #    `bazel shutdown` is the polite path, pkill is the hammer.
+          bazel --output_base="$HOME/.bazel-github" shutdown 2>/dev/null || true
+          pkill -f "$HOME/.bazel-github" 2>/dev/null || true
+          sleep 2
+          # 3. Host is clean now — let dev:clean tear down docker volumes
+          #    and runtime/ directory.
           bazel --output_base="$HOME/.bazel-github" run //deploy/dev:clean || true
 
       - name: Bring up dev backend stack
@@ -918,9 +936,23 @@ jobs:
         # //deploy/dev:clean` runs the dev.sh `clean` lifecycle which
         # calls `stop_host_services` (kills ibazel + group-kills children)
         # before tearing the docker stack down.
+        #
+        # `bazel shutdown` + the pkill belt-and-suspenders below are the
+        # change that actually evicts the Bazel JVM daemon from the host.
+        # Without these, the daemon (`build --java_runtime_version=remotejdk_21`)
+        # lives for its default 3h idle timeout, accumulates on macmini-04
+        # job-by-job, and pushes load avg to ~8 — which is what was
+        # blowing the Electron `firstWindow` 90s timeout in desktop-e2e.
         if: always()
         run: |
-          bazel run //deploy/dev:clean || true
+          bazel --output_base="$HOME/.bazel-github" run //deploy/dev:clean || true
+          bazel --output_base="$HOME/.bazel-github" shutdown 2>/dev/null || true
+          # Belt-and-suspenders: `bazel shutdown` occasionally hangs on a
+          # busy host; the pkill guarantees the daemon is gone before the
+          # next job lands on this runner.
+          pkill -f "$HOME/.bazel-github" 2>/dev/null || true
+          pkill -f "bazel-bin/backend/cmd/server" 2>/dev/null || true
+          pkill -f "bazel-bin/relay/cmd/relay" 2>/dev/null || true
 
   # =========================================================================
   # TODO: Bazel-native replacements tracked below. Each jobs above

--- a/deploy/dev/lib/host_services.sh
+++ b/deploy/dev/lib/host_services.sh
@@ -28,12 +28,28 @@ _launch_ibazel() {
     rt_dir="$(_runtime_dir)/$name"
     mkdir -p "$rt_dir"
     local pid_file="$rt_dir/$name.pid"
+    local pgid_file="$rt_dir/$name.pgid"
     local log_file="$rt_dir/$name.log"
 
+    # Process-group-kill any leftover from a prior run. With setsid below the
+    # whole tree (ibazel + the bazel-spawned binary) shares one pgid, so
+    # `kill -- -PGID` reaps every descendant; without it, ibazel's
+    # detached bazel-spawned server stays alive after the recorded PID dies
+    # and holds the worktree-allocated port.
+    if [[ -f "$pgid_file" ]]; then
+        local old_pgid
+        old_pgid=$(cat "$pgid_file" 2>/dev/null || true)
+        if [[ -n "$old_pgid" ]]; then
+            kill -TERM -- "-$old_pgid" 2>/dev/null || true
+            sleep 1
+            kill -KILL -- "-$old_pgid" 2>/dev/null || true
+        fi
+        rm -f "$pgid_file"
+    fi
     if [[ -f "$pid_file" ]]; then
         local old
-        old=$(cat "$pid_file")
-        if kill -0 "$old" 2>/dev/null; then
+        old=$(cat "$pid_file" 2>/dev/null || true)
+        if [[ -n "$old" ]] && kill -0 "$old" 2>/dev/null; then
             kill -TERM "$old" 2>/dev/null || true
             sleep 1
         fi
@@ -42,10 +58,16 @@ _launch_ibazel() {
 
     info "启动 host service: $name (target: $target)"
     local repo_root="$SCRIPT_DIR/../.."
+    # Use python3 to `setsid()` then `execvp(ibazel ...)`. Portable across
+    # macOS (no GNU `setsid` cmd by default) and Linux. `os.execvp` replaces
+    # the python interpreter with ibazel, so $! captures the pgid leader's
+    # PID (== its PGID after setsid).
     (
         cd "$repo_root"
-        nohup ibazel run "$target" "$@" > "$log_file" 2>&1 &
+        python3 -c "import os, sys; os.setsid(); os.execvp(sys.argv[1], sys.argv[1:])" \
+            ibazel run "$target" "$@" > "$log_file" 2>&1 &
         echo $! > "$pid_file"
+        echo $! > "$pgid_file"
         disown
     )
 }
@@ -203,25 +225,34 @@ start_relay_host() {
 }
 
 # Stop host backend / relay. Runner stays in docker, so `clean` handles
-# it via `docker compose down`.
+# it via `docker compose down`. Process-group-kill is the central trick:
+# `_launch_ibazel` records the pgid (== ibazel's PID under setsid), so a
+# single `kill -- -PGID` reaps ibazel + the bazel-spawned binary in one
+# shot, even though the binary detached from ibazel's direct parent
+# relationship.
 stop_host_services() {
     local rt_root
     rt_root="$(_runtime_dir)"
     [[ -d "$rt_root" ]] || return 0
     for svc in backend relay; do
+        local pgid_file="$rt_root/$svc/$svc.pgid"
         local pid_file="$rt_root/$svc/$svc.pid"
-        if [[ -f "$pid_file" ]]; then
-            local pid
-            pid=$(cat "$pid_file")
-            if kill -0 "$pid" 2>/dev/null; then
-                info "停止 host $svc (pid: $pid)..."
-                # ibazel spawns a child process; group-kill catches both.
-                kill -TERM -- "-$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null || true
-                pkill -P "$pid" 2>/dev/null || true
+        if [[ -f "$pgid_file" ]]; then
+            local pgid
+            pgid=$(cat "$pgid_file" 2>/dev/null || true)
+            if [[ -n "$pgid" ]]; then
+                info "停止 host $svc (pgid: $pgid)..."
+                kill -TERM -- "-$pgid" 2>/dev/null || true
+                sleep 1
+                kill -KILL -- "-$pgid" 2>/dev/null || true
             fi
-            rm -f "$pid_file"
+            rm -f "$pgid_file"
         fi
+        rm -f "$pid_file" 2>/dev/null || true
     done
-    pkill -f 'ibazel run //backend/cmd/server' 2>/dev/null || true
-    pkill -f 'ibazel run //relay/cmd/relay' 2>/dev/null || true
+    # Belt-and-suspenders: kill anything still hanging on the bazel-bin
+    # path (e.g. a server that survived the pgid window because it forked
+    # between recording and our TERM).
+    pkill -f "bazel-bin/backend/cmd/server" 2>/dev/null || true
+    pkill -f "bazel-bin/relay/cmd/relay" 2>/dev/null || true
 }


### PR DESCRIPTION
## Summary
Root-cause fix for the 64% Desktop E2E flaky rate on macmini-04. Stop bumping `firstWindow` timeout; start evicting the Bazel JVM daemon between runs.

> **Scope note (rev 2)**: Web e2e timeout adjustments were reverted from this PR. Investigation showed Web shard 2/2 flaky is a deeper spec-lifecycle issue (pod terminated 275 ms after PTY start, so the e2e-echo bash never gets to write `/tmp/e2e-echo-env-dump-*`) — bumping timeouts to 60s does nothing. Tracked as a follow-up; this PR keeps the daemon-eviction root-cause fix in isolation.

### What was wrong
- `.bazelrc:34` pins `--java_runtime_version=remotejdk_21`, so every Bazel call is a JVM
- Repo-wide \`grep "bazel shutdown" .github deploy/\` = **0 hits**. Default daemon idle timeout is 3 hours — it lives across CI jobs on the same self-hosted runner
- \`_launch_ibazel\` used \`nohup ibazel ... & disown\`, leaving the bazel-spawned backend/relay binaries as init's children once ibazel exited. \`pkill -P \$ibazel_pid\` could not reach them
- macmini-04 runner capacity is 1 — every PR serializes on the same machine, residue accumulates, load avg drifts to 5-8, Electron cold-launch slips past 90s

History of treating the symptom (none fixed the root cause):
- `c7b39090c` bump `electron.launch` 120→240s — commit author wrote "Host hygiene handled out of band"
- `e03c3ee6d` switch macmini-03 → 04
- `0f9f25c3b` add `dev:clean` teardown — only kills ibazel's direct children

### What this PR does
1. **`deploy/dev/lib/host_services.sh`**
   - `_launch_ibazel` uses `python3 -c "os.setsid(); os.execvp(...)"` so ibazel becomes its own process-group leader. PGID persisted alongside PID. (python3 keeps this portable: macOS doesn't ship GNU `setsid(1)`.)
   - `stop_host_services` does `kill -- -PGID`, reaping ibazel + the bazel-spawned binary in one shot.
2. **`.github/workflows/bazel.yml` (desktop-e2e only)**
   - `Pre-clean lingering host processes` step reverses its order: pkill detached binaries → `bazel shutdown` → pkill the JVM daemon → `dev:clean`. The previous version paradoxically spawned a fresh daemon to clean up the prior daemon's residue.
   - `Tear down dev stack` step adds `bazel shutdown` + pkill belt-and-suspenders so the daemon doesn't survive into the next job slot.

### Expected impact
- 64% Desktop E2E flaky → < 20%
- Does NOT touch Web e2e flaky — that needs a separate root-cause investigation (see scope note above).

### Known caveat
- Web shard 2/2 will still flaky on this PR's own CI run (root cause unchanged). Recommendation: admin-bypass merge once Desktop E2E passes, then open follow-up issue on the env-bundle / blockstore failure mode.

## Test plan
- [x] `bash -n deploy/dev/lib/host_services.sh` syntax OK
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/bazel.yml'))"` YAML valid
- [ ] CI: Desktop E2E job passes
- [ ] After merge: sample 10 main pushes, Desktop E2E fail rate < 20% (vs current 64%)