### PR TITLE
fix(desktop-ticket): real ElectronTicketState proto mirror + e2e render coverage

### DIFF
--- a/clients/desktop/e2e/pages/loops.page.ts
+++ b/clients/desktop/e2e/pages/loops.page.ts
@@ -9,6 +9,7 @@ import { gotoHash, expectHashMatches } from "../helpers/nav";
 export class LoopsPage {
   readonly newLoopButton: Locator;
   readonly loopList: Locator;
+  readonly loopRows: Locator;
   readonly runHistoryTable: Locator;
   readonly promptEditor: Locator;
   readonly scheduleInput: Locator;
@@ -16,6 +17,7 @@ export class LoopsPage {
   constructor(private page: Page) {
     this.newLoopButton = page.getByRole("button", { name: /new loop|new/i }).first();
     this.loopList = page.locator('[data-section="loop-list"]');
+    this.loopRows = page.locator('[data-testid="loop-row"]');
     this.runHistoryTable = page.locator('[data-section="run-history"], table').first();
     this.promptEditor = page.locator('textarea[name="prompt"], [data-editor="prompt"]').first();
     this.scheduleInput = page.locator('input[name="schedule"]');

--- a/clients/desktop/e2e/pages/mesh.page.ts
+++ b/clients/desktop/e2e/pages/mesh.page.ts
@@ -15,7 +15,7 @@ export class MeshPage {
   constructor(private page: Page) {
     this.topologyCanvas = page.locator('.react-flow, [data-section="mesh-topology"]').first();
     this.runnerNodes = page.locator('[data-node-type="runner"]');
-    this.podNodes = page.locator('[data-node-type="pod"]');
+    this.podNodes = page.locator('[data-testid="mesh-pod-node"]');
     this.filterControls = page.locator('[data-section="mesh-filters"]');
   }
 

--- a/clients/desktop/e2e/tests/loops/loops-list-render.spec.ts
+++ b/clients/desktop/e2e/tests/loops/loops-list-render.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "../../fixtures";
+import { LoopsPage } from "../../pages/loops.page";
+
+// Render-layer coverage for the Loops desktop state adapter. The loops IDE
+// sidebar (components/ide/sidebar/LoopsSidebarContent.tsx) lists one row per
+// loop from useLoops() — dev seed has 'nightly-dependency-audit', so the
+// sidebar must render at least one loop row. A drifted/stub ElectronLoopState
+// that dropped the fetched loops would show the empty placeholder instead.
+// Guards the same bug class as repositories-list / tickets-board render specs.
+test.describe("Desktop loops · list render", () => {
+  test("loops sidebar renders the seeded loop (not empty)", async ({ page }) => {
+    const loops = new LoopsPage(page);
+    await loops.goto();
+    await loops.expectOnPage();
+
+    await expect(
+      loops.loopRows.first(),
+      "no loop rows while backend has a seeded loop — loops state adapter dropped the fetch?",
+    ).toBeVisible({ timeout: 10_000 });
+    expect(await loops.loopRows.count()).toBeGreaterThan(0);
+  });
+});

--- a/clients/desktop/e2e/tests/tickets/tickets-board-render.spec.ts
+++ b/clients/desktop/e2e/tests/tickets/tickets-board-render.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "../../fixtures";
+import { TicketsBoardPage } from "../../pages/tickets-board.page";
+import { TicketDetailPage } from "../../pages/tickets-detail.page";
+
+// Regression coverage for the ElectronTicketState stub bug. Before the
+// proto-bytes mirror fix (packages/electron-adapter/src/ticket_state.ts),
+// state_adapters.ts shipped an ElectronTicketState whose board_columns_json()
+// / current_ticket_json() returned empty and every mutator was a no-op:
+// Connect-RPC fetched real data, the store called replace_board_columns(bytes)
+// / set_current_ticket(bytes), the stub dropped the bytes, the kanban rendered
+// empty and ticket detail showed "not found". ipc/_generated/ticket.api.spec
+// only proves the IPC route is wired — it never checked the state cache layer.
+// This spec closes that gap (mirrors repositories-list.spec.ts).
+test.describe("Desktop tickets · board + detail render", () => {
+  test("kanban renders seeded tickets (not the empty stub)", async ({ page }) => {
+    const board = new TicketsBoardPage(page);
+    await board.goto();
+    await board.expectOnPage();
+
+    // Stub fingerprint: zero cards while dev seed has DEV-1/DEV-2 (both backlog).
+    await expect(
+      board.ticketCards.first(),
+      "no ticket cards while backend has seeded tickets — ElectronTicketState stub regressed?",
+    ).toBeVisible({ timeout: 10_000 });
+    expect(await board.ticketCards.count()).toBeGreaterThan(0);
+
+    await expect(page.locator('[data-ticket-slug="DEV-1"]').first()).toBeVisible();
+  });
+
+  test("ticket detail loads the ticket (not 'not found')", async ({ page }) => {
+    const detail = new TicketDetailPage(page);
+    await detail.goto("DEV-1");
+    await detail.expectOnPage("DEV-1");
+
+    // set_current_ticket no-op → current_ticket_json() null → "not found".
+    // Positive-assert the seeded title renders instead of the empty-state text.
+    await expect(
+      page.getByText("Implement JWT-based user authentication", { exact: false }).first(),
+      "ticket detail empty while backend has DEV-1 — set_current_ticket dropped the bytes?",
+    ).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/clients/web/src/components/ide/sidebar/LoopsSidebarContent.tsx
+++ b/clients/web/src/components/ide/sidebar/LoopsSidebarContent.tsx
@@ -168,6 +168,8 @@ function LoopListItem({
 
   return (
     <button
+      data-testid="loop-row"
+      data-loop-slug={loop.slug}
       className={cn(
         "w-full text-left px-2.5 py-2 rounded-md",
         "transition-colors duration-150 cursor-pointer",

--- a/deploy/dev/seed/seed.sql
+++ b/deploy/dev/seed/seed.sql
@@ -466,4 +466,17 @@ BEGIN
 
     END; -- inner DECLARE block
 
+    -- =========================================================================
+    -- 10. 创建示例 Loop（Loops 列表 + desktop e2e 渲染断言）
+    -- =========================================================================
+    INSERT INTO loops (organization_id, name, slug, prompt_template, created_by_id)
+    SELECT v_org_id, 'Nightly Dependency Audit', 'nightly-dependency-audit',
+           'Audit project dependencies for known vulnerabilities and open a ticket per finding.',
+           v_user_id
+    WHERE NOT EXISTS (
+        SELECT 1 FROM loops WHERE organization_id = v_org_id AND slug = 'nightly-dependency-audit'
+    );
+
+    RAISE NOTICE '  - Loop: nightly-dependency-audit';
+
 END $$;

--- a/packages/electron-adapter/src/state_adapters.ts
+++ b/packages/electron-adapter/src/state_adapters.ts
@@ -1,42 +1,12 @@
-// State adapters that can't (yet) share an instance with a Service because
-// they have no super-set Service counterpart. Pod / Runner / Mesh /
-// Channel / Loop / Autopilot live on the corresponding `ElectronXxxService`
-// classes — the provider aliases `xxxState` to the same instance so sync
-// getters on the state facet see real cache instead of stub "[]".
-// Repository was migrated to this pattern — its state lives on
-// `ElectronRepositoryService` now. Ticket has its own dedicated state class
-// below because the wasm-side Ticket state is no longer co-located with
-// the ticket service (proto-state mutation API + dedicated WasmTicketState).
-import type { ITicketState } from "@agentsmesh/service-interface";
-
+// Re-export hub for Electron state facets that don't share an instance with a
+// Service. Pod / Runner / Mesh / Channel / Loop / Autopilot / Repository live
+// on their `ElectronXxxService` (the provider aliases `xxxState` to the same
+// instance). Ticket has a dedicated state class (./ticket_state) because the
+// wasm-side WasmTicketState is no longer co-located with the ticket service.
+// The ACP session manager below is still a stub — desktop ACP rendering is
+// not wired to a real cache yet.
 export { ElectronRelayManager } from "./electron-relay-manager";
-
-
-// Desktop ticket state stub. Real ticket data flows through Connect-RPC on
-// every request — the in-memory cache only exists to keep the renderer's
-// store layer from crashing on getTicketState() reads. Future PR will mirror
-// the wasm impl (decode proto bytes, maintain a real cache) but until the
-// IPC bridge to NAPI grows ticket-state ops, every mutator is a no-op and
-// every read returns the empty default.
-export class ElectronTicketState implements ITicketState {
-  tickets_json(): string { return "[]"; }
-  board_columns_json(): string { return "[]"; }
-  labels_json(): string { return "[]"; }
-  current_ticket_json(): unknown { return null; }
-
-  apply_ticket_status_event(_req: Uint8Array): void {}
-  apply_ticket_deleted_event(_req: Uint8Array): void {}
-  replace_cached_tickets(_req: Uint8Array): void {}
-  insert_created_ticket(_req: Uint8Array): void {}
-  patch_cached_ticket(_req: Uint8Array): void {}
-  replace_board_columns(_req: Uint8Array): void {}
-  append_board_column_tickets(_req: Uint8Array): void {}
-  set_current_ticket(_req: Uint8Array): void {}
-  replace_cached_labels(_req: Uint8Array): void {}
-  insert_created_label(_req: Uint8Array): void {}
-  remove_cached_label(_req: Uint8Array): void {}
-  filter_tickets(_req: Uint8Array): Uint8Array { return new Uint8Array(); }
-}
+export { ElectronTicketState } from "./ticket_state";
 
 export class ElectronAcpManager {
   get_session_json(_podKey: string): unknown { return null; }

--- a/packages/electron-adapter/src/ticket_cache_map.ts
+++ b/packages/electron-adapter/src/ticket_cache_map.ts
@@ -1,0 +1,55 @@
+import { create } from "@bufbuild/protobuf";
+import {
+  TicketSchema,
+  type Ticket as ProtoTicket,
+  type Label as ProtoLabel,
+  type BoardColumn as ProtoBoardColumn,
+} from "@agentsmesh/proto/ticket/v1/ticket_pb";
+
+// snake_case projection of proto.ticket.v1 types. Mirrors protoTicketToTicket /
+// ticketToProto in clients/web/src/lib/api/ticketProtoMap.ts but inlined to
+// keep electron-adapter independent of the web/src tree (same rationale as
+// podToCache in pod.ts). The cache holds only the SSOT-shape Ticket; the UI
+// re-reads joined fields (reporter/assignees/labels) from the API payload.
+
+export interface CachedTicket {
+  id: number; number: number; slug: string; title: string;
+  content?: string; status: string; priority: string; severity?: string;
+  estimate?: number; due_date?: string; started_at?: string; completed_at?: string;
+  repository_id?: number; created_at?: string; updated_at?: string;
+}
+
+export interface CachedBoardColumn {
+  status: string; tickets: CachedTicket[]; total_count: number;
+}
+
+export function ticketToCache(p: ProtoTicket): CachedTicket {
+  return {
+    id: Number(p.id), number: p.number, slug: p.slug, title: p.title,
+    content: p.content, status: p.status, priority: p.priority, severity: p.severity,
+    estimate: p.estimate, due_date: p.dueDate, started_at: p.startedAt,
+    completed_at: p.completedAt,
+    repository_id: p.repositoryId !== undefined ? Number(p.repositoryId) : undefined,
+    created_at: p.createdAt, updated_at: p.updatedAt,
+  };
+}
+
+export function boardColumnToCache(c: ProtoBoardColumn): CachedBoardColumn {
+  return { status: c.status, tickets: c.tickets.map(ticketToCache), total_count: Number(c.totalCount) };
+}
+
+export function labelToCache(p: ProtoLabel): Record<string, unknown> {
+  return { id: Number(p.id), name: p.name, color: p.color };
+}
+
+// Inverse of ticketToCache: filter_tickets must return a FilterTicketsResponse
+// of proto Tickets (the store decodes it back via protoTicketToTicket).
+export function cacheTicketToProto(t: CachedTicket): ProtoTicket {
+  return create(TicketSchema, {
+    id: BigInt(t.id), number: t.number, slug: t.slug, title: t.title,
+    content: t.content, status: t.status, priority: t.priority, severity: t.severity,
+    estimate: t.estimate, dueDate: t.due_date, startedAt: t.started_at, completedAt: t.completed_at,
+    repositoryId: t.repository_id !== undefined ? BigInt(t.repository_id) : undefined,
+    createdAt: t.created_at ?? "", updatedAt: t.updated_at ?? "",
+  });
+}

--- a/packages/electron-adapter/src/ticket_state.ts
+++ b/packages/electron-adapter/src/ticket_state.ts
@@ -1,0 +1,147 @@
+import type { ITicketState } from "@agentsmesh/service-interface";
+import { fromBinary, create, toBinary } from "@bufbuild/protobuf";
+import {
+  ReplaceCachedTicketsRequestSchema, InsertCreatedTicketRequestSchema,
+  PatchCachedTicketRequestSchema, ApplyTicketStatusEventRequestSchema,
+  ApplyTicketDeletedEventRequestSchema, ReplaceBoardColumnsRequestSchema,
+  AppendBoardColumnTicketsRequestSchema, SetCurrentTicketRequestSchema,
+  ReplaceCachedLabelsRequestSchema, InsertCreatedLabelRequestSchema,
+  RemoveCachedLabelRequestSchema, FilterTicketsRequestSchema,
+  FilterTicketsResponseSchema,
+} from "@agentsmesh/proto/ticket_state/v1/ticket_state_pb";
+import {
+  ticketToCache, boardColumnToCache, labelToCache, cacheTicketToProto,
+  type CachedTicket, type CachedBoardColumn,
+} from "./ticket_cache_map";
+
+// Desktop ticket-state mirror of clients/core/crates/wasm WasmTicketState
+// (proto-bytes-in / json-out) so the shared web store reads identical payloads
+// on both platforms. Renderer-local only — unlike pod.ts there is no
+// fire-and-forget to main: ticket realtime rides the generic realtime:event
+// channel (not a per-domain snapshot) and no app_ticket_* NAPI command exists.
+export class ElectronTicketState implements ITicketState {
+  private _ticketsCache = "[]";
+  private _boardColumnsCache = "[]";
+  private _labelsCache = "[]";
+  private _currentTicket: string | null = null;
+
+  tickets_json(): string { return this._ticketsCache; }
+  board_columns_json(): string { return this._boardColumnsCache; }
+  labels_json(): string { return this._labelsCache; }
+  current_ticket_json(): unknown { return this._currentTicket; }
+
+  replace_cached_tickets(reqBytes: Uint8Array): void {
+    const req = fromBinary(ReplaceCachedTicketsRequestSchema, reqBytes);
+    this._ticketsCache = JSON.stringify(req.tickets.map(ticketToCache));
+  }
+
+  insert_created_ticket(reqBytes: Uint8Array): void {
+    const req = fromBinary(InsertCreatedTicketRequestSchema, reqBytes);
+    if (!req.ticket) return;
+    const tickets = this._tickets();
+    tickets.push(ticketToCache(req.ticket));
+    this._ticketsCache = JSON.stringify(tickets);
+  }
+
+  patch_cached_ticket(reqBytes: Uint8Array): void {
+    const req = fromBinary(PatchCachedTicketRequestSchema, reqBytes);
+    if (!req.ticket) return;
+    const updated = ticketToCache(req.ticket);
+    this._ticketsCache = JSON.stringify(this._tickets().map((t) => (t.slug === req.slug ? updated : t)));
+    this._replaceInColumns(req.slug, updated);
+    if (this._currentSlug() === req.slug) this._currentTicket = JSON.stringify(updated);
+  }
+
+  apply_ticket_status_event(reqBytes: Uint8Array): void {
+    const req = fromBinary(ApplyTicketStatusEventRequestSchema, reqBytes);
+    this._ticketsCache = JSON.stringify(
+      this._tickets().map((t) => (t.slug === req.slug ? { ...t, status: req.status } : t)),
+    );
+    const cur = this._current();
+    if (cur && cur.slug === req.slug) this._currentTicket = JSON.stringify({ ...cur, status: req.status });
+  }
+
+  apply_ticket_deleted_event(reqBytes: Uint8Array): void {
+    const req = fromBinary(ApplyTicketDeletedEventRequestSchema, reqBytes);
+    this._ticketsCache = JSON.stringify(this._tickets().filter((t) => t.slug !== req.slug));
+    const cols = this._columns();
+    for (const c of cols) c.tickets = c.tickets.filter((t) => t.slug !== req.slug);
+    this._boardColumnsCache = JSON.stringify(cols);
+    if (this._currentSlug() === req.slug) this._currentTicket = null;
+  }
+
+  // set_board_columns flattens column tickets into the flat list AND stores the
+  // columns — the board renders cards from the flat list, counts from columns.
+  replace_board_columns(reqBytes: Uint8Array): void {
+    const req = fromBinary(ReplaceBoardColumnsRequestSchema, reqBytes);
+    const cols = req.columns.map(boardColumnToCache);
+    this._boardColumnsCache = JSON.stringify(cols);
+    this._ticketsCache = JSON.stringify(cols.flatMap((c) => c.tickets));
+  }
+
+  append_board_column_tickets(reqBytes: Uint8Array): void {
+    const req = fromBinary(AppendBoardColumnTicketsRequestSchema, reqBytes);
+    const cols = this._columns();
+    const col = cols.find((c) => c.status === req.status);
+    if (!col) return;
+    const add = req.tickets.map(ticketToCache);
+    col.tickets.push(...add);
+    this._boardColumnsCache = JSON.stringify(cols);
+    const tickets = this._tickets();
+    tickets.push(...add);
+    this._ticketsCache = JSON.stringify(tickets);
+  }
+
+  set_current_ticket(reqBytes: Uint8Array): void {
+    const req = fromBinary(SetCurrentTicketRequestSchema, reqBytes);
+    this._currentTicket = req.ticket ? JSON.stringify(ticketToCache(req.ticket)) : null;
+  }
+
+  replace_cached_labels(reqBytes: Uint8Array): void {
+    const req = fromBinary(ReplaceCachedLabelsRequestSchema, reqBytes);
+    this._labelsCache = JSON.stringify(req.labels.map(labelToCache));
+  }
+
+  insert_created_label(reqBytes: Uint8Array): void {
+    const req = fromBinary(InsertCreatedLabelRequestSchema, reqBytes);
+    if (!req.label) return;
+    const labels = JSON.parse(this._labelsCache) as unknown[];
+    labels.push(labelToCache(req.label));
+    this._labelsCache = JSON.stringify(labels);
+  }
+
+  remove_cached_label(reqBytes: Uint8Array): void {
+    const req = fromBinary(RemoveCachedLabelRequestSchema, reqBytes);
+    const id = Number(req.id);
+    const labels = JSON.parse(this._labelsCache) as { id: number }[];
+    this._labelsCache = JSON.stringify(labels.filter((l) => l.id !== id));
+  }
+
+  filter_tickets(reqBytes: Uint8Array): Uint8Array {
+    const req = fromBinary(FilterTicketsRequestSchema, reqBytes);
+    const search = req.search.toLowerCase();
+    const repoIds = req.repositoryIds.map(Number);
+    const matches = this._tickets().filter((t) => {
+      if (search && !t.title.toLowerCase().includes(search) && !t.slug.toLowerCase().includes(search)) return false;
+      if (req.statuses.length && !req.statuses.includes(t.status)) return false;
+      if (req.priorities.length && !req.priorities.includes(t.priority)) return false;
+      if (repoIds.length && !repoIds.includes(t.repository_id ?? 0)) return false;
+      return true;
+    });
+    const resp = create(FilterTicketsResponseSchema, { tickets: matches.map(cacheTicketToProto) });
+    return toBinary(FilterTicketsResponseSchema, resp);
+  }
+
+  private _tickets(): CachedTicket[] { return JSON.parse(this._ticketsCache) as CachedTicket[]; }
+  private _columns(): CachedBoardColumn[] { return JSON.parse(this._boardColumnsCache) as CachedBoardColumn[]; }
+  private _current(): CachedTicket | null {
+    return this._currentTicket ? (JSON.parse(this._currentTicket) as CachedTicket) : null;
+  }
+  private _currentSlug(): string | null { return this._current()?.slug ?? null; }
+
+  private _replaceInColumns(slug: string, updated: CachedTicket): void {
+    const cols = this._columns();
+    for (const c of cols) c.tickets = c.tickets.map((t) => (t.slug === slug ? updated : t));
+    this._boardColumnsCache = JSON.stringify(cols);
+  }
+}


### PR DESCRIPTION
## 问题
Desktop（Electron）版 Ticket 看板所有列空白、计数 0，点击 ticket 报 "Ticket 未找到"。Web 版正常。

## 根因
`ElectronTicketState`（`packages/electron-adapter/src/state_adapters.ts`）是 no-op stub：每个 proto-bytes mutator 丢弃字节、每个 reader 返回空。Connect-RPC 在 desktop 正常取到数据，但 state 层静默丢弃 → 看板空、详情 null。这是 #416 把 7 域下沉 proto-state 时 ticket 域唯一漏补的 Electron 镜像（`provider.ts` 里唯一 `new` stub 而非复用 service 实例的域）。

## 修复
- 新增 `ticket_state.ts` + `ticket_cache_map.ts`：真实 proto-bytes-in / json-out 本地镜像，16 方法对齐 WASM `WasmTicketState` / Rust `ticket_state.rs` 的 cache 语义（snake_case 输出、board `total_count`）。模式同 `pod.ts`。
- `state_adapters.ts` 删 stub 改 re-export。

## e2e 补齐（防回归）
现有 ticket e2e 全停在 nav/smoke/IPC 层，没有一条断言「列表真的渲染」——所以这个 bug 从三层旁边溜过。新增 render-layer spec（复用 `repositories-list.spec.ts` 模式，该 spec 已守护同款 `ElectronRepoState` stub 回归）：
- `tickets-board-render.spec.ts`：看板渲染卡片 + 详情加载（不再 "not found"）。
- `loops-list-render.spec.ts`：loops 侧栏渲染 seed loop。
- `deploy/dev/seed/seed.sql` 加 loop seed；`LoopsSidebarContent.tsx` 加 `data-testid` 锚点。

## 范围说明
mesh / autopilot 不在 render spec 覆盖内：它们的 UI 数据来自**实时活跃 pod/controller**（mesh 拓扑只收 `IsActive()` pod，DB 直插 pod 被 reconciler 标 `orphaned`；autopilot 无独立列表页，嵌在 pod workspace panel），静态 seed 无法守护。

## 验证
全量 desktop e2e：**357 passed**（含上述新 spec）。`electron_adapter` type-check 通过。