### PR TITLE
docs: add Homebrew cask install instructions

### DIFF
--- a/runner/README.md
+++ b/runner/README.md
@@ -22,6 +22,13 @@ AgentsMesh Runner is a lightweight agent that connects to the AgentsMesh server 
 curl -fsSL https://agentsmesh.ai/install.sh | sh
 ```
 
+### macOS (binary)
+
+On macOS, you can also install the AgentsMesh binary using [Homebrew](https://brew.sh/):
+```bash
+brew install --cask agentsmesh
+```
+
 ### Windows (PowerShell)
 
 ```powershell


### PR DESCRIPTION
## Summary

- Updated the Runner documentation with the new installation details.
- This change was needed because the root `README.md` already points users to `runner/README.md` for additional installation options such as deb, rpm, and Windows, so the detailed instructions belong there instead of the root README.

## Changes

- Updated `runner/README.md` with the relevant installation documentation.
- Left the root `README.md` unchanged because it already links to the Runner README for more installation options.
- Did not update files under `clients/web/src` because I was not able to identify the correct place for a related web UI change.

  ## Validation

- [ ] Backend tests (`bazel test //backend/...`)
- [ ] Web checks (`bazel test //clients/web:lint //clients/web:unit && bazel build //clients/web:src`)
- [ ] Runner checks (`bazel test //runner/...`)
- [ ] Manual validation performed (if applicable)

## Documentation

- [x] Docs updated (README/docs/inline comments)
- [ ] No docs changes needed

## Risk and Rollback

- Risk level: Low
- Rollback plan: Revert the documentation update in `runner/README.md`.

- No `clients/web/src` changes were made because I could not determine a clear or appropriate web UI location for this update.
