### PR TITLE
fix(desktop): heal 24h token-expiry workspace whitescreen

### DIFF
--- a/clients/desktop/src/main/connect-fetch.ts
+++ b/clients/desktop/src/main/connect-fetch.ts
@@ -1,0 +1,44 @@
+// Node's global fetch (undici) reuses pooled keep-alive sockets with no idle
+// health-check: after OS sleep / a network switch the next reuse of a now-dead
+// socket throws `TypeError: fetch failed`, and with no timeout a hung connect
+// blocks forever. Both surfaced in the renderer as a failed Connect-RPC that
+// cascaded into a blank workspace. One retry forces undici onto a fresh socket
+// — the actual fix for the stale-socket case — and an abort timeout bounds the
+// hang. Shared by both main-process Connect callers (connectCall + the legacy
+// JSON aliases) so the retry/timeout policy can't drift between them.
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const RETRY_BACKOFF_MS = 300;
+
+// HTTP 4xx/5xx never reach here — callers check `res.ok` and throw themselves —
+// so a TypeError (undici transport failure) or AbortError is the only thing
+// that lands in catch, and re-attempting it can never replay a real response.
+function isTransientNetworkError(err: unknown): boolean {
+  if (err instanceof TypeError) return true;
+  return err instanceof Error && err.name === "AbortError";
+}
+
+export async function connectFetch(
+  url: string,
+  init: RequestInit,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<Response> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      return await fetch(url, { ...init, signal: controller.signal });
+    } catch (err) {
+      lastErr = err;
+      if (attempt === 0 && isTransientNetworkError(err)) {
+        await new Promise((r) => setTimeout(r, RETRY_BACKOFF_MS));
+        continue;
+      }
+      throw err;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+  throw lastErr;
+}

--- a/clients/desktop/src/main/index.ts
+++ b/clients/desktop/src/main/index.ts
@@ -9,6 +9,7 @@ import { acquireSingleInstance } from "./single_instance";
 import { IPC_ALLOWLIST, IPC_ALLOWLIST_SET } from "./ipc-allowlist.generated";
 import { setupRealtimeBridge, type RealtimeBridge } from "./realtime";
 import { setupRelayBridge, type RelayBridge } from "./relay";
