### PR TITLE
test(autopilot): full-chain E2E coverage + fix 3 production bugs

### DIFF
--- a/backend/internal/service/runner/BUILD.bazel
+++ b/backend/internal/service/runner/BUILD.bazel
@@ -83,6 +83,7 @@ go_test(
     srcs = [
         "affinity_test.go",
         "agents_adapter_test.go",
+        "autopilot_handler_test.go",
         "command_sender_test.go",
         "connection_generation_test.go",
         "connection_manager_handlers_test.go",

--- a/backend/internal/service/runner/autopilot_handler_test.go
+++ b/backend/internal/service/runner/autopilot_handler_test.go
@@ -1,0 +1,265 @@
+package runner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/anthropics/agentsmesh/backend/internal/domain/agentpod"
+	"github.com/anthropics/agentsmesh/backend/internal/infra"
+	runnerv1 "github.com/anthropics/agentsmesh/proto/gen/go/runner/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// newAutopilotTestCoordinator builds a minimal PodCoordinator wired only with
+// the autopilot repo + logger — the autopilot callback handlers depend on
+// nothing else (no connection manager / router / heartbeat).
+func newAutopilotTestCoordinator(db *gorm.DB) *PodCoordinator {
+	return &PodCoordinator{
+		autopilotRepo: infra.NewAutopilotRepository(db),
+		logger:        newTestLogger(),
+	}
+}
+
+func seedAutopilotController(t *testing.T, db *gorm.DB, key string) *agentpod.AutopilotController {
+	t.Helper()
+	c := &agentpod.AutopilotController{
+		AutopilotControllerKey: key,
+		PodKey:                 "pod-target",
+		PodID:                  10,
+		RunnerID:               7,
+		OrganizationID:         1,
+		Phase:                  agentpod.AutopilotPhaseInitializing,
+		MaxIterations:          10,
+		CircuitBreakerState:    agentpod.CircuitBreakerClosed,
+	}
+	require.NoError(t, infra.NewAutopilotRepository(db).Create(context.Background(), c))
+	return c
+}
+
+func fetchController(t *testing.T, db *gorm.DB, key string) *agentpod.AutopilotController {
+	t.Helper()
+	c, err := infra.NewAutopilotRepository(db).GetByKey(context.Background(), key)
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	return c
+}
+
+// ==================== Iteration handler ====================
+
+// TestHandleAutopilotIteration_PersistsAndUpdates also guards BUG-1: a wrong
+// autopilot_iterations column name would make CreateIteration fail here.
+func TestHandleAutopilotIteration_PersistsAndUpdates(t *testing.T) {
+	db := setupTestDB(t)
+	pc := newAutopilotTestCoordinator(db)
+	ctrl := seedAutopilotController(t, db, "autopilot-it-1")
+
+	var iterCb, statusCb bool
+	pc.onAutopilotIterationChange = func(key string, iter int32, phase, summary string, files []string, dur int64) {
+		iterCb = true
+		assert.Equal(t, "autopilot-it-1", key)
+		assert.Equal(t, int32(3), iter)
+		assert.Equal(t, []string{"a.go", "b.go"}, files)
+	}
+	pc.onAutopilotStatusChange = func(key, podKey, phase string, iter, max int32, cbState, cbReason string, takeover bool) {
+		statusCb = true
+	}
+
+	pc.handleAutopilotIteration(7, &runnerv1.AutopilotIterationEvent{
+		AutopilotKey: "autopilot-it-1",
+		Iteration:    3,
+		Phase:        "action_sent",
+		Summary:      "did something",
+		FilesChanged: []string{"a.go", "b.go"},
+		DurationMs:   1500,
+	})
+
+	iters, err := infra.NewAutopilotRepository(db).ListIterations(context.Background(), ctrl.ID)
+	require.NoError(t, err)
+	require.Len(t, iters, 1)
+	assert.Equal(t, int32(3), iters[0].Iteration)
+	assert.Equal(t, "action_sent", iters[0].Phase)
+	require.NotNil(t, iters[0].Summary)
+	assert.Equal(t, "did something", *iters[0].Summary)
+
+	assert.Equal(t, int32(3), fetchController(t, db, "autopilot-it-1").CurrentIteration)
+	assert.True(t, iterCb, "iteration callback should fire")
+	assert.True(t, statusCb, "status callback should fire")
+}
+
+// TestHandleAutopilotIteration_NilController_NoPanic guards BUG-2: GetByKey
+// returns (nil, nil) for an absent record; the handler must not deref rp.
+func TestHandleAutopilotIteration_NilController_NoPanic(t *testing.T) {
+	db := setupTestDB(t)
+	pc := newAutopilotTestCoordinator(db)
+
+	require.NotPanics(t, func() {
+		pc.handleAutopilotIteration(7, &runnerv1.AutopilotIterationEvent{
+			AutopilotKey: "does-not-exist",
+			Iteration:    1,
+		})
+	})
+}
+
+// ==================== Status handler ====================
+
+func TestHandleAutopilotControllerStatus_UpdatesPhase(t *testing.T) {
+	db := setupTestDB(t)
+	pc := newAutopilotTestCoordinator(db)
+	seedAutopilotController(t, db, "autopilot-st-1")
+
+	var cbPhase string
+	pc.onAutopilotStatusChange = func(key, podKey, phase string, iter, max int32, cbState, cbReason string, takeover bool) {
+		cbPhase = phase
+	}
+
+	pc.handleAutopilotControllerStatus(7, &runnerv1.AutopilotStatusEvent{
+		AutopilotKey: "autopilot-st-1",
+		PodKey:       "pod-target",
+		Status: &runnerv1.AutopilotStatus{
+			Phase:               agentpod.AutopilotPhaseRunning,
+			CurrentIteration:    2,
+			MaxIterations:       10,
+			CircuitBreakerState: agentpod.CircuitBreakerClosed,
+		},
+	})
+
+	updated := fetchController(t, db, "autopilot-st-1")
+	assert.Equal(t, agentpod.AutopilotPhaseRunning, updated.Phase)
+	assert.Equal(t, int32(2), updated.CurrentIteration)
+	assert.Equal(t, agentpod.AutopilotPhaseRunning, cbPhase)
+}
+
+func TestHandleAutopilotControllerStatus_WaitingApprovalSetsTimestamp(t *testing.T) {
+	db := setupTestDB(t)
+	pc := newAutopilotTestCoordinator(db)
+	seedAutopilotController(t, db, "autopilot-st-2")
+
+	pc.handleAutopilotControllerStatus(7, &runnerv1.AutopilotStatusEvent{
+		AutopilotKey: "autopilot-st-2",
+		Status: &runnerv1.AutopilotStatus{
+			Phase:        agentpod.AutopilotPhaseWaitingApproval,
+			MaxIterations: 10,
+		},
+	})
+
+	updated := fetchController(t, db, "autopilot-st-2")
+	assert.Equal(t, agentpod.AutopilotPhaseWaitingApproval, updated.Phase)
+	assert.NotNil(t, updated.ApprovalRequestAt, "approval_request_at should be set")
+}
+
+func TestHandleAutopilotControllerStatus_NilStatus_NoUpdate(t *testing.T) {
+	db := setupTestDB(t)
+	pc := newAutopilotTestCoordinator(db)
+	seedAutopilotController(t, db, "autopilot-st-3")
+
+	called := false
+	pc.onAutopilotStatusChange = func(key, podKey, phase string, iter, max int32, cbState, cbReason string, takeover bool) {
+		called = true
+	}
+
+	pc.handleAutopilotControllerStatus(7, &runnerv1.AutopilotStatusEvent{
+		AutopilotKey: "autopilot-st-3",
+		Status:       nil,
+	})
+
+	// Phase untouched, callback not fired.
+	assert.Equal(t, agentpod.AutopilotPhaseInitializing, fetchController(t, db, "autopilot-st-3").Phase)
+	assert.False(t, called)
+}
+
+// ==================== Created handler ====================
+
+func TestHandleAutopilotControllerCreated_SetsRunning(t *testing.T) {
+	db := setupTestDB(t)
+	pc := newAutopilotTestCoordinator(db)
+	seedAutopilotController(t, db, "autopilot-cr-1")
+
+	var cbPhase string
+	pc.onAutopilotStatusChange = func(key, podKey, phase string, iter, max int32, cbState, cbReason string, takeover bool) {
+		cbPhase = phase
+	}
+
+	pc.handleAutopilotControllerCreated(7, &runnerv1.AutopilotCreatedEvent{
+		AutopilotKey: "autopilot-cr-1",
+		PodKey:       "pod-target",
+	})
+
+	updated := fetchController(t, db, "autopilot-cr-1")
+	assert.Equal(t, agentpod.AutopilotPhaseRunning, updated.Phase)
+	assert.NotNil(t, updated.StartedAt)
+	assert.Equal(t, agentpod.AutopilotPhaseRunning, cbPhase)
+}
+
+// TestHandleAutopilotControllerCreated_NilController_NoPanic guards BUG-2 in
+// the created handler: the onAutopilotStatusChange block dereferences rp.
+func TestHandleAutopilotControllerCreated_NilController_NoPanic(t *testing.T) {
+	db := setupTestDB(t)
+	pc := newAutopilotTestCoordinator(db)
+
+	called := false
+	pc.onAutopilotStatusChange = func(key, podKey, phase string, iter, max int32, cbState, cbReason string, takeover bool) {
+		called = true
+	}
+
+	require.NotPanics(t, func() {
+		pc.handleAutopilotControllerCreated(7, &runnerv1.AutopilotCreatedEvent{
+			AutopilotKey: "does-not-exist",
+			PodKey:       "pod-x",
+		})
+	})
+	assert.False(t, called, "callback must not fire when controller is absent")
+}
+
+// ==================== Terminated handler ====================
+
+func TestHandleAutopilotControllerTerminated_ReasonMapping(t *testing.T) {
+	cases := []struct {
+		reason    string
+		wantPhase string
+	}{
+		{"completed", agentpod.AutopilotPhaseCompleted},
+		{"failed", agentpod.AutopilotPhaseFailed},
+		{"max_iterations", agentpod.AutopilotPhaseMaxIterations},
+		{"", agentpod.AutopilotPhaseStopped},
+		{"unrecognized", agentpod.AutopilotPhaseStopped},
+	}
+	for _, tc := range cases {
+		t.Run(tc.reason, func(t *testing.T) {
+			db := setupTestDB(t)
+			pc := newAutopilotTestCoordinator(db)
+			key := "autopilot-tm-" + tc.wantPhase + tc.reason
+			seedAutopilotController(t, db, key)
+
+			pc.handleAutopilotControllerTerminated(7, &runnerv1.AutopilotTerminatedEvent{
+				AutopilotKey: key,
+				Reason:       tc.reason,
+			})
+
+			updated := fetchController(t, db, key)
+			assert.Equal(t, tc.wantPhase, updated.Phase)
+			assert.NotNil(t, updated.CompletedAt, "completed_at should be set on terminate")
+		})
+	}
+}
+
+// TestHandleAutopilotControllerTerminated_NilController_NoPanic guards BUG-2 in
+// the terminated handler: the onAutopilotStatusChange block derefs rp.PodKey.
+func TestHandleAutopilotControllerTerminated_NilController_NoPanic(t *testing.T) {
+	db := setupTestDB(t)
+	pc := newAutopilotTestCoordinator(db)
+
+	called := false
+	pc.onAutopilotStatusChange = func(key, podKey, phase string, iter, max int32, cbState, cbReason string, takeover bool) {
+		called = true
+	}
+
+	require.NotPanics(t, func() {
+		pc.handleAutopilotControllerTerminated(7, &runnerv1.AutopilotTerminatedEvent{
+			AutopilotKey: "does-not-exist",
+			Reason:       "completed",
+		})
+	})
+	assert.False(t, called, "callback must not fire when controller is absent")
+}

--- a/backend/internal/service/runner/autopilot_iteration_handler.go
+++ b/backend/internal/service/runner/autopilot_iteration_handler.go
@@ -14,9 +14,16 @@ func (pc *PodCoordinator) handleAutopilotIteration(runnerID int64, data *runnerv
 
 	rp, err := pc.autopilotRepo.GetByKey(ctx, data.GetAutopilotKey())
 	if err != nil {
-		pc.logger.Error("failed to find autopilot pod for iteration",
+		pc.logger.Error("failed to find autopilot controller for iteration",
 			"autopilot_controller_key", data.GetAutopilotKey(),
 			"error", err)
+		return
+	}
+	// GetByKey returns (nil, nil) when the record is absent (already deleted /
+	// key mismatch). Guard before dereferencing rp.ID below.
+	if rp == nil {
+		pc.logger.Warn("autopilot controller not found for iteration, skipping",
+			"autopilot_controller_key", data.GetAutopilotKey())
 		return
 	}
 

--- a/backend/internal/service/runner/autopilot_status_handler.go
+++ b/backend/internal/service/runner/autopilot_status_handler.go
@@ -105,7 +105,7 @@ func (pc *PodCoordinator) handleAutopilotControllerCreated(runnerID int64, data 
 
 	if pc.onAutopilotStatusChange != nil {
 		rp, err := pc.autopilotRepo.GetByKey(ctx, data.GetAutopilotKey())
-		if err == nil {
+		if err == nil && rp != nil {
 			pc.onAutopilotStatusChange(
 				data.GetAutopilotKey(),
 				data.GetPodKey(),
@@ -156,7 +156,7 @@ func (pc *PodCoordinator) handleAutopilotControllerTerminated(runnerID int64, da
 
 	if pc.onAutopilotStatusChange != nil {
 		rp, err := pc.autopilotRepo.GetByKey(ctx, data.GetAutopilotKey())
-		if err == nil {
+		if err == nil && rp != nil {
 			pc.onAutopilotStatusChange(
 				data.GetAutopilotKey(),
 				rp.PodKey,

--- a/backend/migrations/000158_rename_autopilot_iteration_column.down.sql
+++ b/backend/migrations/000158_rename_autopilot_iteration_column.down.sql
@@ -1,0 +1,4 @@
+ALTER INDEX IF EXISTS idx_autopilot_iterations_autopilot_controller_id
+    RENAME TO idx_autopilot_iterations_autopilot_id;
+
+ALTER TABLE autopilot_iterations RENAME COLUMN autopilot_controller_id TO autopilot_id;

--- a/backend/migrations/000158_rename_autopilot_iteration_column.up.sql
+++ b/backend/migrations/000158_rename_autopilot_iteration_column.up.sql
@@ -1,0 +1,8 @@
+-- Fix schema drift: autopilot_iterations FK column was left as `autopilot_id`
+-- by migration 000041, but the Go model (AutopilotIteration.AutopilotControllerID)
+-- and infra queries expect `autopilot_controller_id`. Without this rename,
+-- CreateIteration/ListIterations fail in production with "column does not exist".
+ALTER TABLE autopilot_iterations RENAME COLUMN autopilot_id TO autopilot_controller_id;
+
+ALTER INDEX IF EXISTS idx_autopilot_iterations_autopilot_id
+    RENAME TO idx_autopilot_iterations_autopilot_controller_id;

--- a/clients/desktop/e2e/tests/autopilot/autopilot-events-bridge.spec.ts
+++ b/clients/desktop/e2e/tests/autopilot/autopilot-events-bridge.spec.ts
@@ -1,0 +1,49 @@
+// Validate that autopilot EventBus events reach the desktop renderer via the
+// IPC ServerStream bridge, and that the electron-adapter fetch path surfaces a
+// live controller. The decision loop runs on the same runner as web; here we
+// only assert the desktop-specific delivery (bridge + electron-adapter), which
+// is a parallel TS impl with drift risk.
+//
+// `api` (backend Connect client) creates the target pod + controller out of
+// band — desktop exposes no autopilot-create IPC, only autopilotFetchControllers.
+import { test, expect } from "../../fixtures";
+import { TEST_ORG_SLUG } from "../../helpers/env";
+import { gotoHash } from "../../helpers/nav";
+import { invokeIpc } from "../../helpers/ipc";
+import { installRealtimeSpy } from "../../helpers/realtime-spy";
+import {
+  createReadyAutopilotTarget,
+  createAutopilotForPod,
+} from "../../../../web/e2e-playwright/helpers/autopilot";
+
+test.describe("Desktop realtime · autopilot events bridge", () => {
+  test("autopilot:created reaches the renderer and the controller is fetchable", async ({ page, api }) => {
+    test.setTimeout(120_000);
+    const pod = await createReadyAutopilotTarget(api);
+
+    await gotoHash(page, `/${TEST_ORG_SLUG}/workspace`);
+    await page.waitForTimeout(2_000); // let the Rust EventSubscriptionManager land its SubscribeRequest
+
+    const spy = await installRealtimeSpy(page);
+    try {
+      const key = await createAutopilotForPod(api, {
+        targetPodKey: pod.podKey,
+        script: { decisions: [{ type: "continue", reasoning: "loop", send_input: "echo loop\n" }] },
+        maxIterations: 20,
+      });
+
+      const created = await spy.waitFor(
+        (json) => json.includes('"autopilot:created"') && json.includes(pod.podKey),
+        20_000,
+      );
+      expect(created).toContain(pod.podKey);
+
+      // electron-adapter fetch path returns the live controller (DTO contract).
+      const raw = await invokeIpc<string>(page, "autopilotFetchControllers");
+      expect(raw, `fetchControllers should include ${key}`).toContain(key);
+    } finally {
+      await spy.dispose();
+      await pod.cleanup();
+    }
+  });
+});

--- a/clients/web/e2e-playwright/helpers/autopilot-actions.ts
+++ b/clients/web/e2e-playwright/helpers/autopilot-actions.ts
@@ -1,0 +1,69 @@
+import type { ApiFixture } from "../fixtures/api.fixture";
+import { TEST_ORG_SLUG } from "./env";
+
+// Thin wrappers over the AutopilotService control RPCs (ActionRequest /
+// ApproveRequest in proto/autopilot/v1). Each takes the autopilot_controller
+// key returned by createAutopilotForPod and issues the matching Connect call.
+
+interface AutopilotClient {
+  pauseAutopilotController(req: object): Promise<unknown>;
+  resumeAutopilotController(req: object): Promise<unknown>;
+  stopAutopilotController(req: object): Promise<unknown>;
+  takeoverAutopilotController(req: object): Promise<unknown>;
+  handbackAutopilotController(req: object): Promise<unknown>;
+  approveAutopilotController(req: object): Promise<unknown>;
+  getIterations(req: object): Promise<{ items?: AutopilotIterationItem[] }>;
+}
+
+export interface AutopilotIterationItem {
+  iterationNumber?: number;
+  status?: string;
+  result?: string;
+}
+
+async function autopilot(api: ApiFixture): Promise<AutopilotClient> {
+  const cc = await api.connect();
+  return cc.autopilot as unknown as AutopilotClient;
+}
+
+export async function pauseAutopilot(api: ApiFixture, key: string): Promise<void> {
+  await (await autopilot(api)).pauseAutopilotController({ orgSlug: TEST_ORG_SLUG, key });
+}
+
+export async function resumeAutopilot(api: ApiFixture, key: string): Promise<void> {
+  await (await autopilot(api)).resumeAutopilotController({ orgSlug: TEST_ORG_SLUG, key });
+}
+
+export async function stopAutopilot(api: ApiFixture, key: string): Promise<void> {
+  await (await autopilot(api)).stopAutopilotController({ orgSlug: TEST_ORG_SLUG, key });
+}
+
+export async function takeoverAutopilot(api: ApiFixture, key: string): Promise<void> {
+  await (await autopilot(api)).takeoverAutopilotController({ orgSlug: TEST_ORG_SLUG, key });
+}
+
+export async function handbackAutopilot(api: ApiFixture, key: string): Promise<void> {
+  await (await autopilot(api)).handbackAutopilotController({ orgSlug: TEST_ORG_SLUG, key });
+}
+
+// approveAutopilot answers a NEED_HUMAN_HELP pause. continueExecution=true
+// resumes (granting additionalIterations), false stops the controller.
+export async function approveAutopilot(
+  api: ApiFixture,
+  key: string,
+  opts: { continueExecution: boolean; additionalIterations?: number },
+): Promise<void> {
+  await (await autopilot(api)).approveAutopilotController({
+    orgSlug: TEST_ORG_SLUG,
+    key,
+    continueExecution: opts.continueExecution,
+    additionalIterations: opts.additionalIterations ?? 0,
+  });
+}
+
+// getIterationHistory reads the persisted iteration rows for a controller —
+// the end-to-end read path for autopilot_iterations (migration 000158 column).
+export async function getIterationHistory(api: ApiFixture, key: string): Promise<AutopilotIterationItem[]> {
+  const resp = await (await autopilot(api)).getIterations({ orgSlug: TEST_ORG_SLUG, key });
+  return resp.items ?? [];
+}

--- a/clients/web/e2e-playwright/helpers/autopilot.ts
+++ b/clients/web/e2e-playwright/helpers/autopilot.ts
@@ -1,0 +1,190 @@
+import type { ApiFixture } from "../fixtures/api.fixture";
+import { TEST_ORG_SLUG } from "./env";
+import { subscribeEvents } from "./eventbus-stream";
+import { createMockAgentPod, type MockAgentPod } from "./mock-agent";
+import { pollUntil } from "./retry";
+
+export interface ControlDecision {
+  type: "continue" | "completed" | "need_help" | "give_up";
+  reasoning?: string;
+  send_input?: string;
+}
+
+export interface AutopilotScript {
+  observe?: boolean;
+  decisions: ControlDecision[];
+}
+
+export interface CollectedEvent {
+  type: string;
+  data: Record<string, unknown>;
+}
+
+const SETTLE_MS = 500;
+
+// AutopilotController.Start() only fires the first iteration when the pod is
+// "waiting" at attach time; gate here to remove the race.
+export async function waitForPodWaiting(
+  api: ApiFixture,
+  podKey: string,
+  opts: { maxAttempts?: number } = {},
+): Promise<void> {
+  const cc = await api.connect();
+  await pollUntil(
+    async () => {
+      const { items } = (await cc.pod.listPods({ orgSlug: TEST_ORG_SLUG })) as {
+        items?: Array<{ podKey?: string; agentStatus?: string }>;
+      };
+      const mine = items?.find((p) => p.podKey === podKey);
+      return mine?.agentStatus === "waiting";
+    },
+    { maxAttempts: opts.maxAttempts ?? 20, intervalMs: 1000, label: `pod-${podKey}-waiting` },
+  );
+}
+
+// Retries on a fresh pod: a dev-env flake leaves the mock producing no PTY
+// output on some runner instances, so the pod never reaches "waiting".
+export async function createReadyAutopilotTarget(
+  api: ApiFixture,
+  opts: { attempts?: number; scenario?: "autopilot" | "autopilot_fs" } = {},
+): Promise<MockAgentPod> {
+  const attempts = opts.attempts ?? 3;
+  const scenario = opts.scenario ?? "autopilot";
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    const pod = await createMockAgentPod(api, { mode: "pty", scenario });
+    try {
+      await waitForPodWaiting(api, pod.podKey, { maxAttempts: 15 });
+      return pod;
+    } catch (e) {
+      lastErr = e;
+      await pod.cleanup();
+    }
+  }
+  throw new Error(`createReadyAutopilotTarget: no pod reached waiting in ${attempts} attempts: ${lastErr}`);
+}
+
+// Attaches a mock control agent (claude-stream); `script` is injected via
+// control_prompt_template, replayed one decision per iteration over MCP.
+export async function createAutopilotForPod(
+  api: ApiFixture,
+  opts: { targetPodKey: string; script: AutopilotScript; maxIterations?: number },
+): Promise<string> {
+  const cc = await api.connect();
+  const ctrl = (await cc.autopilot.createAutopilotController({
+    orgSlug: TEST_ORG_SLUG,
+    podKey: opts.targetPodKey,
+    prompt: "drive the target pod to completion",
+    controlAgentSlug: "e2e-mock-agent",
+    controlPromptTemplate: JSON.stringify({
+      observe: opts.script.observe ?? true,
+      decisions: opts.script.decisions,
+    }),
+    maxIterations: opts.maxIterations ?? 10,
+  })) as { autopilotControllerKey?: string };
+
+  if (!ctrl.autopilotControllerKey) {
+    throw new Error(`createAutopilotForPod: missing key in ${JSON.stringify(ctrl)}`);
+  }
+  return ctrl.autopilotControllerKey;
+}
+
+// collectAutopilotEvents subscribes to the EventBus, runs `action`, and
+// collects every event until `until` matches (e.g. a terminal status) or the
+// timeout elapses. Returns all events in arrival order so specs can assert on
+// the whole decision-loop sequence, not just one event.
+export async function collectAutopilotEvents(
+  opts: {
+    token: string;
+    until: (type: string, data: Record<string, unknown>) => boolean;
+    timeoutMs?: number;
+    onEvent?: (type: string, data: Record<string, unknown>) => Promise<void> | void;
+  },
+  action: () => Promise<void>,
+): Promise<CollectedEvent[]> {
+  const timeout = opts.timeoutMs ?? 30_000;
+  const ctrl = new AbortController();
+  const events: CollectedEvent[] = [];
+
+  const drain = (async () => {
+    try {
+      for await (const ev of subscribeEvents({ token: opts.token, orgSlug: TEST_ORG_SLUG, signal: ctrl.signal })) {
+        let data: Record<string, unknown>;
+        try {
+          data = JSON.parse(ev.dataJson) as Record<string, unknown>;
+        } catch {
+          data = {};
+        }
+        events.push({ type: ev.type, data });
+        if (opts.onEvent) await opts.onEvent(ev.type, data);
+        if (opts.until(ev.type, data)) {
+          ctrl.abort();
+          return;
+        }
+      }
+    } catch {
+      /* abort or clean close */
+    }
+  })();
+
+  await new Promise((r) => setTimeout(r, SETTLE_MS));
+  await action();
+
+  await Promise.race([drain, new Promise((r) => setTimeout(r, timeout))]);
+  ctrl.abort();
+  return events;
+}
+
+export function isTerminalStatus(type: string, data: Record<string, unknown>): boolean {
+  return (
+    type === "autopilot:status_changed" &&
+    ["completed", "failed", "stopped", "max_iterations"].includes(String(data.phase))
+  );
+}
+
+export function statusEventsWithPhase(events: CollectedEvent[], phase: string): CollectedEvent[] {
+  return events.filter((e) => e.type === "autopilot:status_changed" && e.data.phase === phase);
+}
+
+// hasThinkingDecision asserts a thinking event carried a decision whose
+// upper-cased decision_type contains `typeFragment` (the wire enum, e.g.
+// "TASK_COMPLETED" for completed, "GIVE_UP", "NEED_HUMAN_HELP", "CONTINUE")
+// and, when given, the exact reasoning string.
+export function hasThinkingDecision(
+  events: CollectedEvent[],
+  typeFragment: string,
+  reasoning?: string,
+): boolean {
+  return events.some(
+    (e) =>
+      e.type === "autopilot:thinking" &&
+      String(e.data.decision_type).toUpperCase().includes(typeFragment.toUpperCase()) &&
+      (reasoning === undefined || e.data.reasoning === reasoning),
+  );
+}
+
+export function hasStatusPhase(events: CollectedEvent[], phase: string): boolean {
+  return statusEventsWithPhase(events, phase).length > 0;
+}
+
+// hasIterationEvent matches an autopilot:iteration event, optionally with a
+// specific phase ("started" / "action_sent" / "error" / "completed" / …).
+export function hasIterationEvent(events: CollectedEvent[], phase?: string): boolean {
+  return events.some(
+    (e) =>
+      e.type === "autopilot:iteration" &&
+      Number(e.data.iteration) >= 1 &&
+      (phase === undefined || e.data.phase === phase),
+  );
+}
+
+// hasIterationWithFiles matches an iteration event whose files_changed (from the
+// runner ProgressTracker git-diff snapshot) is non-empty.
+export function hasIterationWithFiles(events: CollectedEvent[]): boolean {
+  return events.some(
+    (e) =>
+      e.type === "autopilot:iteration" &&
+      Array.isArray(e.data.files_changed) &&
+      (e.data.files_changed as unknown[]).length > 0,
+  );
+}

--- a/clients/web/e2e-playwright/helpers/mock-agent.ts
+++ b/clients/web/e2e-playwright/helpers/mock-agent.ts
@@ -17,6 +17,8 @@ export type MockAgentMode = "pty" | "acp";
 // Keep in sync with that file and backend/migrations/000151..000153.
 export type MockAgentScenario =
   | "echo"
+  | "autopilot"
+  | "autopilot_fs"
   | "streaming_3"
   | "thinking_then_answer"
   | "tool_call_edit"

--- a/clients/web/e2e-playwright/tests/auth/login.spec.ts
+++ b/clients/web/e2e-playwright/tests/auth/login.spec.ts
@@ -29,9 +29,11 @@ test.describe("Login Flow", () => {
   test("successful login redirects to workspace", async ({ page }) => {
     await loginPage.login(TEST_USER.email, TEST_USER.password);
 
-    // Should redirect away from /login
+    // Post-login navigateAfterLogin blocks on resolvePostLoginUrlLight →
+    // fetchFirstOrgSlug (a network round-trip) before router.push; under a
+    // loaded CI shard that org fetch is slow, so allow generous headroom.
     await page.waitForURL((url) => !url.pathname.includes("/login"), {
-      timeout: 15_000,
+      timeout: 30_000,
     });
 
     // Should land on workspace or dashboard

--- a/clients/web/e2e-playwright/tests/autopilot/autopilot-edge.spec.ts
+++ b/clients/web/e2e-playwright/tests/autopilot/autopilot-edge.spec.ts
@@ -1,0 +1,84 @@
+// Autopilot edge cases: concurrent controllers stay isolated, and a target pod
+// dying mid-run tears its controller down (runner ac.Stop → terminated →
+// backend status_changed phase=stopped).
+import { test, expect } from "../../fixtures/index";
+import { clearAuthRateLimit } from "../../helpers/redis";
+import { terminateAllPods } from "../../helpers/pod-cleanup";
+import {
+  createReadyAutopilotTarget,
+  createAutopilotForPod,
+  collectAutopilotEvents,
+  isTerminalStatus,
+  hasStatusPhase,
+} from "../../helpers/autopilot";
+
+const CASE_TIMEOUT = 180_000;
+
+const completedScript = (sentinel: string) => ({
+  decisions: [
+    { type: "continue" as const, reasoning: "step", send_input: "echo go\n" },
+    { type: "completed" as const, reasoning: sentinel },
+  ],
+});
+
+test.describe("Autopilot edge cases · mock control agent", () => {
+  test.beforeEach(async () => {
+    clearAuthRateLimit();
+  });
+  test.afterEach(async () => {
+    await terminateAllPods();
+  });
+
+  test("concurrent controllers complete independently", async ({ api }) => {
+    test.setTimeout(CASE_TIMEOUT);
+    const { token } = await api.login();
+    const [podA, podB] = await Promise.all([
+      createReadyAutopilotTarget(api),
+      createReadyAutopilotTarget(api),
+    ]);
+
+    const completed = new Set<string>();
+    await collectAutopilotEvents(
+      {
+        token,
+        timeoutMs: 150_000,
+        until: (type, data) => {
+          if (type === "autopilot:status_changed" && data.phase === "completed") {
+            completed.add(String(data.autopilot_controller_key));
+          }
+          return completed.size >= 2;
+        },
+      },
+      async () => {
+        await Promise.all([
+          createAutopilotForPod(api, { targetPodKey: podA.podKey, script: completedScript(`a-${podA.podKey}`) }),
+          createAutopilotForPod(api, { targetPodKey: podB.podKey, script: completedScript(`b-${podB.podKey}`) }),
+        ]);
+      },
+    );
+
+    expect(completed.size, `distinct completed controllers: ${[...completed].join(", ")}`).toBe(2);
+  });
+
+  test("target pod terminated mid-run tears down the controller", async ({ api }) => {
+    test.setTimeout(CASE_TIMEOUT);
+    const { token } = await api.login();
+    const pod = await createReadyAutopilotTarget(api);
+
+    const events = await collectAutopilotEvents(
+      { token, until: isTerminalStatus, timeoutMs: 90_000 },
+      async () => {
+        await createAutopilotForPod(api, {
+          targetPodKey: pod.podKey,
+          script: { decisions: [{ type: "continue", reasoning: "loop", send_input: "echo loop\n" }] },
+          maxIterations: 20,
+        });
+        // Let iteration 1 run, then kill the pod out from under the controller.
+        await new Promise((r) => setTimeout(r, 9000));
+        await pod.cleanup();
+      },
+    );
+
+    expect(hasStatusPhase(events, "stopped")).toBe(true);
+  });
+});

--- a/clients/web/e2e-playwright/tests/autopilot/autopilot-interaction.spec.ts
+++ b/clients/web/e2e-playwright/tests/autopilot/autopilot-interaction.spec.ts
@@ -1,0 +1,144 @@
+// Autopilot user-interaction + control-action coverage (the review's state-machine
+// blind spots). Same fully-mocked chain as autopilot-lifecycle.spec.ts; here the
+// spec drives the control RPCs (approve / pause / resume / takeover / handback /
+// stop) and asserts the resulting phase transitions on the wire.
+import { test, expect } from "../../fixtures/index";
+import { clearAuthRateLimit } from "../../helpers/redis";
+import { terminateAllPods } from "../../helpers/pod-cleanup";
+import {
+  createReadyAutopilotTarget,
+  createAutopilotForPod,
+  collectAutopilotEvents,
+  isTerminalStatus,
+  hasThinkingDecision,
+  hasStatusPhase,
+} from "../../helpers/autopilot";
+import {
+  pauseAutopilot,
+  resumeAutopilot,
+  stopAutopilot,
+  takeoverAutopilot,
+  handbackAutopilot,
+  approveAutopilot,
+} from "../../helpers/autopilot-actions";
+
+const CASE_TIMEOUT = 150_000;
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const stoppedPhase = (t: string, d: Record<string, unknown>) =>
+  t === "autopilot:status_changed" && d.phase === "stopped";
+
+test.describe("Autopilot interaction · mock control agent", () => {
+  test.beforeEach(async () => {
+    clearAuthRateLimit();
+  });
+  test.afterEach(async () => {
+    await terminateAllPods();
+  });
+
+  test("need_human_help: pauses for approval, approve resumes to completed", async ({ api }) => {
+    test.setTimeout(CASE_TIMEOUT);
+    const { token } = await api.login();
+    const pod = await createReadyAutopilotTarget(api);
+    const sentinel = `done-${pod.podKey}`;
+
+    const events = await collectAutopilotEvents(
+      { token, until: isTerminalStatus, timeoutMs: 120_000 },
+      async () => {
+        const key = await createAutopilotForPod(api, {
+          targetPodKey: pod.podKey,
+          script: {
+            decisions: [
+              { type: "need_help", reasoning: "need a human" },
+              { type: "completed", reasoning: sentinel },
+            ],
+          },
+          maxIterations: 5,
+        });
+        // Iteration 1 → need_help → waiting_approval. Wait past the controller's
+        // 5s MinTriggerGap so the post-approve OnPodWaiting isn't deduplicated.
+        await sleep(8000);
+        await approveAutopilot(api, key, { continueExecution: true, additionalIterations: 3 });
+      },
+    );
+
+    expect(hasThinkingDecision(events, "NEED_HUMAN_HELP")).toBe(true);
+    expect(hasStatusPhase(events, "waiting_approval")).toBe(true);
+    // Approval resumed the loop and the next decision completed it.
+    expect(hasThinkingDecision(events, "COMPLETED", sentinel)).toBe(true);
+    expect(hasStatusPhase(events, "completed")).toBe(true);
+  });
+
+  test("need_human_help: deny approval stops the controller", async ({ api }) => {
+    test.setTimeout(CASE_TIMEOUT);
+    const { token } = await api.login();
+    const pod = await createReadyAutopilotTarget(api);
+
+    const events = await collectAutopilotEvents(
+      { token, until: isTerminalStatus, timeoutMs: 60_000 },
+      async () => {
+        const key = await createAutopilotForPod(api, {
+          targetPodKey: pod.podKey,
+          script: { decisions: [{ type: "need_help", reasoning: "need a human" }] },
+          maxIterations: 5,
+        });
+        await sleep(4000);
+        await approveAutopilot(api, key, { continueExecution: false });
+      },
+    );
+
+    expect(hasStatusPhase(events, "waiting_approval")).toBe(true);
+    expect(hasStatusPhase(events, "stopped")).toBe(true);
+  });
+
+  test("pause → resume → stop", async ({ api }) => {
+    test.setTimeout(CASE_TIMEOUT);
+    const { token } = await api.login();
+    const pod = await createReadyAutopilotTarget(api);
+
+    const events = await collectAutopilotEvents(
+      { token, until: stoppedPhase, timeoutMs: 60_000 },
+      async () => {
+        const key = await createAutopilotForPod(api, {
+          targetPodKey: pod.podKey,
+          script: { decisions: [{ type: "continue", reasoning: "loop", send_input: "echo loop\n" }] },
+          maxIterations: 10,
+        });
+        await sleep(2000);
+        await pauseAutopilot(api, key);
+        await sleep(2500);
+        await resumeAutopilot(api, key);
+        await sleep(2500);
+        await stopAutopilot(api, key);
+      },
+    );
+
+    expect(hasStatusPhase(events, "paused")).toBe(true);
+    expect(hasStatusPhase(events, "stopped")).toBe(true);
+  });
+
+  test("takeover → handback → stop", async ({ api }) => {
+    test.setTimeout(CASE_TIMEOUT);
+    const { token } = await api.login();
+    const pod = await createReadyAutopilotTarget(api);
+
+    const events = await collectAutopilotEvents(
+      { token, until: stoppedPhase, timeoutMs: 60_000 },
+      async () => {
+        const key = await createAutopilotForPod(api, {
+          targetPodKey: pod.podKey,
+          script: { decisions: [{ type: "continue", reasoning: "loop", send_input: "echo loop\n" }] },
+          maxIterations: 10,
+        });
+        await sleep(2000);
+        await takeoverAutopilot(api, key);
+        await sleep(2500);
+        await handbackAutopilot(api, key);
+        await sleep(2500);
+        await stopAutopilot(api, key);
+      },
+    );
+
+    expect(hasStatusPhase(events, "user_takeover")).toBe(true);
+    expect(hasStatusPhase(events, "stopped")).toBe(true);
+  });
+});

--- a/clients/web/e2e-playwright/tests/autopilot/autopilot-lifecycle.spec.ts
+++ b/clients/web/e2e-playwright/tests/autopilot/autopilot-lifecycle.spec.ts
@@ -1,0 +1,189 @@
+// Full-chain autopilot decision loop: web → backend → runner → mock control
+// agent (claude-stream) → MCP → target pod. decision_type is the upper-cased
+// wire enum (CONTINUE / TASK_COMPLETED / NEED_HUMAN_HELP / GIVE_UP).
+import { test, expect } from "../../fixtures/index";
+import { clearAuthRateLimit } from "../../helpers/redis";
+import { terminateAllPods } from "../../helpers/pod-cleanup";
+import { pollUntil } from "../../helpers/retry";
+import {
+  createReadyAutopilotTarget,
+  createAutopilotForPod,
+  collectAutopilotEvents,
+  isTerminalStatus,
+  hasThinkingDecision,
+  hasStatusPhase,
+  hasIterationEvent,
+  hasIterationWithFiles,
+} from "../../helpers/autopilot";
+import { getIterationHistory, type AutopilotIterationItem } from "../../helpers/autopilot-actions";
+
+// Each turn holds the pod ~6s to clear the controller's 5s MinTriggerGap, so
+// multi-iteration cases need generous time.
+const CASE_TIMEOUT = 150_000;
+
+test.describe("Autopilot lifecycle · mock control agent", () => {
+  test.beforeEach(async () => {
+    clearAuthRateLimit();
+  });
+  test.afterEach(async () => {
+    await terminateAllPods();
+  });
+
+  test("completed: decision loop drives the pod then terminates", async ({ api }) => {
+    test.setTimeout(CASE_TIMEOUT);
+    const { token } = await api.login();
+    const pod = await createReadyAutopilotTarget(api);
+    const sentinel = `done-${pod.podKey}`;
+
+    const events = await collectAutopilotEvents(
+      { token, until: isTerminalStatus, timeoutMs: 120_000 },
+      () =>
+        createAutopilotForPod(api, {
+          targetPodKey: pod.podKey,
+          script: {
+            decisions: [
+              { type: "continue", reasoning: "step1", send_input: "echo step1\n" },
+              { type: "completed", reasoning: sentinel },
+            ],
+          },
+          maxIterations: 5,
+        }),
+    );
+
+    expect(events.map((e) => e.type)).toContain("autopilot:created");
+    // The completed decision flowed end-to-end (mock → claude-stream →
+    // DecisionParser → gRPC → eventbus) and carried the injected sentinel.
+    expect(
+      hasThinkingDecision(events, "COMPLETED", sentinel),
+      `thinking: ${JSON.stringify(events.filter((e) => e.type === "autopilot:thinking").map((e) => e.data))}`,
+    ).toBe(true);
+    expect(hasIterationEvent(events), `events: ${events.map((e) => e.type).join(",")}`).toBe(true);
+    expect(hasStatusPhase(events, "completed")).toBe(true);
+  });
+
+  test("iteration history persists and is queryable (BUG-1 column)", async ({ api }) => {
+    test.setTimeout(CASE_TIMEOUT);
+    const { token } = await api.login();
+    const pod = await createReadyAutopilotTarget(api);
+    let key = "";
+
+    await collectAutopilotEvents(
+      { token, until: isTerminalStatus, timeoutMs: 120_000 },
+      async () => {
+        key = await createAutopilotForPod(api, {
+          targetPodKey: pod.podKey,
+          script: {
+            decisions: [
+              { type: "continue", reasoning: "drive", send_input: "echo go\n" },
+              { type: "completed", reasoning: "done" },
+            ],
+          },
+          maxIterations: 5,
+        });
+      },
+    );
+
+    // GetIterations reads autopilot_iterations via autopilot_controller_id
+    // (migration 000158). A non-empty history proves the write+read path works
+    // against the real schema — the regression BUG-1 would surface as empty/500.
+    let iters: AutopilotIterationItem[] = [];
+    await pollUntil(
+      async () => {
+        iters = await getIterationHistory(api, key);
+        return iters.length >= 1;
+      },
+      { maxAttempts: 10, intervalMs: 1000, label: `iterations-${key}` },
+    );
+    expect(iters.some((it) => (it.iterationNumber ?? 0) >= 1)).toBe(true);
+  });
+
+  test("give_up: control agent abandons → failed", async ({ api }) => {
+    test.setTimeout(CASE_TIMEOUT);
+    const { token } = await api.login();
+    const pod = await createReadyAutopilotTarget(api);
+
+    const events = await collectAutopilotEvents(
+      { token, until: isTerminalStatus, timeoutMs: 60_000 },
+      () =>
+        createAutopilotForPod(api, {
+          targetPodKey: pod.podKey,
+          script: { decisions: [{ type: "give_up", reasoning: "cannot proceed" }] },
+          maxIterations: 5,
+        }),
+    );
+
+    expect(hasThinkingDecision(events, "GIVE_UP")).toBe(true);
+    expect(hasStatusPhase(events, "failed")).toBe(true);
+  });
+
+  test("max_iterations: cap reached → terminates", async ({ api }) => {
+    test.setTimeout(CASE_TIMEOUT);
+    const { token } = await api.login();
+    const pod = await createReadyAutopilotTarget(api);
+
+    // maxIterations:1 → iteration 1 drives the pod, the next waiting edge hits
+    // the cap. Every decision is continue+send_input so the pod keeps cycling.
+    const events = await collectAutopilotEvents(
+      { token, until: isTerminalStatus, timeoutMs: 90_000 },
+      () =>
+        createAutopilotForPod(api, {
+          targetPodKey: pod.podKey,
+          script: { decisions: [{ type: "continue", reasoning: "loop", send_input: "echo loop\n" }] },
+          maxIterations: 1,
+        }),
+    );
+
+    expect(hasStatusPhase(events, "max_iterations")).toBe(true);
+  });
+
+  test("progress tracker reports changed files in iteration events", async ({ api }) => {
+    test.setTimeout(CASE_TIMEOUT);
+    const { token } = await api.login();
+    // autopilot_fs git-inits the sandbox + drops a probe file, so the runner's
+    // ProgressTracker git-diff snapshot surfaces files_changed on the wire.
+    const pod = await createReadyAutopilotTarget(api, { scenario: "autopilot_fs" });
+
+    const events = await collectAutopilotEvents(
+      { token, until: isTerminalStatus, timeoutMs: 120_000 },
+      () =>
+        createAutopilotForPod(api, {
+          targetPodKey: pod.podKey,
+          script: {
+            decisions: [
+              { type: "continue", reasoning: "step", send_input: "echo go\n" },
+              { type: "completed", reasoning: "done" },
+            ],
+          },
+          maxIterations: 5,
+        }),
+    );
+
+    expect(
+      hasIterationWithFiles(events),
+      `iteration files: ${JSON.stringify(events.filter((e) => e.type === "autopilot:iteration").map((e) => e.data.files_changed))}`,
+    ).toBe(true);
+  });
+
+  test("circuit breaker: consecutive control errors → failed", async ({ api }) => {
+    test.setTimeout(CASE_TIMEOUT);
+    const { token } = await api.login();
+    const pod = await createReadyAutopilotTarget(api);
+
+    // Three "error" decisions make the control agent emit empty output; the
+    // controller retries (pod stays waiting) until MaxConsecutiveErrors=3 trips.
+    const events = await collectAutopilotEvents(
+      { token, until: isTerminalStatus, timeoutMs: 90_000 },
+      () =>
+        createAutopilotForPod(api, {
+          targetPodKey: pod.podKey,
+          script: { decisions: [{ type: "error" }, { type: "error" }, { type: "error" }] },
+          maxIterations: 5,
+        }),
+    );
+
+    // phase=failed alone matches give_up too; the error-phase iteration event
+    // proves it was the consecutive-error circuit breaker.
+    expect(hasIterationEvent(events, "error"), `events: ${events.map((e) => e.type).join(",")}`).toBe(true);
+    expect(hasStatusPhase(events, "failed")).toBe(true);
+  });
+});

--- a/clients/web/e2e-playwright/tests/autopilot/autopilot-ui.spec.ts
+++ b/clients/web/e2e-playwright/tests/autopilot/autopilot-ui.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from "../../fixtures/index";
+import type { Page } from "@playwright/test";
+import type { ApiFixture } from "../../fixtures/api.fixture";
+import type { ConsoleMonitor } from "../../helpers/console-monitor";
+import { clearAuthRateLimit } from "../../helpers/redis";
+import { terminateAllPods } from "../../helpers/pod-cleanup";
+import { workspaceUrlForPod } from "../../helpers/mock-agent";
+import { createReadyAutopilotTarget, createAutopilotForPod } from "../../helpers/autopilot";
+
+// Opens the workspace, attaches a running controller after the page is live on
+// realtime (the autopilot:created edge is what hydrates the store), and returns
+// the visible status bar locator.
+async function openWorkspaceWithAutopilot(page: Page, api: ApiFixture, monitor: ConsoleMonitor) {
+  monitor.allow(/Failed to load resource.*50\d \(/); // transient realtime gateway hiccup
+  await api.login();
+  const pod = await createReadyAutopilotTarget(api);
+
+  await page.goto(workspaceUrlForPod(pod.podKey));
+  await page.waitForLoadState("load");
+  await page.waitForTimeout(3000);
+  await createAutopilotForPod(api, {
+    targetPodKey: pod.podKey,
+    script: { decisions: [{ type: "continue", reasoning: "loop", send_input: "echo loop\n" }] },
+    maxIterations: 20,
+  });
+
+  const statusBar = page.getByTestId("autopilot-status-bar");
+  await expect(statusBar).toBeVisible({ timeout: 30_000 });
+  return statusBar;
+}
+
+test.describe("Autopilot UI · status bar", () => {
+  test.beforeEach(async () => {
+    clearAuthRateLimit();
+  });
+  test.afterEach(async () => {
+    await terminateAllPods();
+  });
+
+  test("workspace renders the autopilot status bar with the live phase", async ({ page, api, monitor }) => {
+    test.setTimeout(120_000);
+    const statusBar = await openWorkspaceWithAutopilot(page, api, monitor);
+    await expect(statusBar).toHaveAttribute(
+      "data-phase",
+      /initializing|running|paused|waiting_approval|user_takeover|completed|max_iterations/,
+    );
+  });
+
+  test("status bar pause/resume buttons drive the controller", async ({ page, api, monitor }) => {
+    test.setTimeout(120_000);
+    const statusBar = await openWorkspaceWithAutopilot(page, api, monitor);
+    await expect(statusBar).toHaveAttribute("data-phase", "running", { timeout: 30_000 });
+
+    // Button click → control RPC → runner → status_changed → store → DOM.
+    await statusBar.getByTitle("Pause").click();
+    await expect(statusBar).toHaveAttribute("data-phase", "paused", { timeout: 20_000 });
+
+    await statusBar.getByTitle("Resume").click();
+    await expect(statusBar).toHaveAttribute("data-phase", "running", { timeout: 20_000 });
+  });
+
+  test("view-details opens the autopilot bottom panel", async ({ page, api, monitor }) => {
+    test.setTimeout(120_000);
+    const statusBar = await openWorkspaceWithAutopilot(page, api, monitor);
+    await statusBar.getByTitle("View Details").click();
+    await expect(page.getByTestId("autopilot-panel")).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/clients/web/src/components/autopilot/AutopilotPanelContent.tsx
+++ b/clients/web/src/components/autopilot/AutopilotPanelContent.tsx
@@ -62,7 +62,7 @@ export function AutopilotPanelContent({ podKey, className }: AutopilotPanelConte
   const progress = (autopilotController.current_iteration / autopilotController.max_iterations) * 100;
 
   return (
-    <div className={cn("flex flex-col h-full", className)}>
+    <div data-testid="autopilot-panel" className={cn("flex flex-col h-full", className)}>
       {/* Header with status and controls */}
       <div className="flex items-center gap-3 px-3 py-2 border-b border-border/50">
         {/* Status */}

--- a/clients/web/src/components/autopilot/AutopilotStatusBar.tsx
+++ b/clients/web/src/components/autopilot/AutopilotStatusBar.tsx
@@ -126,6 +126,8 @@ export function AutopilotStatusBar({
 
   return (
     <div
+      data-testid="autopilot-status-bar"
+      data-phase={autopilotController.phase}
       className={cn(
         "flex items-center gap-2 px-3 py-1.5 border-b",
         needsHelp ? "bg-orange-500/5 border-orange-500/30" : phaseInfo.bgColor,

--- a/clients/web/src/components/autopilot/CircuitBreakerAlert.tsx
+++ b/clients/web/src/components/autopilot/CircuitBreakerAlert.tsx
@@ -17,7 +17,7 @@ export function CircuitBreakerAlert({
   className,
   approvalTimeoutMin = 30,
 }: CircuitBreakerAlertProps) {
-  const { approveAutopilotController } = useAutopilotStore();
+  const approveAutopilotController = useAutopilotStore((s) => s.approveAutopilotController);
   const [additionalIterations, setAdditionalIterations] = React.useState(5);
   const [timeRemaining, setTimeRemaining] = React.useState<string | null>(null);
 

--- a/clients/web/src/components/autopilot/TakeoverBanner.tsx
+++ b/clients/web/src/components/autopilot/TakeoverBanner.tsx
@@ -12,7 +12,7 @@ interface TakeoverBannerProps {
 }
 
 export function TakeoverBanner({ autopilotController, className }: TakeoverBannerProps) {
-  const { handbackAutopilotController } = useAutopilotStore();
+  const handbackAutopilotController = useAutopilotStore((s) => s.handbackAutopilotController);
 
   if (!autopilotController.user_takeover && autopilotController.phase !== "user_takeover") {
     return null;

--- a/clients/web/src/components/workspace/AutopilotOverlay.tsx
+++ b/clients/web/src/components/workspace/AutopilotOverlay.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect } from "react";
-import { useAutopilotStore, useAutopilotThinking } from "@/stores/autopilot";
+import { useAutopilotControllerByPodKey, useAutopilotThinking } from "@/stores/autopilot";
 import { useIDEStore } from "@/stores/ide";
 import {
   CircuitBreakerAlert,
@@ -14,9 +14,7 @@ interface AutopilotOverlayProps {
 }
 
 export function AutopilotOverlay({ podKey }: AutopilotOverlayProps) {
-  const autopilotController = useAutopilotStore((state) =>
-    state.getAutopilotControllerByPodKey(podKey)
-  );
+  const autopilotController = useAutopilotControllerByPodKey(podKey);
   const setBottomPanelOpen = useIDEStore((s) => s.setBottomPanelOpen);
   const setBottomPanelTab = useIDEStore((s) => s.setBottomPanelTab);
 

--- a/clients/web/src/components/workspace/TerminalPane.tsx
+++ b/clients/web/src/components/workspace/TerminalPane.tsx
@@ -6,7 +6,7 @@ import { RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useWorkspaceStore, type SplitDirection } from "@/stores/workspace";
 import { usePodStore } from "@/stores/pod";
-import { useAutopilotStore } from "@/stores/autopilot";
+import { useAutopilotControllerByPodKey } from "@/stores/autopilot";
 import { usePodStatus, useTerminal, useTouchScroll } from "@/hooks";
 import { TerminalPaneHeader } from "./TerminalPaneHeader";
 import { PaneLoadingState, PaneErrorState, PaneReconnectingState } from "./PaneStateViews";
@@ -47,7 +47,7 @@ export function TerminalPane({
   const splitPane = useWorkspaceStore((s) => s.splitPane);
   const panes = useWorkspaceStore((s) => s.panes);
   const initProgress = usePodStore((state) => state.initProgress[podKey]);
-  const hasAutopilot = useAutopilotStore((state) => !!state.getAutopilotControllerByPodKey(podKey));
+  const hasAutopilot = !!useAutopilotControllerByPodKey(podKey);
 
   const openPodKeys = useMemo(() => panes.map((p) => p.podKey), [panes]);
 

--- a/clients/web/src/components/workspace/__tests__/AutopilotOverlay.test.tsx
+++ b/clients/web/src/components/workspace/__tests__/AutopilotOverlay.test.tsx
@@ -10,13 +10,8 @@ let mockController: AutopilotController | undefined;
 let mockThinkingMap: Record<string, AutopilotThinking | null> = {};
 
 vi.mock("@/stores/autopilot", () => ({
-  useAutopilotStore: (selector?: (s: Record<string, unknown>) => unknown) => {
-    const state = {
-      getAutopilotControllerByPodKey: (podKey: string) =>
-        mockController?.pod_key === podKey ? mockController : undefined,
-    };
-    return selector ? selector(state) : state;
-  },
+  useAutopilotControllerByPodKey: (podKey: string) =>
+    mockController?.pod_key === podKey ? mockController : undefined,
   useAutopilotThinking: (key: string | null | undefined) =>
     key ? (mockThinkingMap[key] ?? null) : null,
   useAutopilotIterations: () => [],

--- a/clients/web/src/providers/realtimeFeatureHandlers.ts
+++ b/clients/web/src/providers/realtimeFeatureHandlers.ts
@@ -1,6 +1,6 @@
 import { useAutopilotStore } from "@/stores/autopilot";
 import { useLoopStore } from "@/stores/loop";
-import { getLoopService, parseWasmAny } from "@/lib/wasm-core";
+import { getLoopState, parseWasmAny } from "@/lib/wasm-core";
 import type { DebounceRef } from "./realtimeEventHandlers";
 import {
   type RealtimeEvent,
@@ -47,7 +47,7 @@ export function handleLoopEvent(
         debounceRef.current = null;
         const s = useLoopStore.getState();
         s.fetchLoops?.();
-        const currentLoop = parseWasmAny<{ id: number; slug: string }>(getLoopService().current_loop_json());
+        const currentLoop = parseWasmAny<{ id: number; slug: string }>(getLoopState().current_loop_json());
         const loopRunData = decodeEventData(LoopRunEventDataSchema, event.data);
         if (currentLoop?.id === Number(loopRunData.loopId)) {
           s.fetchLoop?.(currentLoop.slug);

--- a/clients/web/src/stores/autopilot.ts
+++ b/clients/web/src/stores/autopilot.ts
@@ -40,7 +40,7 @@ export type AutopilotIteration = AutopilotIterationData;
 export type AutopilotThinking = AutopilotThinkingData;
 export type { CreateAutopilotControllerRequest, ApproveRequest };
 export {
-  useAutopilotControllers, useCurrentAutopilotController,
+  useAutopilotControllers, useCurrentAutopilotController, useAutopilotControllerByPodKey,
   useAutopilotIterations, useAutopilotThinking, useAutopilotThinkingHistory,
 } from "./autopilotSelectors";
 

--- a/clients/web/src/stores/autopilotSelectors.ts
+++ b/clients/web/src/stores/autopilotSelectors.ts
@@ -19,6 +19,12 @@ export function useCurrentAutopilotController(): Ctrl | null {
   return useMemo(() => parseWasmAny<Ctrl>(svc().current_controller_json()), [tick]);
 }
 
+export function useAutopilotControllerByPodKey(podKey: string): Ctrl | undefined {
+  const tick = useAutopilotStore((s) => s._tick);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return useMemo(() => useAutopilotStore.getState().getAutopilotControllerByPodKey(podKey), [tick, podKey]);
+}
+
 export function useAutopilotIterations(key: string | null | undefined): AutopilotIterationData[] {
   const tick = useAutopilotStore((s) => s._tick);
   return useMemo(() => {

--- a/runner/internal/agents/mockagent/BUILD.bazel
+++ b/runner/internal/agents/mockagent/BUILD.bazel
@@ -5,9 +5,12 @@ go_library(
     srcs = [
         "acp_control.go",
         "acp_runtime.go",
+        "claude_stream_control.go",
         "config_state.go",
+        "control_decision_engine.go",
         "emit.go",
         "env_dump.go",
+        "mcp_client.go",
         "pending_registry.go",
         "pty_runtime.go",
         "runtime_state.go",
@@ -36,12 +39,17 @@ go_test(
     srcs = [
         "acp_control_test.go",
         "acp_runtime_test.go",
+        "claude_stream_control_test.go",
+        "control_decision_engine_test.go",
         "env_dump_test.go",
+        "mcp_client_test.go",
         "pty_runtime_test.go",
         "scenarios_test.go",
     ],
     embed = [":mockagent"],
     deps = [
         "//runner/internal/acp",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/runner/internal/agents/mockagent/claude_stream_control.go
+++ b/runner/internal/agents/mockagent/claude_stream_control.go
@@ -1,0 +1,78 @@
+package mockagent
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+)
+
+const mockControlSessionID = "mock-control-001"
+
+// RunControlAgent drives the claude-stream control-agent runtime. Autopilot's
+// AcpControlProcess speaks claude's NDJSON dialect (not standard ACP JSON-RPC),
+// so this is a separate runtime from RunACP. It handshakes, then for each
+// `user` prompt asks the decision engine for the next decision (which observes
+// and drives the target pod via MCP) and emits it as an assistant message +
+// result — exactly the wire shape the real claude CLI produces.
+func RunControlAgent(mcpConfigPath string, logger *slog.Logger) int {
+	return runControlAgentWithIO(mcpConfigPath, os.Stdin, os.Stdout, logger)
+}
+
+func runControlAgentWithIO(mcpConfigPath string, in io.Reader, out io.Writer, logger *slog.Logger) int {
+	engine := newControlDecisionEngine(mcpConfigPath, logger)
+	w := &ndjsonWriter{out: out}
+
+	scanner := bufio.NewScanner(in)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+	for scanner.Scan() {
+		var msg struct {
+			Type      string `json:"type"`
+			RequestID string `json:"request_id"`
+			Message   struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &msg); err != nil {
+			continue
+		}
+		switch msg.Type {
+		case "control_request":
+			// Handshake: system/init seeds the session id; a control_response
+			// whose request_id isn't a tracked outgoing request closes the
+			// runner's initCh (see claude/handler.go handleControlResponse).
+			w.write(map[string]any{"type": "system", "subtype": "init", "session_id": mockControlSessionID})
+			w.write(map[string]any{
+				"type":     "control_response",
+				"response": map[string]any{"subtype": "success", "request_id": msg.RequestID},
+			})
+		case "user":
+			decision := engine.next(msg.Message.Content)
+			if decision != "" {
+				w.write(assistantTextMessage(decision))
+			}
+			w.write(map[string]any{"type": "result", "subtype": "success"})
+		}
+	}
+	return 0
+}
+
+type ndjsonWriter struct{ out io.Writer }
+
+func (n *ndjsonWriter) write(v any) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return
+	}
+	_, _ = n.out.Write(append(b, '\n'))
+}
+
+func assistantTextMessage(text string) map[string]any {
+	return map[string]any{
+		"type": "assistant",
+		"message": map[string]any{
+			"content": []map[string]any{{"type": "text", "text": text}},
+		},
+	}
+}

--- a/runner/internal/agents/mockagent/claude_stream_control_test.go
+++ b/runner/internal/agents/mockagent/claude_stream_control_test.go
@@ -1,0 +1,86 @@
+package mockagent
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const initLine = `{"type":"control_request","request_id":"init_1","request":{"subtype":"initialize"}}`
+
+func runControlAgent(t *testing.T, lines []string) []map[string]any {
+	t.Helper()
+	in := strings.NewReader(strings.Join(lines, "\n") + "\n")
+	var out bytes.Buffer
+	runControlAgentWithIO("", in, &out, newControlTestLogger())
+
+	var msgs []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &m))
+		msgs = append(msgs, m)
+	}
+	return msgs
+}
+
+func userLine(t *testing.T, content string) string {
+	t.Helper()
+	b, err := json.Marshal(map[string]any{
+		"type":    "user",
+		"message": map[string]any{"role": "user", "content": content},
+	})
+	require.NoError(t, err)
+	return string(b)
+}
+
+func assistantText(t *testing.T, msg map[string]any) string {
+	t.Helper()
+	m := msg["message"].(map[string]any)
+	content := m["content"].([]any)
+	require.NotEmpty(t, content)
+	return content[0].(map[string]any)["text"].(string)
+}
+
+func TestRunControlAgent_HandshakeClosesInit(t *testing.T) {
+	msgs := runControlAgent(t, []string{initLine})
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "system", msgs[0]["type"])
+	assert.Equal(t, "init", msgs[0]["subtype"])
+	assert.Equal(t, "control_response", msgs[1]["type"])
+	resp := msgs[1]["response"].(map[string]any)
+	assert.Equal(t, "success", resp["subtype"])
+	assert.Equal(t, "init_1", resp["request_id"])
+}
+
+func TestRunControlAgent_PromptEmitsDecisionThenResult(t *testing.T) {
+	script := `{"decisions":[{"type":"completed","reasoning":"all good"}]}`
+	msgs := runControlAgent(t, []string{initLine, userLine(t, script)})
+	require.Len(t, msgs, 4) // system, control_response, assistant, result
+
+	assert.Equal(t, "assistant", msgs[2]["type"])
+	var dec parsedDecision
+	require.NoError(t, json.Unmarshal([]byte(assistantText(t, msgs[2])), &dec))
+	assert.Equal(t, "completed", dec.Decision.Type)
+	assert.Equal(t, "all good", dec.Decision.Reasoning)
+
+	assert.Equal(t, "result", msgs[3]["type"])
+	assert.Equal(t, "success", msgs[3]["subtype"])
+}
+
+// An "error" decision emits a result with NO assistant message, so the runner's
+// RunControlProcess sees empty output and counts a consecutive error.
+func TestRunControlAgent_ErrorDecisionEmitsNoAssistant(t *testing.T) {
+	msgs := runControlAgent(t, []string{initLine, userLine(t, `{"decisions":[{"type":"error"}]}`)})
+	require.Len(t, msgs, 3) // system, control_response, result (no assistant)
+	assert.Equal(t, "result", msgs[2]["type"])
+	for _, m := range msgs {
+		assert.NotEqual(t, "assistant", m["type"])
+	}
+}

--- a/runner/internal/agents/mockagent/cmd/e2e-mock-agent/main.go
+++ b/runner/internal/agents/mockagent/cmd/e2e-mock-agent/main.go
@@ -25,9 +25,20 @@ import (
 func main() {
 	mode := flag.String("mode", envDefault("E2E_MOCK_MODE", "pty"), "runtime mode: pty | acp")
 	scenario := flag.String("scenario", envDefault("E2E_MOCK_SCENARIO", "echo"), "behavior scenario name")
+	// Autopilot launches its control agent as
+	// `<slug> --dangerously-skip-permissions --mcp-config <path>` (claude CLI
+	// flags, no --mode). Declaring these flags lets the parser tolerate that
+	// invocation; --dangerously-skip-permissions doubles as the signal to run
+	// the claude-stream control-agent runtime instead of a target pod.
+	controlAgent := flag.Bool("dangerously-skip-permissions", false, "run as autopilot control agent (claude-stream)")
+	mcpConfig := flag.String("mcp-config", "", "path to .mcp.json (control-agent mode)")
 	flag.Parse()
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	if *controlAgent {
+		os.Exit(mockagent.RunControlAgent(*mcpConfig, logger))
+	}
 
 	switch *mode {
 	case "pty":

--- a/runner/internal/agents/mockagent/control_decision_engine.go
+++ b/runner/internal/agents/mockagent/control_decision_engine.go
@@ -1,0 +1,109 @@
+package mockagent
+
+import (
+	"encoding/json"
+	"log/slog"
+)
+
+// controlScript is the decision program the e2e test injects via the autopilot
+// controller's control_prompt_template. The control agent receives it as the
+// first prompt, parses it once, then replays one decision per iteration.
+type controlScript struct {
+	Observe   bool              `json:"observe"`
+	Decisions []controlDecision `json:"decisions"`
+}
+
+type controlDecision struct {
+	Type      string `json:"type"`       // continue | completed | need_help | give_up | error
+	Reasoning string `json:"reasoning"`
+	SendInput string `json:"send_input"` // optional: text to drive the target pod this round
+}
+
+// controlDecisionEngine turns the injected script into the structured decision
+// JSON autopilot's DecisionParser expects, observing/driving the target pod via
+// MCP along the way. It is a long-lived per-process state machine (the control
+// agent is a persistent claude-stream session), so a plain iteration counter
+// is sufficient.
+type controlDecisionEngine struct {
+	mcp    *mcpClient
+	script controlScript
+	parsed bool
+	iter   int
+	logger *slog.Logger
+}
+
+func newControlDecisionEngine(mcpConfigPath string, logger *slog.Logger) *controlDecisionEngine {
+	return &controlDecisionEngine{
+		mcp:    newMCPClientFromConfig(mcpConfigPath),
+		logger: logger,
+	}
+}
+
+// next parses the script from the first prompt, then for each call observes +
+// drives the target pod via MCP and returns the structured decision JSON.
+func (e *controlDecisionEngine) next(prompt string) string {
+	if !e.parsed {
+		if err := json.Unmarshal([]byte(prompt), &e.script); err != nil {
+			e.logger.Warn("control script parse failed; defaulting to continue", "error", err)
+		}
+		e.parsed = true
+	}
+
+	d := e.decisionForIteration()
+	e.iter++
+
+	// "error" produces empty output, which RunControlProcess treats as a failed
+	// decision — drives the controller's consecutive-error circuit breaker.
+	if d.Type == "error" {
+		return ""
+	}
+
+	if e.mcp != nil {
+		if e.script.Observe {
+			if _, err := e.mcp.getPodSnapshot(50); err != nil {
+				e.logger.Warn("get_pod_snapshot failed", "error", err)
+			}
+			if _, err := e.mcp.getPodStatus(); err != nil {
+				e.logger.Warn("get_pod_status failed", "error", err)
+			}
+		}
+		if d.SendInput != "" {
+			if _, err := e.mcp.sendPodInput(d.SendInput); err != nil {
+				e.logger.Warn("send_pod_input failed", "error", err)
+			}
+		}
+	}
+
+	return buildDecisionJSON(d)
+}
+
+func (e *controlDecisionEngine) decisionForIteration() controlDecision {
+	if e.iter < len(e.script.Decisions) {
+		return e.script.Decisions[e.iter]
+	}
+	// Script exhausted → keep continuing so max_iterations can terminate us.
+	return controlDecision{Type: "continue", Reasoning: "script exhausted; continuing"}
+}
+
+func buildDecisionJSON(d controlDecision) string {
+	typ := d.Type
+	if typ == "" {
+		typ = "continue"
+	}
+	out := map[string]any{
+		"decision": map[string]any{
+			"type":       typ,
+			"confidence": 1.0,
+			"reasoning":  d.Reasoning,
+		},
+	}
+	if d.SendInput != "" {
+		out["action"] = map[string]any{
+			"type":    "send_input",
+			"content": d.SendInput,
+			"reason":  d.Reasoning,
+		}
+	}
+	b, _ := json.Marshal(out)
+	return string(b)
+}

--- a/runner/internal/agents/mockagent/control_decision_engine_test.go
+++ b/runner/internal/agents/mockagent/control_decision_engine_test.go
@@ -1,0 +1,111 @@
+package mockagent
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newControlTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+type parsedDecision struct {
+	Decision struct {
+		Type       string  `json:"type"`
+		Confidence float64 `json:"confidence"`
+		Reasoning  string  `json:"reasoning"`
+	} `json:"decision"`
+	Action struct {
+		Type    string `json:"type"`
+		Content string `json:"content"`
+		Reason  string `json:"reason"`
+	} `json:"action"`
+}
+
+func decodeDecision(t *testing.T, s string) parsedDecision {
+	t.Helper()
+	var d parsedDecision
+	require.NoError(t, json.Unmarshal([]byte(s), &d))
+	return d
+}
+
+func TestControlDecisionEngine_ReplaysScriptByIteration(t *testing.T) {
+	e := newControlDecisionEngine("", newControlTestLogger())
+	script := `{"decisions":[{"type":"continue","reasoning":"step1","send_input":"echo hi\n"},{"type":"completed","reasoning":"done"}]}`
+
+	d1 := decodeDecision(t, e.next(script))
+	assert.Equal(t, "continue", d1.Decision.Type)
+	assert.Equal(t, "step1", d1.Decision.Reasoning)
+	assert.Equal(t, "send_input", d1.Action.Type)
+	assert.Equal(t, "echo hi\n", d1.Action.Content)
+
+	// Resume prompt (iteration 2) is ignored — the parsed script drives it.
+	d2 := decodeDecision(t, e.next("resume prompt"))
+	assert.Equal(t, "completed", d2.Decision.Type)
+	assert.Equal(t, "done", d2.Decision.Reasoning)
+}
+
+func TestControlDecisionEngine_ExhaustedScriptContinues(t *testing.T) {
+	e := newControlDecisionEngine("", newControlTestLogger())
+	d1 := decodeDecision(t, e.next(`{"decisions":[{"type":"give_up","reasoning":"r1"}]}`))
+	assert.Equal(t, "give_up", d1.Decision.Type)
+
+	d2 := decodeDecision(t, e.next("x"))
+	assert.Equal(t, "continue", d2.Decision.Type)
+	assert.Contains(t, d2.Decision.Reasoning, "exhausted")
+}
+
+func TestControlDecisionEngine_ParseFailDefaultsContinue(t *testing.T) {
+	e := newControlDecisionEngine("", newControlTestLogger())
+	d := decodeDecision(t, e.next("not json at all"))
+	assert.Equal(t, "continue", d.Decision.Type)
+}
+
+func TestControlDecisionEngine_ErrorYieldsEmptyOutput(t *testing.T) {
+	e := newControlDecisionEngine("", newControlTestLogger())
+	assert.Equal(t, "", e.next(`{"decisions":[{"type":"error"}]}`))
+}
+
+// TestControlDecisionEngine_DrivesPodViaMCP proves the control agent really
+// observes + drives the target pod over MCP (the full-chain requirement).
+func TestControlDecisionEngine_DrivesPodViaMCP(t *testing.T) {
+	type call struct {
+		name string
+		args map[string]any
+	}
+	var calls []call
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "pod-target", r.Header.Get("X-Pod-Key"))
+		var body struct {
+			Params struct {
+				Name      string         `json:"name"`
+				Arguments map[string]any `json:"arguments"`
+			} `json:"params"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		calls = append(calls, call{body.Params.Name, body.Params.Arguments})
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0", "id": 1,
+			"result": map[string]any{"content": []map[string]any{{"type": "text", "text": "ok"}}},
+		})
+	}))
+	defer srv.Close()
+
+	path := writeMCPConfig(t, srv.URL, "pod-target")
+	e := newControlDecisionEngine(path, newControlTestLogger())
+	_ = e.next(`{"observe":true,"decisions":[{"type":"continue","send_input":"echo go\n"}]}`)
+
+	require.Len(t, calls, 3)
+	assert.Equal(t, "get_pod_snapshot", calls[0].name)
+	assert.Equal(t, "get_pod_status", calls[1].name)
+	assert.Equal(t, "send_pod_input", calls[2].name)
+	assert.Equal(t, "echo go\n", calls[2].args["text"])
+	assert.Equal(t, "pod-target", calls[2].args["pod_key"])
+}

--- a/runner/internal/agents/mockagent/mcp_client.go
+++ b/runner/internal/agents/mockagent/mcp_client.go
@@ -1,0 +1,107 @@
+package mockagent
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+// mcpClient is a minimal MCP-over-HTTP JSON-RPC 2.0 client the control agent
+// uses to observe and drive the target pod, mirroring how the real claude CLI
+// calls the autopilot-control MCP server.
+type mcpClient struct {
+	url    string
+	podKey string // X-Pod-Key = the target pod this control agent supervises
+	http   *http.Client
+	nextID int
+}
+
+// newMCPClientFromConfig reads the .mcp.json the runner generated (via
+// --mcp-config) and extracts the autopilot-control url + X-Pod-Key. Returns
+// nil when the config is missing/unparseable — the control agent then runs
+// blind (decisions still flow, the pod just isn't observed/driven).
+func newMCPClientFromConfig(path string) *mcpClient {
+	if path == "" {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var cfg struct {
+		MCPServers map[string]struct {
+			URL     string            `json:"url"`
+			Headers map[string]string `json:"headers"`
+		} `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil
+	}
+	srv, ok := cfg.MCPServers["autopilot-control"]
+	if !ok || srv.URL == "" {
+		return nil
+	}
+	return &mcpClient{
+		url:    srv.URL,
+		podKey: srv.Headers["X-Pod-Key"],
+		http:   &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (c *mcpClient) callTool(name string, args map[string]any) (string, error) {
+	c.nextID++
+	reqBody, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      c.nextID,
+		"method":  "tools/call",
+		"params":  map[string]any{"name": name, "arguments": args},
+	})
+	req, err := http.NewRequest(http.MethodPost, c.url, bytes.NewReader(reqBody))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Pod-Key", c.podKey)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var out struct {
+		Result struct {
+			Content []struct {
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"result"`
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", err
+	}
+	if out.Error != nil {
+		return "", fmt.Errorf("mcp error: %s", out.Error.Message)
+	}
+	if len(out.Result.Content) > 0 {
+		return out.Result.Content[0].Text, nil
+	}
+	return "", nil
+}
+
+func (c *mcpClient) getPodSnapshot(lines int) (string, error) {
+	return c.callTool("get_pod_snapshot", map[string]any{"pod_key": c.podKey, "lines": lines})
+}
+
+func (c *mcpClient) sendPodInput(text string) (string, error) {
+	return c.callTool("send_pod_input", map[string]any{"pod_key": c.podKey, "text": text})
+}
+
+func (c *mcpClient) getPodStatus() (string, error) {
+	return c.callTool("get_pod_status", map[string]any{"pod_key": c.podKey})
+}

--- a/runner/internal/agents/mockagent/mcp_client_test.go
+++ b/runner/internal/agents/mockagent/mcp_client_test.go
@@ -1,0 +1,119 @@
+package mockagent
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeMCPConfig writes a .mcp.json matching what the runner generates and
+// returns its path. Shared by the engine + client tests.
+func writeMCPConfig(t *testing.T, url, podKey string) string {
+	t.Helper()
+	cfg := map[string]any{
+		"mcpServers": map[string]any{
+			"autopilot-control": map[string]any{
+				"type":    "http",
+				"url":     url,
+				"headers": map[string]string{"Content-Type": "application/json", "X-Pod-Key": podKey},
+			},
+		},
+	}
+	b, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), ".mcp.json")
+	require.NoError(t, os.WriteFile(path, b, 0o644))
+	return path
+}
+
+func TestNewMCPClientFromConfig(t *testing.T) {
+	path := writeMCPConfig(t, "http://127.0.0.1:19000/mcp", "pod-abc")
+	c := newMCPClientFromConfig(path)
+	require.NotNil(t, c)
+	assert.Equal(t, "http://127.0.0.1:19000/mcp", c.url)
+	assert.Equal(t, "pod-abc", c.podKey)
+}
+
+func TestNewMCPClientFromConfig_MissingReturnsNil(t *testing.T) {
+	assert.Nil(t, newMCPClientFromConfig(""))
+	assert.Nil(t, newMCPClientFromConfig(filepath.Join(t.TempDir(), "nope.json")))
+}
+
+func TestMCPClient_CallToolSendsJSONRPC(t *testing.T) {
+	var gotName, gotPodKey string
+	var gotArgs map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPodKey = r.Header.Get("X-Pod-Key")
+		var body struct {
+			Method string `json:"method"`
+			Params struct {
+				Name      string         `json:"name"`
+				Arguments map[string]any `json:"arguments"`
+			} `json:"params"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "tools/call", body.Method)
+		gotName = body.Params.Name
+		gotArgs = body.Params.Arguments
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0", "id": 1,
+			"result": map[string]any{"content": []map[string]any{{"type": "text", "text": "snapshot text"}}},
+		})
+	}))
+	defer srv.Close()
+
+	c := &mcpClient{url: srv.URL, podKey: "pod-x", http: srv.Client()}
+	out, err := c.getPodSnapshot(50)
+	require.NoError(t, err)
+	assert.Equal(t, "snapshot text", out)
+	assert.Equal(t, "get_pod_snapshot", gotName)
+	assert.Equal(t, "pod-x", gotPodKey)
+	assert.Equal(t, "pod-x", gotArgs["pod_key"])
+	assert.EqualValues(t, 50, gotArgs["lines"])
+}
+
+func TestMCPClient_GetPodStatusSendsPodKey(t *testing.T) {
+	var gotName, gotPodKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPodKey = r.Header.Get("X-Pod-Key")
+		var body struct {
+			Params struct {
+				Name string `json:"name"`
+			} `json:"params"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		gotName = body.Params.Name
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0", "id": 1,
+			"result": map[string]any{"content": []map[string]any{{"type": "text", "text": "running"}}},
+		})
+	}))
+	defer srv.Close()
+
+	c := &mcpClient{url: srv.URL, podKey: "pod-z", http: srv.Client()}
+	out, err := c.getPodStatus()
+	require.NoError(t, err)
+	assert.Equal(t, "running", out)
+	assert.Equal(t, "get_pod_status", gotName)
+	assert.Equal(t, "pod-z", gotPodKey)
+}
+
+func TestMCPClient_CallToolPropagatesError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0", "id": 1,
+			"error": map[string]any{"code": -32602, "message": "bad pod"},
+		})
+	}))
+	defer srv.Close()
+	c := &mcpClient{url: srv.URL, podKey: "pod-x", http: srv.Client()}
+	_, err := c.sendPodInput("hi")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bad pod")
+}

--- a/runner/internal/agents/mockagent/pty_runtime.go
+++ b/runner/internal/agents/mockagent/pty_runtime.go
@@ -78,7 +78,7 @@ func promptEchoLoop(in io.Reader, out io.Writer, turnDelay time.Duration) {
 		if turnDelay > 0 {
 			time.Sleep(turnDelay)
 		}
-		fmt.Fprint(out, autopilotPrompt)
+		_, _ = fmt.Fprint(out, autopilotPrompt)
 	}
 }
 

--- a/runner/internal/agents/mockagent/pty_runtime.go
+++ b/runner/internal/agents/mockagent/pty_runtime.go
@@ -9,6 +9,9 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
 )
 
 // RunPTY drives the PTY-mode runtime. It writes "ready" to signal liveness
@@ -22,12 +25,33 @@ func RunPTY(scenario string, logger *slog.Logger) int {
 	return runPTYWithIO(scenario, os.Stdin, os.Stdout, os.Environ(), logger)
 }
 
+// "❯" is in detector.promptEndSymbols → the PTY state detector scores the
+// trailing screen line as a prompt and transitions the pod to "waiting".
+const autopilotPrompt = "❯ "
+
+// autopilotTurnDelay lands the executing→waiting edge past the
+// AutopilotController's 5s MinTriggerGap; an instant echo gets deduped.
+const autopilotTurnDelay = 6 * time.Second
+
 func runPTYWithIO(scenario string, in io.Reader, out io.Writer, env []string, logger *slog.Logger) int {
 	switch scenario {
 	case "", "echo":
 		_, _ = fmt.Fprintln(out, "ready")
 		writeEnvDump(env)
 		echoLoop(in, out)
+		return 0
+	case "autopilot":
+		_, _ = fmt.Fprintln(out, "ready")
+		writeEnvDump(env)
+		_, _ = fmt.Fprint(out, autopilotPrompt)
+		promptEchoLoop(in, out, autopilotTurnDelay)
+		return 0
+	case "autopilot_fs":
+		seedSandboxGitChange()
+		_, _ = fmt.Fprintln(out, "ready")
+		writeEnvDump(env)
+		_, _ = fmt.Fprint(out, autopilotPrompt)
+		promptEchoLoop(in, out, autopilotTurnDelay)
 		return 0
 	default:
 		_, _ = fmt.Fprintf(out, "unknown PTY scenario: %s\n", scenario)
@@ -42,4 +66,32 @@ func echoLoop(in io.Reader, out io.Writer) {
 	for scanner.Scan() {
 		fmt.Fprintf(out, "got: %s\n", scanner.Text())
 	}
+}
+
+// Echo, hold for turnDelay (the non-prompt "got:" line keeps the pod
+// executing), then print the prompt to drive the executing→waiting edge.
+func promptEchoLoop(in io.Reader, out io.Writer, turnDelay time.Duration) {
+	scanner := bufio.NewScanner(in)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		fmt.Fprintf(out, "got: %s\n", scanner.Text())
+		if turnDelay > 0 {
+			time.Sleep(turnDelay)
+		}
+		fmt.Fprint(out, autopilotPrompt)
+	}
+}
+
+// seedSandboxGitChange git-inits the pod's SandboxPath (parent of the agent's
+// cwd) and drops a probe file there, so the AutopilotController's
+// ProgressTracker (`git status` in SandboxPath) reports a non-empty
+// files_changed on its iterations.
+func seedSandboxGitChange() {
+	wd, err := os.Getwd()
+	if err != nil {
+		return
+	}
+	sandbox := filepath.Dir(wd)
+	_ = exec.Command("git", "-C", sandbox, "init").Run()
+	_ = os.WriteFile(filepath.Join(sandbox, "autopilot-probe.txt"), []byte("probe\n"), 0o644)
 }

--- a/runner/internal/agents/mockagent/pty_runtime_test.go
+++ b/runner/internal/agents/mockagent/pty_runtime_test.go
@@ -45,6 +45,24 @@ func TestRunPTY_UnknownScenario(t *testing.T) {
 	}
 }
 
+// The autopilot scenario must echo `got: <line>` then leave a prompt symbol as
+// the trailing screen line so the runner's PTY state detector classifies the
+// pod as waiting. Without it the AutopilotController never fires an iteration.
+// Tested via promptEchoLoop directly (turnDelay=0) to avoid the production
+// turn delay that holds the pod executing past the controller's MinTriggerGap.
+func TestPromptEchoLoop_EchoesThenPrompt(t *testing.T) {
+	in := strings.NewReader("echo step1\necho step2\n")
+	var out bytes.Buffer
+	promptEchoLoop(in, &out, 0)
+	got := out.String()
+	if !strings.Contains(got, "got: echo step1\n") || !strings.Contains(got, "got: echo step2\n") {
+		t.Errorf("missing echo round-trips: %q", got)
+	}
+	if !strings.HasSuffix(got, autopilotPrompt) {
+		t.Errorf("output must end with prompt %q, got tail %q", autopilotPrompt, got)
+	}
+}
+
 func TestEchoLoop_PreservesLineOrder(t *testing.T) {
 	in := strings.NewReader("a\nb\nc\n")
 	var out bytes.Buffer


### PR DESCRIPTION
## What

Systematic autopilot review → fix bugs → comprehensive end-to-end coverage. The autopilot decision loop (status/iteration/thinking) was previously **never** E2E-tested (the existing `autopilot-events-wire.spec.ts` covered only `autopilot:created`, rest marked Out-of-Scope).

## Bugs fixed
- **BUG-1** — `autopilot_iterations.autopilot_id` → `autopilot_controller_id` (migration `000158`). Iteration history read/write was broken in production; testkit's schema masked it.
- **BUG-2** — nil-guard 3 runner autopilot callback handlers (`GetByKey` returns `(nil, nil)` on missing record; handlers only checked `err`).
- **UI infinite render loop** — `AutopilotOverlay` "Maximum update depth": `getAutopilotControllerByPodKey` returns a fresh object each call → loops under zustand v5's bare `useSyncExternalStore`. Fixed with a stable `useAutopilotControllerByPodKey` (`_tick`+`useMemo`).

## E2E infrastructure (zero autopilot prod-logic change)
- `e2e-mock-agent` doubles as the **claude-stream control agent** (MCP-driven): `claude_stream_control` / `mcp_client` / `control_decision_engine` + `autopilot`/`autopilot_fs` PTY target scenarios.
- **19 web e2e**: decision loop (continue/completed/need_help/give_up/error), control actions (pause/resume/stop/takeover/handback/approve±), wire events, GetIterations history (closes BUG-1 E2E), circuit breaker, concurrency, pod-terminate teardown, ProgressTracker `files_changed`, deep UI (status bar + pause/resume button round-trips + panel).
- **1 desktop e2e**: autopilot events reach the renderer via the IPC bridge + electron-adapter fetch path.
- backend handler + mockagent unit tests.

## Verification (all via bazel)
- `bazel test //clients/web/e2e-playwright:e2e --test_arg=tests/autopilot/` → 19 passed
- `bazel test //clients/desktop:e2e --test_arg=autopilot-events-bridge` → passed
- `bazel test //runner/internal/agents/mockagent:mockagent_test //backend/internal/service/runner:runner_test` → passed

## Not covered (rationale)
- runner-disconnect: killing the runner container in the shared dev env disrupts other pods/tests; needs an isolated/disposable runner.