### PR TITLE
hotfix(desktop-oauth): load orgs via Rust fetch_organizations after callback

### DIFF
--- a/clients/desktop/src/renderer/pages/auth/callback/OAuthCallbackPage.tsx
+++ b/clients/desktop/src/renderer/pages/auth/callback/OAuthCallbackPage.tsx
@@ -2,8 +2,8 @@ import { Suspense, useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
-import { useAuthStore } from "@/stores/auth";
-import { userApi, organizationApi } from "@/lib/api";
+import { useAuthStore, readOrganizations } from "@/stores/auth";
+import { userApi } from "@/lib/api";
 import { Logo } from "@/components/common";
 
 function OAuthCallbackContent() {
@@ -12,7 +12,7 @@ function OAuthCallbackContent() {
   const token = searchParams.get("token");
   const refreshToken = searchParams.get("refresh_token");
   const error = searchParams.get("error");
-  const { setAuth, setOrganizations } = useAuthStore();
+  const { setAuth, fetchOrganizations } = useAuthStore();
 
   const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
   const [errorMessage, setErrorMessage] = useState("");
@@ -44,12 +44,23 @@ function OAuthCallbackContent() {
         const user = userResponse.user;
         await setAuth(token, user, refreshToken || undefined);
 
-        const orgsResponse = await organizationApi.list();
-        if (orgsResponse.organizations && orgsResponse.organizations.length > 0) {
-          await setOrganizations(orgsResponse.organizations);
+        // Use the SAME path as password login (stores/auth.ts:login() does
+        // await mgr().fetch_organizations()). The Rust auth manager fetches
+        // ListMyOrgs through its own ApiClient AND writes the result into
+        // its state atomically — no TS↔Rust JSON round-trip.
+        //
+        // The previous code path (organizationApi.list() then setOrganizations)
+        // round-tripped the orgs back through `mgr().set_organizations(JSON)`,
+        // whose IPC failure was silently swallowed by an empty catch in
+        // stores/auth.ts. On desktop electron this manifested as a
+        // successful-looking login that landed on the workspace with
+        // "暂无组织" — every scoped feature broke.
+        await fetchOrganizations();
+        const orgs = readOrganizations();
+        if (orgs.length > 0) {
           setStatus("success");
           setTimeout(() => {
-            router.push(`/${orgsResponse.organizations[0].slug}/workspace`);
+            router.push(`/${orgs[0].slug}/workspace`);
           }, 1500);
         } else {
           setStatus("success");
@@ -69,7 +80,7 @@ function OAuthCallbackContent() {
     };
 
     handleCallback();
-  }, [token, refreshToken, error, setAuth, setOrganizations, router]);
+  }, [token, refreshToken, error, setAuth, fetchOrganizations, router]);
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background px-4">


### PR DESCRIPTION
## Summary

After GitHub OAuth login on **desktop electron**, the "当前组织" dropdown shows "暂无组织" even for accounts with existing orgs. Every org-scoped feature (channels, runners, pods, blocks) renders empty because no `org_slug` is in the Rust auth state. The same account works on web.

## Root cause

`OAuthCallbackPage.tsx` was calling:

```ts
const orgsResponse = await organizationApi.list();        // TS-level Connect call
await setOrganizations(orgsResponse.organizations);
```

`setOrganizations` (`stores/auth.ts:194`) wraps the IPC in a swallow-all catch:

```ts
try { await mgr().set_organizations(JSON.stringify(orgs)); } catch { /* noop */ }
```

- **Web**: `mgr()` is the wasm same-process instance — the call writes orgs directly into Rust auth state ✓
- **Desktop electron**: `mgr()` goes through `service-runtime → IPC → main-process NAPI AppState`. Any IPC failure (serialization, AppState instance mismatch, method name drift) is silently eaten. OAuth flow appears successful, user lands on `/<slug>/workspace`, but Rust auth state never received the orgs.

## Fix

Mirror the password-login flow (`stores/auth.ts:148-149`). Replace the TS round-trip with `useAuthStore.fetchOrganizations()`, which delegates to `mgr().fetch_organizations()` — Rust core fetches ListMyOrgs through its own ApiClient AND writes the result into its own state in **one atomic op**, no TS↔Rust JSON round-trip, no silently-swallowed IPC. Then read back via `readOrganizations()` to decide the workspace-vs-onboarding redirect.

## Verification

```
bazel test //clients/desktop:lint    # PASS
```

## Follow-up (out of scope)

`stores/auth.ts` `setOrganizations` / `setAuth` / `setCurrentOrg` all use empty catches. The "WASM not ready yet" comment is legitimate during hydration but masks real IPC failures in steady state. Worth a dedicated audit + structured logging pass.

## Test plan

- [ ] CI 21/21 green
- [ ] Deploy → manual: open desktop app, GitHub login, verify OrgSwitcher shows real orgs
- [ ] Manual: same flow with account that has 0 orgs → lands on /onboarding (not empty workspace)