### PR TITLE
feat(agents): integrate Cursor CLI + fix OpenCode discovery (closes #417)

### DIFF
--- a/backend/migrations/000157_add_cursor_cli_agent.down.sql
+++ b/backend/migrations/000157_add_cursor_cli_agent.down.sql
@@ -1,0 +1,21 @@
+-- 000157_add_cursor_cli_agent.down.sql
+-- Rollback path: clear FK-referencing rows before removing the agents row,
+-- wrapped in a transaction for atomicity (matches the BEGIN/COMMIT convention
+-- in 000156/000149/000130 down migrations).
+--
+-- organization_agents and organization_agent_configs carry NO ACTION foreign
+-- keys onto agents(slug) (migration 000093:23,31), so deleting cursor-cli from
+-- agents while any org enabled it would fail — they MUST be cleared first.
+-- user_agent_configs carries agent_slug with an index but no FK (000090), so
+-- it's cleared only to avoid orphan slug references, not for FK safety.
+--
+-- NOTE: user_agent_credential_profiles is intentionally NOT touched here — it
+-- was dropped in 000146 and no longer exists at this point in history.
+BEGIN;
+
+DELETE FROM organization_agent_configs WHERE agent_slug = 'cursor-cli';
+DELETE FROM organization_agents WHERE agent_slug = 'cursor-cli';
+DELETE FROM user_agent_configs WHERE agent_slug = 'cursor-cli';
+DELETE FROM agents WHERE slug = 'cursor-cli';
+
+COMMIT;

--- a/backend/migrations/000157_add_cursor_cli_agent.up.sql
+++ b/backend/migrations/000157_add_cursor_cli_agent.up.sql
@@ -1,0 +1,30 @@
+-- 000157_add_cursor_cli_agent.up.sql
+-- Register Cursor CLI (cursor-agent) as a builtin agent.
+--
+-- Cursor CLI is Anysphere's terminal coding agent. The binary on disk is
+-- `cursor-agent` (installed via curl https://cursor.com/install to
+-- ~/.local/bin/cursor-agent). The DB `slug` keeps the `-cli` suffix to match
+-- the claude-code / codex-cli / gemini-cli naming convention, but the
+-- AgentFile's AGENT/EXECUTABLE fields MUST be the actual binary name —
+-- agentfile/eval/eval_decl.go:10 wires AGENT directly into LaunchCommand,
+-- which the runner exec()s. Compare migration 000103: slug='claude-code' but
+-- AGENT=claude (the binary). Using AGENT=cursor-cli here would cause every
+-- pod to fail with ENOENT.
+--
+-- First-pass integration is PTY-only — ACP adapter is deferred (see plan:
+-- hashed-strolling-moth.md, "Out of scope"). MCP is intentionally NOT declared
+-- (no `MCP ON`): cursor-agent uses its own ~/.cursor/mcp.json format and we do
+-- not inject it, so declaring MCP would set MCPEnabled=true on BuildResult
+-- without any config landing in the sandbox — surfacing a capability we don't
+-- deliver.
+--
+-- CURSOR_API_KEY is declared as an OPTIONAL secret: cursor-agent authenticates
+-- via `cursor-agent login` OAuth (token in HOME, inherited by the pod) by
+-- default, but also honors CURSOR_API_KEY for headless/key-based auth. The ENV
+-- declaration is pure schema metadata (agentfile/eval/eval_decl.go skips
+-- `ENV X SECRET OPTIONAL` at eval time); it lets the frontend render a curated
+-- credential field, mirroring gemini-cli's GOOGLE_API_KEY.
+
+INSERT INTO agents (slug, name, launch_command, executable, is_builtin, is_active, supported_modes, agentfile_source)
+VALUES ('cursor-cli', 'Cursor CLI', 'cursor-agent', 'cursor-agent', true, true, 'pty',
+  E'# === Identity ===\nAGENT cursor-agent\nEXECUTABLE cursor-agent\n\n# === Mode ===\nMODE pty\n\n# === Environment ===\nENV CURSOR_API_KEY SECRET OPTIONAL\n\n# === Prompt ===\nPROMPT_POSITION prepend\n');

--- a/backend/migrations/embed_test.go
+++ b/backend/migrations/embed_test.go
@@ -37,3 +37,66 @@ func TestMigration000133AgentUsesLegacyColumns(t *testing.T) {
 		t.Error("down migration must drop the column")
 	}
 }