+import { connectFetch } from "./connect-fetch";
 import {
   registerProtocol,
   attachSecondInstanceUrlHandler,
@@ -275,7 +276,7 @@ function registerLegacyApiAliases() {
       "Connect-Protocol-Version": "1",
     };
     if (token) headers.Authorization = `Bearer ${token}`;
-    const res = await fetch(url, {
+    const res = await connectFetch(url, {
       method: "POST",
       headers,
       body: JSON.stringify(payload),
@@ -556,7 +557,7 @@ function registerLegacyApiAliases() {
       "Connect-Protocol-Version": "1",
     };
     if (token) headers.Authorization = `Bearer ${token}`;
-    const res = await fetch(url, {
+    const res = await connectFetch(url, {
       method: "POST",
       headers,
       body: Uint8Array.from(bodyArr),

--- a/clients/desktop/src/renderer/components/RootErrorBoundary.tsx
+++ b/clients/desktop/src/renderer/components/RootErrorBoundary.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+
+interface State {
+  error: Error | null;
+}
+
+// RouterProvider's per-route errorElement cannot catch throws from the
+// providers mounted ABOVE it (AppProviders / QueryClient) nor from an
+// errorElement that itself throws — those unwind to the root and blank the
+// window. This boundary is the last resort. It deliberately uses inline styles
+// and hard-coded copy: ThemeProvider / Tailwind / next-intl may be the very
+// thing that crashed, so the fallback must not depend on any of them.
+export class RootErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  State
+> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    console.error("[root-error-boundary]", error, info.componentStack);
+  }
+
+  render(): React.ReactNode {
+    if (!this.state.error) return this.props.children;
+    return (
+      <div style={WRAP}>
+        <div style={CARD}>
+          <h1 style={TITLE}>Something went wrong</h1>
+          <p style={MESSAGE}>{this.state.error.message}</p>
+          <button style={BUTTON} onClick={() => window.location.reload()}>
+            Reload
+          </button>
+        </div>
+      </div>
+    );
+  }
+}
+
+const WRAP: React.CSSProperties = {
+  display: "flex", height: "100vh", width: "100vw",
+  alignItems: "center", justifyContent: "center",
+  background: "#0a0a0a", color: "#e5e5e5",
+  fontFamily: "system-ui, -apple-system, sans-serif", padding: 24,
+};
+const CARD: React.CSSProperties = { maxWidth: 420, textAlign: "center" };
+const TITLE: React.CSSProperties = { fontSize: 18, fontWeight: 600, marginBottom: 8 };
+const MESSAGE: React.CSSProperties = {
+  fontSize: 13, color: "#a3a3a3", marginBottom: 20, wordBreak: "break-word",
+};
+const BUTTON: React.CSSProperties = {
+  padding: "8px 16px", fontSize: 13, borderRadius: 6,
+  border: "1px solid #404040", background: "#171717",
+  color: "#e5e5e5", cursor: "pointer",
+};

--- a/clients/desktop/src/renderer/main.tsx
+++ b/clients/desktop/src/renderer/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AppProviders } from "./providers/AppProviders";
+import { RootErrorBoundary } from "./components/RootErrorBoundary";
 import { router } from "./router";
 import "./lib/platform-init";
 import "./globals.css";
@@ -37,10 +38,12 @@ if (typeof window !== "undefined" && window.electronAPI?.onOAuthCallback) {
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <AppProviders>
-        <RouterProvider router={router} />
-      </AppProviders>
-    </QueryClientProvider>
+    <RootErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <AppProviders>
+          <RouterProvider router={router} />
+        </AppProviders>
+      </QueryClientProvider>
+    </RootErrorBoundary>
   </React.StrictMode>,
 );

--- a/clients/desktop/src/renderer/pages/layouts/DashboardShell.tsx
+++ b/clients/desktop/src/renderer/pages/layouts/DashboardShell.tsx
@@ -8,7 +8,7 @@ import {
 import { ResponsiveShell } from "@/components/layout";
 import { Spinner } from "@/components/ui/spinner";
 import { RealtimeProvider } from "@/providers/RealtimeProvider";
-import { useBrowserNotification } from "@/hooks";
+import { useBrowserNotification, useSessionKeepAlive } from "@/hooks";
 import { handleNotificationEvent } from "@/stores/notificationHandler";
 import type { RealtimeEvent } from "@/lib/realtime";
 
@@ -25,12 +25,19 @@ export function DashboardShell({
   const organizations = useAuthOrganizations();
   const currentOrg = useCurrentOrg();
   const { permission, showNotification, requestPermission } = useBrowserNotification();
+  useSessionKeepAlive();
+
+  // Evaluate per-render so token expiry (a time-driven flip with no store
+  // event) becomes an effect-dependency change. Calling isAuthenticated
+  // directly in the effect dep list keeps a stable fn ref, so the redirect
+  // would never re-run and the shell would sit blank on an expired session.
+  const authed = isAuthenticated();
 
   useEffect(() => {
-    if (_hasHydrated && !isAuthenticated()) {
+    if (_hasHydrated && !authed) {
       router.push("/login");
     }
-  }, [_hasHydrated, isAuthenticated, router]);
+  }, [_hasHydrated, authed, router]);
 
   useEffect(() => {
     const orgSlug = params.org;
@@ -69,16 +76,14 @@ export function DashboardShell({
     [showNotification, router, currentOrg]
   );
 
-  if (!_hasHydrated) {
+  // Not-hydrated and expired-session both park on a spinner; the redirect
+  // effect above carries an expired session on to /login.
+  if (!_hasHydrated || !authed) {
     return (
       <div className="flex h-screen items-center justify-center bg-background">
         <Spinner />
       </div>
     );
-  }
-
-  if (!isAuthenticated()) {
-    return null;
   }
 
   return (

--- a/clients/web/src/hooks/__tests__/useSessionKeepAlive.test.ts
+++ b/clients/web/src/hooks/__tests__/useSessionKeepAlive.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+const { mockRefreshSession } = vi.hoisted(() => ({ mockRefreshSession: vi.fn() }));
+
+vi.mock("@/stores/auth", () => ({
+  useAuthStore: (selector: (s: { refreshSession: () => Promise<void> }) => unknown) =>
+    selector({ refreshSession: mockRefreshSession }),
+}));
+
+import { useSessionKeepAlive } from "../useSessionKeepAlive";
+
+const INTERVAL_MS = 30 * 60 * 1000;
+
+function setVisibility(state: DocumentVisibilityState) {
+  Object.defineProperty(document, "visibilityState", { value: state, configurable: true });
+}
+
+describe("useSessionKeepAlive", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockRefreshSession.mockReset().mockResolvedValue(undefined);
+    setVisibility("visible");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("refreshes when the window regains focus", () => {
+    renderHook(() => useSessionKeepAlive());
+    window.dispatchEvent(new Event("focus"));
+    expect(mockRefreshSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes when the document becomes visible", () => {
+    renderHook(() => useSessionKeepAlive());
+    setVisibility("visible");
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(mockRefreshSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not refresh while the document is hidden", () => {
+    renderHook(() => useSessionKeepAlive());
+    setVisibility("hidden");
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(mockRefreshSession).not.toHaveBeenCalled();
+  });
+
+  it("refreshes on the interval while foregrounded", () => {
+    renderHook(() => useSessionKeepAlive());
+    vi.advanceTimersByTime(INTERVAL_MS);
+    expect(mockRefreshSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops refreshing after unmount", () => {
+    const { unmount } = renderHook(() => useSessionKeepAlive());
+    unmount();
+    window.dispatchEvent(new Event("focus"));
+    vi.advanceTimersByTime(INTERVAL_MS);
+    expect(mockRefreshSession).not.toHaveBeenCalled();
+  });
+
+  it("swallows a rejected refresh so it never throws", () => {
+    mockRefreshSession.mockRejectedValue(new Error("network down"));
+    renderHook(() => useSessionKeepAlive());
+    expect(() => window.dispatchEvent(new Event("focus"))).not.toThrow();
+  });
+});

--- a/clients/web/src/hooks/index.ts
+++ b/clients/web/src/hooks/index.ts
@@ -16,5 +16,7 @@ export { useTouchScroll } from './useTouchScroll';
 export { useBrowserNotification } from './useBrowserNotification';
 export type { BrowserNotificationOptions } from './useBrowserNotification';
 
+export { useSessionKeepAlive } from './useSessionKeepAlive';
+
 export { useMentionCandidates } from './useMentionCandidates';
 export type { MentionItem } from './useMentionCandidates';

--- a/clients/web/src/hooks/useSessionKeepAlive.ts
+++ b/clients/web/src/hooks/useSessionKeepAlive.ts
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+import { useAuthStore } from "@/stores/auth";
+
+// Access tokens expire (backend JWT TTL is 24h) and nothing rotates them while
+// the app stays open, so once the TTL elapses the session reads as expired and
+// the dashboard blanks. Proactively refresh: on regaining foreground (covers
+// the OS-sleep / window-switch case, the dominant 24h trigger) and on a coarse
+// interval for an always-foreground window.
+const REFRESH_INTERVAL_MS = 30 * 60 * 1000;
+
+export function useSessionKeepAlive(): void {
+  const refreshSession = useAuthStore((s) => s.refreshSession);
+
+  useEffect(() => {
+    let disposed = false;
+    // Transient failures are swallowed — the next focus/interval retries. A
+    // hard failure (refresh token also expired) flips is_authenticated to
+    // false, which DashboardShell turns into a redirect to /login.
+    const refresh = () => {
+      if (!disposed) void refreshSession().catch(() => {});
+    };
+    const onVisible = () => {
+      if (document.visibilityState === "visible") refresh();
+    };
+
+    document.addEventListener("visibilitychange", onVisible);
+    window.addEventListener("focus", onVisible);
+    const timer = window.setInterval(refresh, REFRESH_INTERVAL_MS);
+
+    return () => {
+      disposed = true;
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("focus", onVisible);
+      window.clearInterval(timer);
+    };
+  }, [refreshSession]);
+}

--- a/clients/web/src/stores/auth.ts
+++ b/clients/web/src/stores/auth.ts
@@ -178,8 +178,13 @@ export const useAuthStore = create<AuthState>((set) => ({
     await initWasmCore();
     try {
       await mgr().refresh_token();
+      bump();
     } catch (e) {
       set({ error: getErrorMessage(e, "Session refresh failed") });
+      // Bump even on failure: keepalive callers swallow the throw, so this
+      // tick is what lets DashboardShell re-evaluate is_authenticated and
+      // redirect once the refresh token is also dead.
+      bump();
       throw e;
     }
   },


### PR DESCRIPTION
## Problem

Desktop sessions left open past the 24h JWT access-token TTL (or resumed after OS sleep) blank the entire workspace and log `Failed to load runner: connectCall: TypeError: fetch failed` — completely unusable until restart.

## Root cause (four compounding defects)

1. **No proactive token refresh** — `bootstrap()` runs once at cold start (PlatformGate `useEffect([])`); nothing refreshes the token during a long-running session, so once the 24h TTL elapses `is_authenticated()` flips false.
2. **Blank shell, no redirect** — `DashboardShell` rendered `null` on expiry and its redirect `useEffect` depended only on stable refs, so the time-driven expiry never re-ran it → blank, never navigated to `/login`.
3. **`fetch failed`, not 401** — main-process `connectCall`/`callConnectJson` used bare `fetch` with no timeout/retry; after OS sleep undici's keep-alive pool reuses a dead socket → `TypeError: fetch failed` (HTTP 401 takes the `!res.ok` path, confirming a transport failure).
4. **No top-level ErrorBoundary** — `RouteErrorBoundary` cannot catch throws above `RouterProvider`.

## Fix

- **`useSessionKeepAlive`** — refresh on focus/visibility (covers OS-sleep wake) + coarse interval
- **`DashboardShell`** — per-render `authed` as effect dep + spinner fallback (no more `null`); `refreshSession` bumps the tick on success/failure so expiry is re-evaluated
- **`connect-fetch.ts`** — `AbortController` timeout + one transient-failure retry (the retry forces undici onto a fresh socket — the actual stale-socket fix); shared by both Connect callers
- **`RootErrorBoundary`** — theme/i18n-independent last-resort fallback with a Reload action

## Verification

- `bazel build //clients/web:src` (tsc) ✅
- `bazel build //clients/desktop:out` (main + renderer compile) ✅
- `bazel test //clients/web:unit` ✅ — 6 new `useSessionKeepAlive` cases + zero auth-store regression

## Notes

- **Web is unaffected**: its auth guard keys off `user`, not `expires_at`, and browser fetch has no stale-socket issue. `useSessionKeepAlive` lives in shared `@/hooks` but is mounted only in desktop.
- Desktop e2e not run (heavy env deps); covered by full compile.
