### PR TITLE
hotfix(listpods): runner detail + workspace sidebar empty post-R6

### DIFF
--- a/backend/internal/infra/agentpod_repo.go
+++ b/backend/internal/infra/agentpod_repo.go
@@ -81,6 +81,9 @@ func (r *podRepo) ListByOrg(ctx context.Context, orgID int64, q agentpod.PodList
 	} else if q.CreatedByID > 0 {
 		query = query.Where("created_by_id = ?", q.CreatedByID)
 	}
+	if q.RunnerID > 0 {
+		query = query.Where("runner_id = ?", q.RunnerID)
+	}
 
 	var total int64
 	if err := query.Count(&total).Error; err != nil {

--- a/clients/core/crates/wasm/src/state_pod.rs
+++ b/clients/core/crates/wasm/src/state_pod.rs
@@ -42,6 +42,19 @@ impl WasmPodState {
         }
     }
 
+    /// Replace the entire pod list with a fresh batch from a ListPods call.
+    /// Mirrors WasmRunnerState::set_runners. Stores/pod.ts::fetchPods +
+    /// fetchSidebarPods call this after each Connect ListPods round-trip
+    /// so the sidebar / workspace pod list reflects the latest server state.
+    /// Without this method, the JS call throws TypeError silently inside
+    /// the store's try/catch and the UI keeps showing "暂无 Pod" even
+    /// though the network round-trip succeeded.
+    pub fn set_pods(&mut self, json: &str) {
+        if let Ok(pods) = serde_json::from_str::<Vec<Pod>>(json) {
+            self.inner.set_pods(pods);
+        }
+    }
+
     pub fn update_pod_status(
         &mut self,
         pod_key: &str,

--- a/clients/web/src/app/(dashboard)/[org]/runners/[id]/components/useRunnerDetail.ts
+++ b/clients/web/src/app/(dashboard)/[org]/runners/[id]/components/useRunnerDetail.ts
@@ -70,10 +70,17 @@ export function useRunnerDetail(t: (key: string) => string, runnerIdArg?: number
   const loadPods = useCallback(async () => {
     setLoadingPods(true);
     try {
-      const res: { pods: RunnerPodData[]; total: number } = JSON.parse(
+      // `list_runner_pods` returns a serde-serialized ListPodsResponse from
+      // Rust core — proto field names (snake_case), so the wire shape is
+      // `{ items, total, limit, offset }`, NOT `{ pods, total }`. The
+      // pre-R5-7 REST endpoint used `pods`; the migration to the Connect
+      // ListPods (with runner_id filter) flipped the field name and this
+      // call site wasn't updated, so the list silently rendered empty
+      // even though `total` came back correct.
+      const res: { items: RunnerPodData[]; total: number } = JSON.parse(
         await getRunnerService().list_runner_pods(BigInt(runnerId), podFilter || null, limit ?? null, offset ?? null)
       );
-      setPods(res.pods || []);
+      setPods(res.items || []);
       setTotal(res.total);
     } catch (error) {
       console.error("Failed to load pods:", error);


### PR DESCRIPTION
## Summary

After R6 (v0.38.0) deploy, two pod-list pages showed empty even though pods existed:
- **Infra → Runner detail → Pod 列表 tab** — table empty, footer says "共 202 个 Pod" (org-wide total)
- **Workspace 侧边栏** 我创建的 / 组织 / 已完成 tabs — "暂无 Pod" even when terminal panel shows a running pod

Three independent bugs that masked each other. Hotfix branches off v0.38.0 main.

## Bugs

### Bug A — backend repo drops `runner_id` filter
`backend/internal/infra/agentpod_repo.go::ListByOrg` accepts `PodListQuery.RunnerID` but never applies it to GORM. Connect handler + service threading is correct, repo silently ignores. Result: runner-detail's request with runner_id=112 returns org-wide pods + total=202 instead of the 1 pod on that runner.

### Bug B — `useRunnerDetail.ts` reads wrong field
`list_runner_pods` wasm method returns serde-serialized `ListPodsResponse` with snake_case proto field names `{items, total, limit, offset}`. The pre-R5-7 REST path returned `{pods, total}`; the call site at `useRunnerDetail.ts:73-76` still reads `res.pods` → `undefined || []` → empty table. `res.total` field name happens to match → pagination footer shows correct total but table is empty.

### Bug C — wasm `set_pods` FFI method missing
`stores/pod.ts::fetchPods` + `fetchSidebarPods` call `getPodState().set_pods(JSON.stringify(items))` after every Connect ListPods round-trip. Rust state crate has `set_pods` (`pod_state.rs:165`), but the wasm bridge at `clients/core/crates/wasm/src/state_pod.rs` never exported it — every other batch method (`upsert_pod`, `pods_json`, `update_pod_status`) is there. JS call throws TypeError silently inside the store's try/catch → wasm cache empty → workspace sidebar shows "暂无 Pod" forever.

## Verification

```
bazel test //backend/internal/{infra,service/agentpod}/...   # PASS
bazel build //clients/core/crates/wasm:wasm_lib              # PASS
bazel build //clients/web:src + //clients/web:lint            # PASS
```

## Test plan

- [ ] CI 21/21 green
- [ ] Deploy to us-west + cn after merge
- [ ] Manual: open Infra → macmini-03-64.lan → Pod 列表 tab → see the 1 running pod
- [ ] Manual: open Workspace → 我创建的 tab → see expected pod list