+
+// TestMigration000157CursorCLIAgent locks two failure modes in the
+// cursor-cli builtin migration:
+//   - AgentFile AGENT decl MUST be the actual binary name `cursor-agent`,
+//     NOT the DB slug `cursor-cli`. agentfile/eval/eval_decl.go writes the
+//     AGENT decl directly to LaunchCommand which the runner exec()s; using
+//     the slug there makes every pod fail with ENOENT.
+//   - Down migration MUST clear referencing rows first or it fails on the
+//     organization_agents FK (000093 declares NO ACTION).
+func TestMigration000157CursorCLIAgent(t *testing.T) {
+	up, err := FS.ReadFile("000157_add_cursor_cli_agent.up.sql")
+	if err != nil {
+		t.Fatalf("read up migration: %v", err)
+	}
+	upStr := string(up)
+
+	if !strings.Contains(upStr, "AGENT cursor-agent") {
+		t.Error("AgentFile AGENT must declare the binary name `cursor-agent` (not the slug)")
+	}
+	if strings.Contains(upStr, "AGENT cursor-cli") {
+		t.Error("AGENT must NOT be the DB slug `cursor-cli` — that value becomes LaunchCommand and is exec'd; the binary is `cursor-agent`")
+	}
+	if !strings.Contains(upStr, "EXECUTABLE cursor-agent") {
+		t.Error("EXECUTABLE must be `cursor-agent`")
+	}
+	if !strings.Contains(upStr, "'cursor-cli'") {
+		t.Error("DB slug column must be 'cursor-cli' (matches claude-code / codex-cli / gemini-cli convention)")
+	}
+	if !strings.Contains(upStr, "'cursor-agent'") {
+		t.Error("launch_command / executable columns must be 'cursor-agent'")
+	}
+	if !strings.Contains(upStr, "ENV CURSOR_API_KEY SECRET OPTIONAL") {
+		t.Error("AgentFile must declare CURSOR_API_KEY as an optional secret so the credential UI can render a curated field")
+	}
+
+	down, err := FS.ReadFile("000157_add_cursor_cli_agent.down.sql")
+	if err != nil {
+		t.Fatalf("read down migration: %v", err)
+	}
+	downStr := string(down)
+
+	// Anchor on the full `DELETE FROM <table>` statement, NOT the bare table
+	// name — the latter also appears in the explanatory comment block, so
+	// indexing on it would assert comment-text ordering rather than statement
+	// ordering (a stale lock-in that passes even when the SQL is reordered).
+	// Both NO-ACTION-FK tables (000093) must be deleted BEFORE agents.
+	orgConfigsIdx := strings.Index(downStr, "DELETE FROM organization_agent_configs")
+	orgAgentsIdx := strings.Index(downStr, "DELETE FROM organization_agents WHERE")
+	agentsIdx := strings.Index(downStr, "DELETE FROM agents WHERE slug")
+	if orgConfigsIdx < 0 || orgAgentsIdx < 0 || agentsIdx < 0 {
+		t.Fatal("down migration must DELETE from organization_agent_configs, organization_agents, AND agents")
+	}
+	if orgConfigsIdx > agentsIdx || orgAgentsIdx > agentsIdx {
+		t.Error("down migration must clear organization_agent_configs/organization_agents BEFORE agents (FK NO ACTION blocks otherwise)")
+	}
+
+	// user_agent_credential_profiles was dropped in 000146 — a DELETE against
+	// it would make any rollback fail with `relation does not exist`. Anchor
+	// on the statement, not the bare name (the NOTE comment mentions it).
+	if strings.Contains(downStr, "DELETE FROM user_agent_credential_profiles") {
+		t.Error("down migration must NOT DELETE FROM user_agent_credential_profiles — dropped in 000146")
+	}
+}

--- a/clients/web/src/components/landing/AgentLogos.tsx
+++ b/clients/web/src/components/landing/AgentLogos.tsx
@@ -52,6 +52,15 @@ const agentConfigs = [
     ),
   },
   {
+    name: "Cursor CLI",
+    descriptionKey: "landing.agentLogos.descriptions.anysphere",
+    icon: (
+      <svg viewBox="0 0 24 24" className="w-8 h-8" fill="currentColor">
+        <path d="M5 3l14 7-6 2-2 6-6-15z" stroke="currentColor" strokeWidth="2" fill="none" strokeLinejoin="round" />
+      </svg>
+    ),
+  },
+  {
     name: "Loopal",
     descriptionKey: "landing.agentLogos.descriptions.selfBuilt",
     icon: (

--- a/clients/web/src/components/settings/AgentCredentialsSettings/credentialForms/__tests__/index.test.ts
+++ b/clients/web/src/components/settings/AgentCredentialsSettings/credentialForms/__tests__/index.test.ts
@@ -49,6 +49,13 @@ describe("credentialForms registry", () => {
     }
   );
 
+  it("cursor-cli exposes CURSOR_API_KEY secret + allows custom env", () => {
+    const spec = getCredentialFormSpec("cursor-cli");
+    expect(spec.agentSlug).toBe("cursor-cli");
+    expect(spec.allowCustomEnv).toBe(true);
+    expect(getEnvKeysFromSpec(spec)).toEqual(new Set(["CURSOR_API_KEY"]));
+  });
+
   it("falls back to pure custom-env form for unknown slug", () => {
     const spec = getCredentialFormSpec("custom-user-agent-xyz");
     expect(spec).toEqual({

--- a/clients/web/src/components/settings/AgentCredentialsSettings/credentialForms/cursor-cli.ts
+++ b/clients/web/src/components/settings/AgentCredentialsSettings/credentialForms/cursor-cli.ts
@@ -1,0 +1,20 @@
+import type { CredentialFormSpec } from "./types";
+
+// AgentFile source: backend/migrations/000157_add_cursor_cli_agent.up.sql
+//   ENV CURSOR_API_KEY SECRET OPTIONAL
+// cursor-agent defaults to `cursor-agent login` OAuth (token inherited from
+// HOME); CURSOR_API_KEY is the headless/key-based alternative. Custom ENV
+// stays open for proxy/model overrides.
+export const cursorCliFormSpec: CredentialFormSpec = {
+  agentSlug: "cursor-cli",
+  fields: [
+    {
+      kind: "secret",
+      envKey: "CURSOR_API_KEY",
+      label: "settings.credentialForm.cursor.apiKey",
+      description: "settings.credentialForm.cursor.apiKeyHint",
+    },
+  ],
+  allowCustomEnv: true,
+  customEnvHint: "settings.credentialForm.cursor.customEnvHint",
+};

--- a/clients/web/src/components/settings/AgentCredentialsSettings/credentialForms/index.ts
+++ b/clients/web/src/components/settings/AgentCredentialsSettings/credentialForms/index.ts
@@ -5,6 +5,7 @@ import { loopalFormSpec } from "./loopal";
 import { geminiCliFormSpec } from "./gemini-cli";
 import { aiderFormSpec } from "./aider";
 import { opencodeFormSpec } from "./opencode";
+import { cursorCliFormSpec } from "./cursor-cli";
 
 const REGISTRY: Record<string, CredentialFormSpec> = {
   [claudeCodeFormSpec.agentSlug]: claudeCodeFormSpec,
@@ -13,6 +14,7 @@ const REGISTRY: Record<string, CredentialFormSpec> = {
   [geminiCliFormSpec.agentSlug]: geminiCliFormSpec,
   [aiderFormSpec.agentSlug]: aiderFormSpec,
   [opencodeFormSpec.agentSlug]: opencodeFormSpec,
+  [cursorCliFormSpec.agentSlug]: cursorCliFormSpec,
 };
 
 // e2e-echo is a test-only agent (see deploy/dev/seed/e2e_echo.sql). The

--- a/clients/web/src/messages/de/landing.json
+++ b/clients/web/src/messages/de/landing.json
@@ -34,7 +34,8 @@
         "google": "Google",
         "openSource": "Open Source",
         "community": "Community",
-        "yourOwn": "Eigene"
+        "yourOwn": "Eigene",
+        "anysphere": "Anysphere"
       }
     },
     "paradigmShift": {

--- a/clients/web/src/messages/en/landing.json
+++ b/clients/web/src/messages/en/landing.json
@@ -38,7 +38,8 @@
         "openSource": "Open Source",
         "community": "Community",
         "selfBuilt": "Self-Built",
-        "yourOwn": "Your Own"
+        "yourOwn": "Your Own",
+        "anysphere": "Anysphere"
       }
     },
     "paradigmShift": {

--- a/clients/web/src/messages/en/settings.json
+++ b/clients/web/src/messages/en/settings.json
@@ -442,6 +442,11 @@
       },
       "opencode": {
         "customEnvHint": "Any environment variables required by opencode"
+      },
+      "cursor": {
+        "apiKey": "Cursor API Key",
+        "apiKeyHint": "Optional. Leave blank to use `cursor-agent login` (OAuth); set for headless / key-based auth.",
+        "customEnvHint": "Add any extra environment variables cursor-agent needs"
       }
     },
     "sshKeys": {

--- a/clients/web/src/messages/es/landing.json
+++ b/clients/web/src/messages/es/landing.json
@@ -34,7 +34,8 @@
         "google": "Google",
         "openSource": "Open Source",
         "community": "Comunidad",
-        "yourOwn": "Personalizado"
+        "yourOwn": "Personalizado",
+        "anysphere": "Anysphere"
       }
     },
     "paradigmShift": {

--- a/clients/web/src/messages/fr/landing.json
+++ b/clients/web/src/messages/fr/landing.json
@@ -34,7 +34,8 @@
         "google": "Google",
         "openSource": "Open Source",
         "community": "Communauté",
-        "yourOwn": "Le Vôtre"
+        "yourOwn": "Le Vôtre",
+        "anysphere": "Anysphere"
       }
     },
     "paradigmShift": {

--- a/clients/web/src/messages/ja/landing.json
+++ b/clients/web/src/messages/ja/landing.json
@@ -34,7 +34,8 @@
         "google": "Google",
         "openSource": "オープンソース",
         "community": "コミュニティ",
-        "yourOwn": "カスタム"
+        "yourOwn": "カスタム",
+        "anysphere": "Anysphere"
       }
     },
     "paradigmShift": {

--- a/clients/web/src/messages/ko/landing.json
+++ b/clients/web/src/messages/ko/landing.json
@@ -34,7 +34,8 @@
         "google": "Google",
         "openSource": "오픈소스",
         "community": "커뮤니티",
-        "yourOwn": "커스텀"
+        "yourOwn": "커스텀",
+        "anysphere": "Anysphere"
       }
     },
     "paradigmShift": {

--- a/clients/web/src/messages/pt/landing.json
+++ b/clients/web/src/messages/pt/landing.json
@@ -34,7 +34,8 @@
         "google": "Google",
         "openSource": "Open Source",
         "community": "Comunidade",
-        "yourOwn": "O Seu Proprio"
+        "yourOwn": "O Seu Proprio",
+        "anysphere": "Anysphere"
       }
     },
     "paradigmShift": {

--- a/clients/web/src/messages/zh/landing.json
+++ b/clients/web/src/messages/zh/landing.json
@@ -38,7 +38,8 @@
         "openSource": "开源",
         "community": "社区",
         "selfBuilt": "自研",
-        "yourOwn": "自定义"
+        "yourOwn": "自定义",
+        "anysphere": "Anysphere"
       }
     },
     "paradigmShift": {

--- a/clients/web/src/messages/zh/settings.json
+++ b/clients/web/src/messages/zh/settings.json
@@ -442,6 +442,11 @@
       },
       "opencode": {
         "customEnvHint": "添加 opencode 运行所需的任意环境变量"
+      },
+      "cursor": {
+        "apiKey": "Cursor API Key",
+        "apiKeyHint": "可选。留空则使用 `cursor-agent login`（OAuth）；填写用于无头 / 密钥认证。",
+        "customEnvHint": "添加 cursor-agent 运行所需的任意环境变量"
       }
     },
     "sshKeys": {

--- a/runner/internal/agents/cursor/BUILD.bazel
+++ b/runner/internal/agents/cursor/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "cursor",
+    srcs = ["register.go"],
+    importpath = "github.com/anthropics/agentsmesh/runner/internal/agents/cursor",
+    visibility = ["//runner:__subpackages__"],
+    deps = [
+        "//runner/internal/agentkit",
+        "//runner/internal/tokenusage",
+    ],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":cursor",
+    visibility = ["//runner:__subpackages__"],
+)
+
+go_test(
+    name = "cursor_test",
+    srcs = ["register_test.go"],
+    embed = [":cursor"],
+    deps = [
+        "//runner/internal/agentkit",
+        "//runner/internal/tokenusage",
+        "@com_github_stretchr_testify//assert",
+    ],
+)

--- a/runner/internal/agents/cursor/register.go
+++ b/runner/internal/agents/cursor/register.go
@@ -1,0 +1,28 @@
+package cursor
+
+import (
+	"github.com/anthropics/agentsmesh/runner/internal/agentkit"
+	"github.com/anthropics/agentsmesh/runner/internal/tokenusage"
+)
+
+func init() {
+	// Cursor CLI 的 session 文件在 ~/.local/share/cursor-agent/versions/ 下，
+	// 格式未公开 — 首版 opt out，避免 cross-agent contract test 要求 fixture。
+	// 同时覆盖 slug ("cursor-cli") 和运行时 token-collection 用的 launch_command
+	// ("cursor-agent")：tokenusage.Collect 以 pod.Agent=LaunchCommand 为 key，
+	// 两个都登记才能在未来有人误加 parser 时仍命中 opt-out（参考 claude 同时
+	// 注册 "claude"/"claude-code" 双 alias）。
+	tokenusage.RegisterParserOptOut([]string{"cursor-cli", "cursor-agent"})
+	// 严禁注册 "cursor" — Cursor IDE 启动器同名会冲突。
+	//
+	// 已知系统级隐患：Cursor CLI 通过 bundled Node 运行
+	// (~/.local/share/cursor-agent/versions/<ver>/node)。agentkit 默认
+	// processNameSet 已包含 "node"，monitor_check 用全局 set 而不是
+	// (slug → process-name) 映射，所以 PTY 子树里出现的 node 进程会被
+	// 笼统识别为 "agent process"，但无法区分属于 cursor / claude /
+	// opencode 的哪一个。当前 cursor-agent 进程会先于 bundled node 在
+	// process tree 中出现，所以正常路径 OK；若未来 Cursor 改成 wrapper
+	// 直接 exec node 而非 cursor-agent，监控会退化为 ambiguous。
+	// 修复方向：把 agentkit.processNameSet 改成 (process-name → slug) 映射。
+	agentkit.RegisterProcessNames("cursor-agent")
+}

--- a/runner/internal/agents/cursor/register_test.go
+++ b/runner/internal/agents/cursor/register_test.go
@@ -1,0 +1,21 @@
+package cursor
+
+import (
+	"testing"
+
+	"github.com/anthropics/agentsmesh/runner/internal/agentkit"
+	"github.com/anthropics/agentsmesh/runner/internal/tokenusage"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCursorRegistered(t *testing.T) {
+	// Opt-out covers BOTH the DB slug and the runtime launch_command key.
+	assert.True(t, tokenusage.IsParserOptOut("cursor-cli"), "slug cursor-cli should be opt-out from token-usage fixture contract")
+	assert.True(t, tokenusage.IsParserOptOut("cursor-agent"), "launch_command cursor-agent (the runtime token-collection key) should be opt-out")
+	assert.Nil(t, tokenusage.GetParser("cursor-cli"), "opt-out agents must not register a parser (slug key)")
+	assert.Nil(t, tokenusage.GetParser("cursor-agent"), "opt-out agents must not register a parser (runtime launch_command key)")
+
+	assert.True(t, agentkit.IsAgentProcess("cursor-agent"), "process name cursor-agent must be registered")
+	assert.False(t, agentkit.IsAgentProcess("cursor"), "bare 'cursor' must NOT be registered (collides with Cursor IDE)")
+	assert.False(t, agentkit.IsAgentProcess("cursor-cli"), "the DB slug must NOT be registered as a process name (the binary is cursor-agent)")
+}

--- a/runner/internal/envpath/paths_test.go
+++ b/runner/internal/envpath/paths_test.go
@@ -2,7 +2,9 @@ package envpath
 
 import (
 	"os"
+	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -90,5 +92,107 @@ func TestPrependToPath_WindowsSemicolonSeparator(t *testing.T) {
 	result2 := PrependToPath(current, `C:\Windows\System32`)
 	if result2 != current {
 		t.Errorf("expected no change for existing dir, got: %s", result2)
+	}
+}
+
+// TestUserBinaryDirs_IncludesAgentSubdirs ensures agent installers that drop
+// binaries under per-tool home subdirs (OpenCode → ~/.opencode/bin, some
+// Cursor wrappers → ~/.cursor/bin) are reachable via the fallback search.
+func TestUserBinaryDirs_IncludesAgentSubdirs(t *testing.T) {
+	// Force a known HOME so the test exercises the happy path even in Bazel
+	// sandboxes that may clear or unset $HOME (which would cause UserHomeDir
+	// to return an error, taking us to the home-empty branch covered by the
+	// dedicated test below).
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // Windows
+
+	dirs := UserBinaryDirs()
+
+	for _, want := range []string{
+		filepath.Join(home, ".local", "bin"),
+		filepath.Join(home, "bin"),
+		filepath.Join(home, ".opencode", "bin"),
+		filepath.Join(home, ".cursor", "bin"),
+	} {
+		if !slices.Contains(dirs, want) {
+			t.Errorf("UserBinaryDirs() missing %q\nfull list: %v", want, dirs)
+		}
+	}
+}
+
+// TestUserBinaryDirs_AllAbsolute documents the invariant that every returned
+// path is absolute — never a CWD-relative confused-deputy hazard. The home-
+// empty branch (UserHomeDir error / unset $HOME on Unix) must omit home-rooted
+// entries entirely rather than emit relative ones like `.opencode/bin`.
+func TestUserBinaryDirs_AllAbsolute(t *testing.T) {
+	// Setting HOME="" simulates a UserHomeDir failure on Unix (Go falls back
+	// to $HOME first). On Windows the equivalent is USERPROFILE="".
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+
+	dirs := UserBinaryDirs()
+	for _, d := range dirs {
+		if !filepath.IsAbs(d) {
+			t.Errorf("UserBinaryDirs() returned non-absolute path %q with empty home; full list: %v", d, dirs)
+		}
+	}
+}
+
+func TestUserBinaryDirs_PlatformSpecificDirs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	dirs := UserBinaryDirs()
+
+	switch runtime.GOOS {
+	case "darwin":
+		for _, want := range []string{"/opt/homebrew/bin", "/usr/local/bin"} {
+			if !slices.Contains(dirs, want) {
+				t.Errorf("darwin UserBinaryDirs() missing %q\nfull list: %v", want, dirs)
+			}
+		}
+	case "linux":
+		for _, want := range []string{"/usr/local/bin", "/snap/bin"} {
+			if !slices.Contains(dirs, want) {
+				t.Errorf("linux UserBinaryDirs() missing %q\nfull list: %v", want, dirs)
+			}
+		}
+	case "windows":
+		// Windows-specific dirs depend on env (LOCALAPPDATA/ProgramFiles);
+		// the home-relative subdirs are covered by IncludesAgentSubdirs.
+	default:
+		// Other Unix (freebsd/openbsd/netbsd) fall through paths_unix.go's
+		// `else` branch and currently get /snap/bin (Linux-specific). Skip
+		// rather than assert, but make the gap visible.
+		t.Skipf("UserBinaryDirs platform assertions not defined for GOOS=%s (returns: %v)", runtime.GOOS, dirs)
+	}
+}
+
+// TestUserBinaryDirs_SystemDirsBeforeAgentSubdirs locks the precedence
+// invariant: canonical system prefixes (/opt/homebrew/bin, /usr/local/bin)
+// must be searched BEFORE per-tool home subdirs (~/.opencode/bin, etc),
+// otherwise a stale ~/bin/claude shadows the brew-installed version.
+func TestUserBinaryDirs_SystemDirsBeforeAgentSubdirs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("precedence test targets Unix system prefixes")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dirs := UserBinaryDirs()
+
+	systemDir := "/usr/local/bin"
+	agentSubdir := filepath.Join(home, ".opencode", "bin")
+	sysIdx := slices.Index(dirs, systemDir)
+	agentIdx := slices.Index(dirs, agentSubdir)
+
+	if sysIdx < 0 || agentIdx < 0 {
+		t.Fatalf("expected both %q and %q in list; got %v", systemDir, agentSubdir, dirs)
+	}
+	if sysIdx >= agentIdx {
+		t.Errorf("system dir %q (idx=%d) must precede agent subdir %q (idx=%d); full list: %v",
+			systemDir, sysIdx, agentSubdir, agentIdx, dirs)
 	}
 }

--- a/runner/internal/envpath/paths_unix.go
+++ b/runner/internal/envpath/paths_unix.go
@@ -11,12 +11,30 @@ import (
 
 // UserBinaryDirs returns common directories where user-installed binaries live.
 //
-//   - darwin: ~/.local/bin, /opt/homebrew/bin, /opt/homebrew/sbin, /usr/local/bin
-//   - linux:  ~/.local/bin, /usr/local/bin, /snap/bin
+// Order matters — entries are searched and prepended to PATH in order:
+// system prefixes come first so canonical (e.g. Homebrew) installs win over
+// stale dotfile copies; per-tool home subdirs come last as a safety net for
+// installers that bypass standard prefixes.
+//
+//   - darwin: ~/.local/bin, /opt/homebrew/bin, /opt/homebrew/sbin,
+//     /usr/local/bin, ~/bin, ~/.opencode/bin, ~/.cursor/bin
+//   - linux:  ~/.local/bin, /usr/local/bin, /snap/bin,
+//     ~/bin, ~/.opencode/bin, ~/.cursor/bin
+//
+// If os.UserHomeDir() fails (e.g. systemd unit with no HOME and no passwd
+// entry), home-rooted entries are omitted entirely — never returned as
+// relative paths. LookPathFallback consumers therefore only ever see absolute
+// paths, eliminating CWD-relative confused-deputy risk.
 func UserBinaryDirs() []string {
-	home, _ := os.UserHomeDir()
-	dirs := []string{
-		filepath.Join(home, ".local", "bin"),
+	dirs := []string{}
+
+	home, err := os.UserHomeDir()
+	homeOK := err == nil && home != ""
+
+	if homeOK {
+		// ~/.local/bin is the XDG-standard user prefix — keep it FIRST so it
+		// continues to behave as the canonical user install location.
+		dirs = append(dirs, filepath.Join(home, ".local", "bin"))
 	}
 
 	if runtime.GOOS == "darwin" {
@@ -30,6 +48,18 @@ func UserBinaryDirs() []string {
 		dirs = append(dirs,
 			"/usr/local/bin",
 			"/snap/bin",
+		)
+	}
+
+	// Per-tool home subdirs as a safety net for installers that bypass
+	// standard prefixes (OpenCode's install.sh → ~/.opencode/bin when
+	// $OPENCODE_INSTALL_DIR and $XDG_BIN_DIR are unset; some Cursor wrappers
+	// → ~/.cursor/bin). Placed AFTER system dirs so brew/apt stays canonical.
+	if homeOK {
+		dirs = append(dirs,
+			filepath.Join(home, "bin"),
+			filepath.Join(home, ".opencode", "bin"),
+			filepath.Join(home, ".cursor", "bin"),
 		)
 	}
 

--- a/runner/internal/envpath/paths_windows.go
+++ b/runner/internal/envpath/paths_windows.go
@@ -9,15 +9,30 @@ import (
 	"strings"
 )
 
-// UserBinaryDirs returns common directories where user-installed binaries live on Windows.
+// UserBinaryDirs returns common directories where user-installed binaries
+// live on Windows. Order: system prefixes first (canonical installs win),
+// per-tool home subdirs last (safety net for installers that bypass
+// standard prefixes).
 //
 //   - %USERPROFILE%\.local\bin
 //   - %LOCALAPPDATA%\Programs
 //   - %ProgramFiles%
+//   - %USERPROFILE%\bin
+//   - %USERPROFILE%\.opencode\bin
+//   - %USERPROFILE%\.cursor\bin
+//
+// If os.UserHomeDir() fails (e.g. LOCAL SERVICE / SYSTEM account with no
+// resolvable USERPROFILE), home-rooted entries are omitted — never returned
+// as drive-root-relative paths (which would let any C:\ writer hijack a
+// lookup).
 func UserBinaryDirs() []string {
-	home, _ := os.UserHomeDir()
-	dirs := []string{
-		filepath.Join(home, ".local", "bin"),
+	dirs := []string{}
+
+	home, err := os.UserHomeDir()
+	homeOK := err == nil && home != ""
+
+	if homeOK {
+		dirs = append(dirs, filepath.Join(home, ".local", "bin"))
 	}
 
 	if localAppData := os.Getenv("LOCALAPPDATA"); localAppData != "" {
@@ -26,6 +41,14 @@ func UserBinaryDirs() []string {
 
 	if programFiles := os.Getenv("ProgramFiles"); programFiles != "" {
 		dirs = append(dirs, programFiles)
+	}
+
+	if homeOK {
+		dirs = append(dirs,
+			filepath.Join(home, "bin"),
+			filepath.Join(home, ".opencode", "bin"),
+			filepath.Join(home, ".cursor", "bin"),
+		)
 	}
 
 	return dirs

--- a/runner/internal/runner/BUILD.bazel
+++ b/runner/internal/runner/BUILD.bazel
@@ -71,6 +71,7 @@ go_library(
         "//runner/internal/agents/aider",
         "//runner/internal/agents/claude",
         "//runner/internal/agents/codex",
+        "//runner/internal/agents/cursor",
         "//runner/internal/agents/gemini",
         "//runner/internal/agents/loopal",
         "//runner/internal/agents/opencode",

--- a/runner/internal/runner/agents_import.go
+++ b/runner/internal/runner/agents_import.go
@@ -4,6 +4,7 @@ import (
 	_ "github.com/anthropics/agentsmesh/runner/internal/agents/aider"
 	_ "github.com/anthropics/agentsmesh/runner/internal/agents/claude"
 	_ "github.com/anthropics/agentsmesh/runner/internal/agents/codex"
+	_ "github.com/anthropics/agentsmesh/runner/internal/agents/cursor"
 	_ "github.com/anthropics/agentsmesh/runner/internal/agents/gemini"
 	_ "github.com/anthropics/agentsmesh/runner/internal/agents/loopal"
 	_ "github.com/anthropics/agentsmesh/runner/internal/agents/opencode"

--- a/runner/internal/tokenusage/BUILD.bazel
+++ b/runner/internal/tokenusage/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
         "//runner/internal/agents/claude/testsupport",
         "//runner/internal/agents/codex",
         "//runner/internal/agents/codex/testsupport",
+        "//runner/internal/agents/cursor",
         "//runner/internal/agents/loopal",
         "//runner/internal/agents/opencode",
         "//runner/internal/agents/opencode/testsupport",

--- a/runner/internal/tokenusage/parser_contract_test.go
+++ b/runner/internal/tokenusage/parser_contract_test.go
@@ -15,6 +15,7 @@ import (
 	aiderfixture "github.com/anthropics/agentsmesh/runner/internal/agents/aider/testsupport"
 	claudefixture "github.com/anthropics/agentsmesh/runner/internal/agents/claude/testsupport"
 	codexfixture "github.com/anthropics/agentsmesh/runner/internal/agents/codex/testsupport"
+	_ "github.com/anthropics/agentsmesh/runner/internal/agents/cursor"
 	_ "github.com/anthropics/agentsmesh/runner/internal/agents/loopal"
 	opencodefixture "github.com/anthropics/agentsmesh/runner/internal/agents/opencode/testsupport"
 	"github.com/anthropics/agentsmesh/runner/internal/tokenusage"

--- a/runner/internal/workspace/script_step_test.go
+++ b/runner/internal/workspace/script_step_test.go
@@ -131,9 +131,20 @@ func TestAddToolPathsWithPATH(t *testing.T) {
 }
 
 func TestAddToolPathsWithoutPATH(t *testing.T) {
+	// addToolPaths → envpath.UserBinaryDirs() resolves per-tool subdirs from
+	// the PROCESS home via os.UserHomeDir() (USERPROFILE on Windows, HOME on
+	// Unix) — NOT from the env slice below. Pin both so home resolves to an
+	// absolute dir on every platform: the bazel Windows test sandbox does not
+	// inherit USERPROFILE, and after the empty-home hardening UserBinaryDirs()
+	// deliberately omits home-rooted dirs (e.g. ~/.local/bin) when home is
+	// unresolvable — which is what the Windows assertion below relies on.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
 	step := NewScriptPreparationStep("echo test", time.Minute)
 
-	env := []string{"HOME=/home/test", "USER=test"}
+	env := []string{"USER=test"}
 	result := step.addToolPaths(env)
 
 	pathFound := false


### PR DESCRIPTION
## 背景

Issue #417：用户在 Incus 容器装了 Runner v0.38.1 + OpenCode 1.15.7 + Cursor CLI，创建 pod 时报「该 Runner 暂不支持任何智能体」。两个独立根因：

1. **OpenCode 装在 fallback 路径外** —— 官方 `install.sh` 默认装到 `~/.opencode/bin`，而 Runner 在 systemd/launchd 的最小 PATH 下，`UserBinaryDirs()` fallback 列表没覆盖它，探测不到 → `available_agents` 为空。
2. **Cursor CLI 完全没支持** —— runner plugin 没注册、backend 没 builtin row、前端无任何触点。

## 改动

### runner
- 新增 cursor agent plugin（binary `cursor-agent`，pty 模式，token-usage opt-out 同时覆盖 slug + launch_command 两个 key；进程名注册 `cursor-agent`，**绝不注册裸 `cursor`** 以避免与 Cursor IDE 启动器冲突）
- 扩展 `UserBinaryDirs()` fallback：加 `~/.opencode/bin`、`~/.cursor/bin`、`~/bin`；`UserHomeDir` 失败时**完全省略** home-rooted 条目（杜绝相对路径）；系统前缀排在 per-tool 子目录**之前**，保证 brew/apt 仍是 canonical

### backend
- migration 000157：cursor-cli builtin（`AGENT`/`EXECUTABLE` = `cursor-agent`，slug = `cursor-cli`；`ENV CURSOR_API_KEY SECRET OPTIONAL`；MCP/ACP 首版 deferred）
- down migration 事务化，按 FK 依赖顺序清理引用行（org_agents/org_agent_configs 有 NO ACTION FK）
- `embed_test` 锁定三个失败模式：AGENT 必须是 binary 名、ENV 声明存在、FK-safe 删除顺序

### web
- cursor-cli 凭证表单（`CURSOR_API_KEY`）+ AgentLogos 条目
- i18n：`credentialForm.cursor`（en/zh，与现有 opencode 等 en/zh-only 约定一致）、`agentLogos.anysphere`（8 语言）

## 认证说明

cursor-agent 默认走 `cursor-agent login` OAuth（token 在 HOME，pod 透传继承，与 claude 同构）；`CURSOR_API_KEY` 为可选的 headless/key 认证路径。**无 pod 认证阻断缺陷。**

## 范围外（有意 deferred）

- Cursor 的 ACP/stream-json transport（需自研，≈claude 全套工作量）
- MCP（cursor 用专属 `~/.cursor/mcp.json` 格式，未注入）

## 测试

- runner：`go test ./internal/envpath/ ./internal/agents/cursor/ ./internal/tokenusage/` 全 PASS（含新增 4 个 envpath 不变量测试 + cursor 注册测试 + token contract）
- backend：`go test ./migrations/` PASS（含 000157 锁定断言）
- web：credentialForms 单测加 cursor-cli 断言；JSON 合法性 + i18n key 覆盖静态验证通过（本地 worktree 无 node_modules，实跑留 CI）

🤖 Generated with [Claude Code](https://claude.com/claude-code)