### PR TITLE
feat(observability): comprehensive desktop + core logging coverage

### DIFF
--- a/clients/core/crates/api-client/src/connect_call.rs
+++ b/clients/core/crates/api-client/src/connect_call.rs
@@ -29,6 +29,7 @@ where
 {
     let url = format!("{}{}", client.base_url, procedure);
     let payload = body.encode_to_vec();
+    tracing::debug!(target: "api", procedure, bytes = payload.len(), "connect_call →");
 
     let mut builder = client
         .http
@@ -60,6 +61,7 @@ where
     if !status.is_success() {
         let status_code = status.as_u16();
         if status_code == 401 {
+            tracing::warn!(target: "api", procedure, "connect_call ← 401 auth expired");
             return Err(ApiError::AuthExpired);
         }
         let status_text = status
@@ -78,6 +80,13 @@ where
             .and_then(|b| std::str::from_utf8(b).ok())
             .filter(|s| !s.is_empty())
             .map(String::from);
+        tracing::warn!(
+            target: "api",
+            procedure,
+            status = status_code,
+            message = server_message.as_deref().unwrap_or(""),
+            "connect_call ← error"
+        );
         return Err(ApiError::Http {
             status: status_code,
             status_text,
@@ -89,5 +98,6 @@ where
     }
 
     let resp_bytes = resp.bytes().await?;
+    tracing::debug!(target: "api", procedure, status = status.as_u16(), bytes = resp_bytes.len(), "connect_call ← ok");
     Res::decode(resp_bytes).map_err(|e| ApiError::Decode(format!("prost decode: {e}")))
 }

--- a/clients/core/crates/api-client/src/refresh.rs
+++ b/clients/core/crates/api-client/src/refresh.rs
@@ -1,6 +1,6 @@
 use prost::Message;
 use reqwest::header::{HeaderName, HeaderValue};
-use tracing::warn;
+use tracing::{debug, info, warn};
 
 use crate::client::ApiClient;
 use agentsmesh_types::proto_auth_v1 as auth_proto;
@@ -24,6 +24,7 @@ impl ApiClient {
         // `/api/v1/auth/refresh` handler is gone. Proto.auth.v1 owns the
         // refresh data plane (see backend/internal/api/connect/auth).
         let req = auth_proto::RefreshTokenRequest { refresh_token };
+        debug!(target: "auth", "refreshing access token");
         let url = format!(
             "{}/proto.auth.v1.AuthService/RefreshToken",
             self.base_url
@@ -47,6 +48,7 @@ impl ApiClient {
             Ok(resp) if resp.status().is_success() => match resp.bytes().await {
                 Ok(body) => match auth_proto::RefreshTokenResponse::decode(body) {
                     Ok(data) => {
+                        info!(target: "auth", expires_in = data.expires_in, "access token refreshed");
                         self.auth_store.set_tokens(
                             data.token,
                             data.refresh_token,

--- a/clients/core/crates/events/src/subscription_manager.rs
+++ b/clients/core/crates/events/src/subscription_manager.rs
@@ -236,6 +236,7 @@ pub(crate) fn set_state(inner: &Arc<RwLock<Inner>>, state: ConnectionState) {
 }
 
 pub(crate) fn dispatch_event(inner: &Arc<RwLock<Inner>>, event: &RealtimeEvent) {
+    tracing::debug!(target: "events", event_type = ?event.event_type, "dispatch");
     // Step 1: Rust-SSOT dispatch hook applies event to AppState. We clone
     // the Arc out under read lock, then drop the events-side lock before
     // calling the hook — the hook will acquire its own AppState write

--- a/clients/core/crates/logging/src/init.rs
+++ b/clients/core/crates/logging/src/init.rs
@@ -45,8 +45,33 @@ pub fn init(config: LogConfig) -> Result<(), LogError> {
     Ok(())
 }
 
+// Third-party crates flood debug/trace (hyper wire dumps, rustls handshake,
+// tokio scheduler) and bury our own logs. A bare debug/trace level is scoped to
+// our crates and clamps these to info. A directive already targeting crates
+// (`=` present) or listing several (`,` present) is honored verbatim — RUST_LOG
+// / power-user overrides keep full control.
+const NOISY_CRATES: &[&str] = &[
+    "hyper", "h2", "rustls", "tokio", "tungstenite", "tokio_tungstenite", "reqwest", "tower", "mio",
+    "want", "tonic",
+];
+
+fn scoped_spec(level: &str) -> String {
+    let level = level.trim();
+    if !matches!(level, "debug" | "trace") {
+        return level.to_string();
+    }
+    let mut s = String::with_capacity(level.len() + NOISY_CRATES.len() * 12);
+    s.push_str(level);
+    for c in NOISY_CRATES {
+        s.push(',');
+        s.push_str(c);
+        s.push_str("=info");
+    }
+    s
+}
+
 fn parse_filter(config: &LogConfig) -> Result<EnvFilter, LogError> {
-    EnvFilter::try_new(&config.level).map_err(|e| LogError::InvalidLevel(e.to_string()))
+    EnvFilter::try_new(scoped_spec(&config.level)).map_err(|e| LogError::InvalidLevel(e.to_string()))
 }
 
 #[cfg(test)]
@@ -70,5 +95,27 @@ mod tests {
         let cfg = LogConfig::console("=invalid=garbage=");
         let err = parse_filter(&cfg).err();
         assert!(matches!(err, Some(LogError::InvalidLevel(_))));
+    }
+
+    #[test]
+    fn bare_debug_scopes_noisy_crates() {
+        let spec = scoped_spec("debug");
+        assert!(spec.starts_with("debug,"), "spec: {spec}");
+        assert!(spec.contains("hyper=info"), "spec: {spec}");
+        assert!(spec.contains("rustls=info"), "spec: {spec}");
+        // our own crates keep the bare debug level — no clamp injected for them
+        assert!(!spec.contains("agentsmesh"), "spec: {spec}");
+    }
+
+    #[test]
+    fn bare_info_left_verbatim() {
+        assert_eq!(scoped_spec("info"), "info");
+    }
+
+    #[test]
+    fn explicit_directive_left_verbatim() {
+        // RUST_LOG / power-user style: not a bare level, so pass through untouched
+        assert_eq!(scoped_spec("agentsmesh_relay=debug"), "agentsmesh_relay=debug");
+        assert_eq!(scoped_spec("debug,hyper=trace"), "debug,hyper=trace");
     }
 }

--- a/clients/core/crates/node-bridge/BUILD.bazel
+++ b/clients/core/crates/node-bridge/BUILD.bazel
@@ -33,6 +33,7 @@ rust_library(
         "@crates//:serde",
         "@crates//:serde_json",
         "@crates//:tokio",
+        "@crates//:tracing",
     ],
 )
 
@@ -69,6 +70,7 @@ napi_rust_library(
         "@crates//:serde",
         "@crates//:serde_json",
         "@crates//:tokio",
+        "@crates//:tracing",
     ],
 )
 

--- a/clients/core/crates/node-bridge/src/commands/local_runner.rs
+++ b/clients/core/crates/node-bridge/src/commands/local_runner.rs
@@ -34,6 +34,7 @@ impl AppState {
         release_url: String,
         expected_sha256: Option<String>,
     ) -> napi::Result<()> {
+        tracing::info!(target: "local-runner", %release_url, "install binary");
         self.local_runner
             .install_binary(&release_url, expected_sha256.as_deref())
             .await
@@ -52,26 +53,31 @@ impl AppState {
 
     #[napi]
     pub async fn local_runner_register(&self, token: String) -> napi::Result<()> {
+        tracing::info!(target: "local-runner", "register");
         self.local_runner.register(&token).await.map_err(err)
     }
 
     #[napi]
     pub async fn local_runner_service_install(&self) -> napi::Result<()> {
+        tracing::info!(target: "local-runner", "service install");
         self.local_runner.service_install().await.map_err(err)
     }
 
     #[napi]
     pub async fn local_runner_service_uninstall(&self) -> napi::Result<()> {
+        tracing::info!(target: "local-runner", "service uninstall");
         self.local_runner.service_uninstall().await.map_err(err)
     }
 
     #[napi]
     pub async fn local_runner_service_start(&self) -> napi::Result<()> {
+        tracing::info!(target: "local-runner", "service start");
         self.local_runner.service_start().await.map_err(err)
     }
 
     #[napi]
     pub async fn local_runner_service_stop(&self) -> napi::Result<()> {
+        tracing::info!(target: "local-runner", "service stop");
         self.local_runner.service_stop().await.map_err(err)
     }
 

--- a/clients/core/crates/relay/src/driver/mod.rs
+++ b/clients/core/crates/relay/src/driver/mod.rs
@@ -104,6 +104,7 @@ impl<R: Runtime> Driver<R> {
             .await;
             let stop = match connect {
                 Ok(Ok((sender, mut receiver))) => {
+                    tracing::info!(target: "relay", pod_key = %self.pod_key, "ws connected");
                     self.snapshot_received = false;
                     // Fresh connection: assume the runner is up until a
                     // RunnerDisconnected frame says otherwise, and don't let input

--- a/clients/core/crates/relay/src/driver/session.rs
+++ b/clients/core/crates/relay/src/driver/session.rs
@@ -59,6 +59,7 @@ impl<R: Runtime> Driver<R> {
                 if resync_count > retry::SNAPSHOT_GIVEUP_ATTEMPTS {
                     // Connected but data never arrived: rebuild the link so it
                     // self-heals once relay/runner recovers, not blank-forever.
+                    tracing::warn!(target: "relay", pod_key = %self.pod_key, attempts = resync_count, "snapshot never arrived — rebuilding link");
                     return SessionEnd::Closed;
                 }
                 let _ = sender.send_binary(encode_message(MsgType::Resync, &[]));
@@ -118,6 +119,7 @@ impl<R: Runtime> Driver<R> {
                 // green on real data-ready, not the bare WS handshake (kills the
                 // "green but blank" gap).
                 self.set_status(RelayStatus::Connected);
+                tracing::info!(target: "relay", pod_key = %self.pod_key, "data ready → connected");
             }
             DispatchAction::PodResized { cols, rows } => {
                 self.pod_size = Some((cols, rows));
@@ -125,11 +127,13 @@ impl<R: Runtime> Driver<R> {
             }
             DispatchAction::RunnerDisconnected => {
                 self.runner_disconnected = true;
+                tracing::warn!(target: "relay", pod_key = %self.pod_key, "runner disconnected");
                 self.write_snapshot();
                 self.notify_status();
             }
             DispatchAction::RunnerReconnected => {
                 self.runner_disconnected = false;
+                tracing::info!(target: "relay", pod_key = %self.pod_key, "runner reconnected");
                 self.write_snapshot();
                 self.notify_status();
             }

--- a/clients/core/crates/relay/src/pool.rs
+++ b/clients/core/crates/relay/src/pool.rs
@@ -72,6 +72,7 @@ impl<R: Runtime> RelayConnectionPool<R> {
         relay_token: &str,
         callback: OutputCallback,
     ) -> ConnectionHandle {
+        tracing::info!(target: "relay", pod_key, %subscription_id, "subscribe");
         let cmd_tx = {
             let mut router = self.inner.write();
             if let Some(handle) = router.pods.get(pod_key) {
@@ -98,6 +99,7 @@ impl<R: Runtime> RelayConnectionPool<R> {
                         snapshot: Arc::clone(&snapshot),
                     },
                 );
+                tracing::debug!(target: "relay", pod_key, "no live driver — spawning");
                 Driver::spawn(
                     self.runtime.clone(),
                     Arc::clone(&self.inner),
@@ -166,6 +168,7 @@ impl<R: Runtime> RelayConnectionPool<R> {
     }
 
     pub async fn disconnect(&self, pod_key: &str) {
+        tracing::info!(target: "relay", pod_key, "disconnect");
         self.send_command(pod_key, Command::Disconnect);
     }
 

--- a/clients/core/crates/services/src/agent.rs
+++ b/clients/core/crates/services/src/agent.rs
@@ -21,6 +21,7 @@ impl AgentService {
     // the Connect interceptor's TenantContext, no payload-derived org_slug.
 
     pub async fn get_agentpod_settings_connect(&self) -> Result<Vec<u8>, String> {
+        tracing::debug!(target: "agent", "get agentpod settings");
         let resp = self.client.get_agentpod_settings_connect().await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -28,11 +29,13 @@ impl AgentService {
     pub async fn update_agentpod_settings_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = pod_proto::UpdateSettingsRequest::decode(request_bytes)
             .map_err(|e| format!("decode update_agentpod_settings request: {e}"))?;
+        tracing::info!(target: "agent", "update agentpod settings");
         let resp = self.client.update_agentpod_settings_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
 
     pub async fn list_agentpod_providers_connect(&self) -> Result<Vec<u8>, String> {
+        tracing::debug!(target: "agent", "list agentpod providers");
         let resp = self.client.list_agentpod_providers_connect().await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -40,6 +43,7 @@ impl AgentService {
     pub async fn create_agentpod_provider_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = pod_proto::CreateProviderRequest::decode(request_bytes)
             .map_err(|e| format!("decode create_agentpod_provider request: {e}"))?;
+        tracing::info!(target: "agent", provider_type = %req.provider_type, "create agentpod provider");
         let resp = self.client.create_agentpod_provider_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -47,6 +51,7 @@ impl AgentService {
     pub async fn update_agentpod_provider_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = pod_proto::UpdateProviderRequest::decode(request_bytes)
             .map_err(|e| format!("decode update_agentpod_provider request: {e}"))?;
+        tracing::info!(target: "agent", provider_id = req.id, "update agentpod provider");
         let resp = self.client.update_agentpod_provider_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -54,6 +59,7 @@ impl AgentService {
     pub async fn delete_agentpod_provider_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = pod_proto::DeleteProviderRequest::decode(request_bytes)
             .map_err(|e| format!("decode delete_agentpod_provider request: {e}"))?;
+        tracing::info!(target: "agent", provider_id = req.id, "delete agentpod provider");
         let resp = self.client.delete_agentpod_provider_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -61,6 +67,7 @@ impl AgentService {
     pub async fn set_default_agentpod_provider_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = pod_proto::SetDefaultProviderRequest::decode(request_bytes)
             .map_err(|e| format!("decode set_default_agentpod_provider request: {e}"))?;
+        tracing::info!(target: "agent", provider_id = req.id, "set default agentpod provider");
         let resp = self.client.set_default_agentpod_provider_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -75,6 +82,7 @@ impl AgentService {
     pub async fn list_agents_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = agent_proto::ListAgentsRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_agents request: {e}"))?;
+        tracing::debug!(target: "agent", org_slug = %req.org_slug, "list agents");
         let resp = self.client.list_agents_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -82,6 +90,7 @@ impl AgentService {
     pub async fn get_agent_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = agent_proto::GetAgentRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_agent request: {e}"))?;
+        tracing::debug!(target: "agent", org_slug = %req.org_slug, agent_slug = %req.agent_slug, "get agent");
         let resp = self.client.get_agent_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -89,6 +98,7 @@ impl AgentService {
     pub async fn get_agent_config_schema_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = agent_proto::GetAgentConfigSchemaRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_agent_config_schema request: {e}"))?;
+        tracing::debug!(target: "agent", org_slug = %req.org_slug, agent_slug = %req.agent_slug, "get agent config schema");
         let resp = self.client.get_agent_config_schema_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -96,6 +106,7 @@ impl AgentService {
     pub async fn create_custom_agent_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = agent_proto::CreateCustomAgentRequest::decode(request_bytes)
             .map_err(|e| format!("decode create_custom_agent request: {e}"))?;
+        tracing::info!(target: "agent", org_slug = %req.org_slug, slug = %req.slug, "create custom agent");
         let resp = self.client.create_custom_agent_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -103,6 +114,7 @@ impl AgentService {
     pub async fn update_custom_agent_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = agent_proto::UpdateCustomAgentRequest::decode(request_bytes)
             .map_err(|e| format!("decode update_custom_agent request: {e}"))?;
+        tracing::info!(target: "agent", org_slug = %req.org_slug, agent_slug = %req.agent_slug, "update custom agent");
         let resp = self.client.update_custom_agent_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -110,11 +122,13 @@ impl AgentService {
     pub async fn delete_custom_agent_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = agent_proto::DeleteCustomAgentRequest::decode(request_bytes)
             .map_err(|e| format!("decode delete_custom_agent request: {e}"))?;
+        tracing::info!(target: "agent", org_slug = %req.org_slug, agent_slug = %req.agent_slug, "delete custom agent");
         let resp = self.client.delete_custom_agent_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
 
     pub async fn list_user_agent_configs_connect(&self) -> Result<Vec<u8>, String> {
+        tracing::debug!(target: "agent", "list user agent configs");
         let resp = self.client.list_user_agent_configs_connect().await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -122,6 +136,7 @@ impl AgentService {
     pub async fn get_user_agent_config_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = agent_proto::GetUserAgentConfigRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_user_agent_config request: {e}"))?;
+        tracing::debug!(target: "agent", agent_slug = %req.agent_slug, "get user agent config");
         let resp = self.client.get_user_agent_config_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -129,6 +144,7 @@ impl AgentService {
     pub async fn set_user_agent_config_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = agent_proto::SetUserAgentConfigRequest::decode(request_bytes)
             .map_err(|e| format!("decode set_user_agent_config request: {e}"))?;
+        tracing::info!(target: "agent", agent_slug = %req.agent_slug, "set user agent config");
         let resp = self.client.set_user_agent_config_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -136,6 +152,7 @@ impl AgentService {
     pub async fn delete_user_agent_config_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = agent_proto::DeleteUserAgentConfigRequest::decode(request_bytes)
             .map_err(|e| format!("decode delete_user_agent_config request: {e}"))?;
+        tracing::info!(target: "agent", agent_slug = %req.agent_slug, "delete user agent config");
         let resp = self.client.delete_user_agent_config_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }

--- a/clients/core/crates/services/src/apikey.rs
+++ b/clients/core/crates/services/src/apikey.rs
@@ -28,6 +28,7 @@ impl ApiKeyService {
     pub async fn list_api_keys_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = apikey_proto::ListApiKeysRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_api_keys request: {e}"))?;
+        tracing::debug!(target: "apikey", org_slug = %req.org_slug, "list api keys");
         let resp = self.client.list_api_keys_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -35,6 +36,7 @@ impl ApiKeyService {
     pub async fn get_api_key_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = apikey_proto::GetApiKeyRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_api_key request: {e}"))?;
+        tracing::debug!(target: "apikey", org_slug = %req.org_slug, api_key_id = req.id, "get api key");
         let resp = self.client.get_api_key_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -42,6 +44,7 @@ impl ApiKeyService {
     pub async fn create_api_key_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = apikey_proto::CreateApiKeyRequest::decode(request_bytes)
             .map_err(|e| format!("decode create_api_key request: {e}"))?;
+        tracing::info!(target: "apikey", org_slug = %req.org_slug, "create api key");
         let resp = self.client.create_api_key_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -49,6 +52,7 @@ impl ApiKeyService {
     pub async fn update_api_key_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = apikey_proto::UpdateApiKeyRequest::decode(request_bytes)
             .map_err(|e| format!("decode update_api_key request: {e}"))?;
+        tracing::info!(target: "apikey", org_slug = %req.org_slug, api_key_id = req.id, "update api key");
         let resp = self.client.update_api_key_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -56,6 +60,7 @@ impl ApiKeyService {
     pub async fn revoke_api_key_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = apikey_proto::RevokeApiKeyRequest::decode(request_bytes)
             .map_err(|e| format!("decode revoke_api_key request: {e}"))?;
+        tracing::info!(target: "apikey", org_slug = %req.org_slug, api_key_id = req.id, "revoke api key");
         let resp = self.client.revoke_api_key_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -63,6 +68,7 @@ impl ApiKeyService {
     pub async fn delete_api_key_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = apikey_proto::DeleteApiKeyRequest::decode(request_bytes)
             .map_err(|e| format!("decode delete_api_key request: {e}"))?;
+        tracing::info!(target: "apikey", org_slug = %req.org_slug, api_key_id = req.id, "delete api key");
         let resp = self.client.delete_api_key_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }

--- a/clients/core/crates/services/src/auth_connect.rs
+++ b/clients/core/crates/services/src/auth_connect.rs
@@ -33,6 +33,7 @@ impl AuthConnectService {
     pub async fn login_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = auth_proto::LoginRequest::decode(request_bytes)
             .map_err(|e| format!("decode login request: {e}"))?;
+        tracing::info!(target: "auth", "login");
         let resp = self.client.auth_login_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -40,6 +41,7 @@ impl AuthConnectService {
     pub async fn register_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = auth_proto::RegisterRequest::decode(request_bytes)
             .map_err(|e| format!("decode register request: {e}"))?;
+        tracing::info!(target: "auth", "register");
         let resp = self.client.auth_register_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -47,6 +49,7 @@ impl AuthConnectService {
     pub async fn refresh_token_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = auth_proto::RefreshTokenRequest::decode(request_bytes)
             .map_err(|e| format!("decode refresh_token request: {e}"))?;
+        tracing::debug!(target: "auth", "refresh token");
         let resp = self
             .client
             .auth_refresh_token_connect(&req)
@@ -58,6 +61,7 @@ impl AuthConnectService {
     pub async fn verify_email_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = auth_proto::VerifyEmailRequest::decode(request_bytes)
             .map_err(|e| format!("decode verify_email request: {e}"))?;
+        tracing::info!(target: "auth", "verify email");
         let resp = self
             .client
             .auth_verify_email_connect(&req)
@@ -72,6 +76,7 @@ impl AuthConnectService {
     ) -> Result<Vec<u8>, String> {
         let req = auth_proto::ResendVerificationRequest::decode(request_bytes)
             .map_err(|e| format!("decode resend_verification request: {e}"))?;
+        tracing::info!(target: "auth", "resend verification");
         let resp = self
             .client
             .auth_resend_verification_connect(&req)
@@ -83,6 +88,7 @@ impl AuthConnectService {
     pub async fn forgot_password_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = auth_proto::ForgotPasswordRequest::decode(request_bytes)
             .map_err(|e| format!("decode forgot_password request: {e}"))?;
+        tracing::info!(target: "auth", "forgot password");
         let resp = self
             .client
             .auth_forgot_password_connect(&req)
@@ -94,6 +100,7 @@ impl AuthConnectService {
     pub async fn reset_password_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = auth_proto::ResetPasswordRequest::decode(request_bytes)
             .map_err(|e| format!("decode reset_password request: {e}"))?;
+        tracing::info!(target: "auth", "reset password");
         let resp = self
             .client
             .auth_reset_password_connect(&req)
@@ -105,6 +112,7 @@ impl AuthConnectService {
     pub async fn oauth_redirect_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = auth_proto::OAuthRedirectRequest::decode(request_bytes)
             .map_err(|e| format!("decode oauth_redirect request: {e}"))?;
+        tracing::info!(target: "auth", provider = %req.provider, "oauth redirect");
         let resp = self
             .client
             .auth_oauth_redirect_connect(&req)
@@ -116,6 +124,7 @@ impl AuthConnectService {
     pub async fn oauth_callback_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = auth_proto::OAuthCallbackRequest::decode(request_bytes)
             .map_err(|e| format!("decode oauth_callback request: {e}"))?;
+        tracing::info!(target: "auth", provider = %req.provider, "oauth callback");
         let resp = self
             .client
             .auth_oauth_callback_connect(&req)
@@ -127,6 +136,7 @@ impl AuthConnectService {
     pub async fn logout_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = auth_proto::LogoutRequest::decode(request_bytes)
             .map_err(|e| format!("decode logout request: {e}"))?;
+        tracing::info!(target: "auth", "logout");
         let resp = self.client.auth_logout_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }

--- a/clients/core/crates/services/src/autopilot.rs
+++ b/clients/core/crates/services/src/autopilot.rs
@@ -23,6 +23,7 @@ impl AutopilotService {
         use prost::Message;
         let req = ap::ListAutopilotControllersRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_autopilots request: {e}"))?;
+        tracing::debug!(target: "autopilot", org_slug = %req.org_slug, "list autopilots");
         let resp = self.client.list_autopilots_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -32,6 +33,7 @@ impl AutopilotService {
         use prost::Message;
         let req = ap::GetAutopilotControllerRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_autopilot request: {e}"))?;
+        tracing::debug!(target: "autopilot", org_slug = %req.org_slug, key = %req.key, "get autopilot");
         let resp = self.client.get_autopilot_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -41,6 +43,7 @@ impl AutopilotService {
         use prost::Message;
         let req = ap::CreateAutopilotControllerRequest::decode(request_bytes)
             .map_err(|e| format!("decode create_autopilot request: {e}"))?;
+        tracing::info!(target: "autopilot", org_slug = %req.org_slug, pod_key = %req.pod_key, "create autopilot");
         let resp = self.client.create_autopilot_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -52,6 +55,7 @@ impl AutopilotService {
         use prost::Message;
         let req = ap::ActionRequest::decode(request_bytes)
             .map_err(|e| format!("decode action_autopilot request: {e}"))?;
+        tracing::info!(target: "autopilot", org_slug = %req.org_slug, key = %req.key, procedure, "action autopilot");
         let resp = match procedure {
             "pause" => self.client.pause_autopilot_connect(&req).await,
             "resume" => self.client.resume_autopilot_connect(&req).await,
@@ -68,6 +72,7 @@ impl AutopilotService {
         use prost::Message;
         let req = ap::ApproveRequest::decode(request_bytes)
             .map_err(|e| format!("decode approve_autopilot request: {e}"))?;
+        tracing::info!(target: "autopilot", org_slug = %req.org_slug, key = %req.key, "approve autopilot");
         let resp = self.client.approve_autopilot_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -77,6 +82,7 @@ impl AutopilotService {
         use prost::Message;
         let req = ap::GetIterationsRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_iterations request: {e}"))?;
+        tracing::debug!(target: "autopilot", org_slug = %req.org_slug, key = %req.key, "get iterations");
         let resp = self.client.get_autopilot_iterations_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }

--- a/clients/core/crates/services/src/billing.rs
+++ b/clients/core/crates/services/src/billing.rs
@@ -23,6 +23,7 @@ impl BillingService {
     pub async fn get_overview_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = billing_proto::GetOverviewRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_overview request: {e}"))?;
+        tracing::debug!(target: "billing", org_slug = %req.org_slug, "get overview");
         let resp = self.client.get_billing_overview_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -30,6 +31,7 @@ impl BillingService {
     pub async fn list_plans_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = billing_proto::ListPlansRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_plans request: {e}"))?;
+        tracing::debug!(target: "billing", org_slug = %req.org_slug, "list plans");
         let resp = self.client.list_billing_plans_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -37,6 +39,7 @@ impl BillingService {
     pub async fn get_subscription_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = billing_proto::GetSubscriptionRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_subscription request: {e}"))?;
+        tracing::debug!(target: "billing", org_slug = %req.org_slug, "get subscription");
         let resp = self.client.get_billing_subscription_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -44,6 +47,7 @@ impl BillingService {
     pub async fn create_subscription_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = billing_proto::CreateSubscriptionRequest::decode(request_bytes)
             .map_err(|e| format!("decode create_subscription request: {e}"))?;
+        tracing::info!(target: "billing", org_slug = %req.org_slug, plan_name = %req.plan_name, "create subscription");
         let resp = self.client.create_billing_subscription_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -51,6 +55,7 @@ impl BillingService {
     pub async fn update_subscription_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = billing_proto::UpdateSubscriptionRequest::decode(request_bytes)
             .map_err(|e| format!("decode update_subscription request: {e}"))?;
+        tracing::info!(target: "billing", org_slug = %req.org_slug, plan_name = %req.plan_name, "update subscription");
         let resp = self.client.update_billing_subscription_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -58,6 +63,7 @@ impl BillingService {
     pub async fn cancel_subscription_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = billing_proto::CancelSubscriptionRequest::decode(request_bytes)
             .map_err(|e| format!("decode cancel_subscription request: {e}"))?;
+        tracing::info!(target: "billing", org_slug = %req.org_slug, "cancel subscription");
         let resp = self.client.cancel_billing_subscription_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -65,6 +71,7 @@ impl BillingService {
     pub async fn request_cancel_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = billing_proto::RequestCancelSubscriptionRequest::decode(request_bytes)
             .map_err(|e| format!("decode request_cancel request: {e}"))?;
+        tracing::info!(target: "billing", org_slug = %req.org_slug, immediate = req.immediate, "request cancel subscription");
         let resp = self.client.request_cancel_subscription_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -72,6 +79,7 @@ impl BillingService {
     pub async fn reactivate_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = billing_proto::ReactivateSubscriptionRequest::decode(request_bytes)
             .map_err(|e| format!("decode reactivate request: {e}"))?;
+        tracing::info!(target: "billing", org_slug = %req.org_slug, "reactivate subscription");
         let resp = self.client.reactivate_subscription_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -79,6 +87,7 @@ impl BillingService {
     pub async fn upgrade_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = billing_proto::UpgradeSubscriptionRequest::decode(request_bytes)
             .map_err(|e| format!("decode upgrade request: {e}"))?;
+        tracing::info!(target: "billing", org_slug = %req.org_slug, plan_name = %req.plan_name, "upgrade subscription");
         let resp = self.client.upgrade_subscription_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -86,6 +95,7 @@ impl BillingService {
     pub async fn change_cycle_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = billing_proto::ChangeBillingCycleRequest::decode(request_bytes)
             .map_err(|e| format!("decode change_cycle request: {e}"))?;
+        tracing::info!(target: "billing", org_slug = %req.org_slug, billing_cycle = %req.billing_cycle, "change billing cycle");
         let resp = self.client.change_billing_cycle_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -93,6 +103,7 @@ impl BillingService {
     pub async fn update_auto_renew_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = billing_proto::UpdateAutoRenewRequest::decode(request_bytes)
             .map_err(|e| format!("decode update_auto_renew request: {e}"))?;
+        tracing::info!(target: "billing", org_slug = %req.org_slug, auto_renew = req.auto_renew, "update auto renew");
         let resp = self.client.update_auto_renew_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -100,6 +111,7 @@ impl BillingService {
     pub async fn get_seat_usage_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = billing_proto::GetSeatUsageRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_seat_usage request: {e}"))?;
+        tracing::debug!(target: "billing", org_slug = %req.org_slug, "get seat usage");
         let resp = self.client.get_seat_usage_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -107,6 +119,7 @@ impl BillingService {
     pub async fn purchase_seats_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = billing_proto::PurchaseSeatsRequest::decode(request_bytes)
             .map_err(|e| format!("decode purchase_seats request: {e}"))?;
+        tracing::info!(target: "billing", org_slug = %req.org_slug, seats = req.seats, "purchase seats");
         let resp = self.client.purchase_seats_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -114,6 +127,7 @@ impl BillingService {
     pub async fn list_invoices_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = billing_proto::ListInvoicesRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_invoices request: {e}"))?;
+        tracing::debug!(target: "billing", org_slug = %req.org_slug, "list invoices");
         let resp = self.client.list_billing_invoices_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -121,6 +135,7 @@ impl BillingService {
     pub async fn create_checkout_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = billing_proto::CreateCheckoutRequest::decode(request_bytes)
             .map_err(|e| format!("decode create_checkout request: {e}"))?;
+        tracing::info!(target: "billing", org_slug = %req.org_slug, order_type = %req.order_type, "create checkout");
         let resp = self.client.create_billing_checkout_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -128,6 +143,7 @@ impl BillingService {
     pub async fn get_checkout_status_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = billing_proto::GetCheckoutStatusRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_checkout_status request: {e}"))?;
+        tracing::debug!(target: "billing", org_slug = %req.org_slug, order_no = %req.order_no, "get checkout status");
         let resp = self.client.get_billing_checkout_status_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -135,6 +151,7 @@ impl BillingService {
     pub async fn get_deployment_info_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = billing_proto::GetDeploymentInfoRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_deployment_info request: {e}"))?;
+        tracing::debug!(target: "billing", org_slug = %req.org_slug, "get deployment info");
         let resp = self.client.get_billing_deployment_info_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -142,6 +159,7 @@ impl BillingService {
     pub async fn get_public_pricing_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = billing_proto::GetPublicPricingRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_public_pricing request: {e}"))?;
+        tracing::debug!(target: "billing", "get public pricing");
         let resp = self.client.get_public_pricing_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -149,6 +167,7 @@ impl BillingService {
     pub async fn get_public_deployment_info_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = billing_proto::GetPublicDeploymentInfoRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_public_deployment_info request: {e}"))?;
+        tracing::debug!(target: "billing", "get public deployment info");
         let resp = self.client.get_public_deployment_info_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -158,6 +177,7 @@ impl BillingService {
     pub async fn get_usage_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = billing_proto::GetUsageRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_usage request: {e}"))?;
+        tracing::debug!(target: "billing", org_slug = %req.org_slug, "get usage");
         let resp = self.client.get_usage_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -165,6 +185,7 @@ impl BillingService {
     pub async fn get_usage_history_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = billing_proto::GetUsageHistoryRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_usage_history request: {e}"))?;
+        tracing::debug!(target: "billing", org_slug = %req.org_slug, months = req.months, "get usage history");
         let resp = self
             .client
             .get_usage_history_connect(&req)
@@ -176,6 +197,7 @@ impl BillingService {
     pub async fn check_quota_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = billing_proto::CheckQuotaRequest::decode(request_bytes)
             .map_err(|e| format!("decode check_quota request: {e}"))?;
+        tracing::debug!(target: "billing", org_slug = %req.org_slug, resource = %req.resource, "check quota");
         let resp = self.client.check_quota_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -183,6 +205,7 @@ impl BillingService {
     pub async fn set_custom_quota_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = billing_proto::SetCustomQuotaRequest::decode(request_bytes)
             .map_err(|e| format!("decode set_custom_quota request: {e}"))?;
+        tracing::info!(target: "billing", org_slug = %req.org_slug, resource = %req.resource, "set custom quota");
         let resp = self
             .client
             .set_custom_quota_connect(&req)
@@ -194,6 +217,7 @@ impl BillingService {
     pub async fn create_customer_portal_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = billing_proto::CreateCustomerPortalRequest::decode(request_bytes)
             .map_err(|e| format!("decode create_customer_portal request: {e}"))?;
+        tracing::info!(target: "billing", org_slug = %req.org_slug, "create customer portal");
         let resp = self
             .client
             .create_customer_portal_connect(&req)

--- a/clients/core/crates/services/src/binding.rs
+++ b/clients/core/crates/services/src/binding.rs
@@ -29,6 +29,7 @@ macro_rules! connect_bridge {
         pub async fn $name(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
             let req = bp::$req::decode(request_bytes)
                 .map_err(|e| format!("decode {}: {e}", stringify!($req)))?;
+            tracing::debug!(target: "binding", rpc = stringify!($req));
             let resp = self.client().$client_call(&req).await.map_err(wire)?;
             Ok(resp.encode_to_vec())
         }

--- a/clients/core/crates/services/src/blockstore.rs
+++ b/clients/core/crates/services/src/blockstore.rs
@@ -53,6 +53,7 @@ impl BlockstoreService {
 
     pub async fn list_workspaces(&self) -> Result<String, String> {
         let req = blockstore_proto::ListWorkspacesRequest { org_slug: self.org_slug() };
+        tracing::debug!(target: "blockstore", org_slug = %req.org_slug, "list workspaces");
         let resp = self.client.blockstore_list_workspaces_connect(&req).await
             .map_err(crate::wire)?;
         let list: Vec<Workspace> = resp.items.into_iter().map(workspace_from_proto).collect();
@@ -63,6 +64,7 @@ impl BlockstoreService {
 
     pub async fn ensure_default_workspace(&self) -> Result<String, String> {
         let req = blockstore_proto::EnsureDefaultWorkspaceRequest { org_slug: self.org_slug() };
+        tracing::info!(target: "blockstore", org_slug = %req.org_slug, "ensure default workspace");
         let resp = self.client.blockstore_ensure_default_workspace_connect(&req).await
             .map_err(crate::wire)?;
         let ws = workspace_from_proto(resp);
@@ -77,6 +79,7 @@ impl BlockstoreService {
             root_id: root_id.to_string(),
             max_depth: Some(64),
         };
+        tracing::debug!(target: "blockstore", workspace_id, root_id, "load subtree");
         let resp = self.client.blockstore_get_subtree_connect(&req).await
             .map_err(crate::wire)?;
         let mut state = self.state.write().unwrap();
@@ -94,6 +97,7 @@ impl BlockstoreService {
             org_slug: self.org_slug(),
             workspace_id: workspace_id.to_string(),
         };
+        tracing::debug!(target: "blockstore", workspace_id, "load type defs");
         let resp = self.client.blockstore_list_type_defs_connect(&req).await
             .map_err(crate::wire)?;
         let mut state = self.state.write().unwrap();
@@ -109,6 +113,7 @@ impl BlockstoreService {
             after: Some(after),
             limit: Some(500),
         };
+        tracing::debug!(target: "blockstore", workspace_id, after, "catchup ops");
         let resp = self.client.blockstore_stream_ops_connect(&req).await
             .map_err(crate::wire)?;
         let mut state = self.state.write().unwrap();
@@ -254,6 +259,7 @@ macro_rules! connect_bridge {
         pub async fn $name(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
             let req = blockstore_proto::$req::decode(request_bytes)
                 .map_err(|e| format!("decode {}: {e}", stringify!($req)))?;
+            tracing::debug!(target: "blockstore", rpc = stringify!($req));
             let resp = self.client().$client_call(&req).await.map_err(crate::wire)?;
             Ok(resp.encode_to_vec())
         }

--- a/clients/core/crates/services/src/channel.rs
+++ b/clients/core/crates/services/src/channel.rs
@@ -34,6 +34,7 @@ macro_rules! connect_bridge {
         pub async fn $name(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
             let req = channel_proto::$req::decode(request_bytes)
                 .map_err(|e| format!("decode {}: {e}", stringify!($req)))?;
+            tracing::debug!(target: "channel", rpc = stringify!($req));
             let resp = self.client().$client_call(&req).await.map_err(wire)?;
             Ok(resp.encode_to_vec())
         }

--- a/clients/core/crates/services/src/env_bundle.rs
+++ b/clients/core/crates/services/src/env_bundle.rs
@@ -22,6 +22,7 @@ impl EnvBundleService {
     pub async fn list_env_bundles_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = eb_proto::ListEnvBundlesRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_env_bundles request: {e}"))?;
+        tracing::debug!(target: "env_bundle", "list env bundles");
         let resp = self
             .client
             .list_user_env_bundles_connect(&req)
@@ -33,6 +34,7 @@ impl EnvBundleService {
     pub async fn get_env_bundle_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = eb_proto::GetEnvBundleRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_env_bundle request: {e}"))?;
+        tracing::debug!(target: "env_bundle", env_bundle_id = req.id, "get env bundle");
         let resp = self
             .client
             .get_user_env_bundle_connect(&req)
@@ -44,6 +46,7 @@ impl EnvBundleService {
     pub async fn create_env_bundle_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = eb_proto::CreateEnvBundleRequest::decode(request_bytes)
             .map_err(|e| format!("decode create_env_bundle request: {e}"))?;
+        tracing::info!(target: "env_bundle", kind = %req.kind, "create env bundle");
         let resp = self
             .client
             .create_user_env_bundle_connect(&req)
@@ -55,6 +58,7 @@ impl EnvBundleService {
     pub async fn update_env_bundle_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = eb_proto::UpdateEnvBundleRequest::decode(request_bytes)
             .map_err(|e| format!("decode update_env_bundle request: {e}"))?;
+        tracing::info!(target: "env_bundle", env_bundle_id = req.id, "update env bundle");
         let resp = self
             .client
             .update_user_env_bundle_connect(&req)
@@ -66,6 +70,7 @@ impl EnvBundleService {
     pub async fn delete_env_bundle_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = eb_proto::DeleteEnvBundleRequest::decode(request_bytes)
             .map_err(|e| format!("decode delete_env_bundle request: {e}"))?;
+        tracing::info!(target: "env_bundle", env_bundle_id = req.id, "delete env bundle");
         let resp = self
             .client
             .delete_user_env_bundle_connect(&req)
@@ -77,6 +82,7 @@ impl EnvBundleService {
     pub async fn set_primary_env_bundle_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = eb_proto::SetPrimaryEnvBundleRequest::decode(request_bytes)
             .map_err(|e| format!("decode set_primary_env_bundle request: {e}"))?;
+        tracing::info!(target: "env_bundle", env_bundle_id = req.id, "set primary env bundle");
         let resp = self
             .client
             .set_primary_env_bundle_connect(&req)

--- a/clients/core/crates/services/src/extension.rs
+++ b/clients/core/crates/services/src/extension.rs
@@ -26,6 +26,7 @@ impl ExtensionService {
     pub async fn list_skill_registries_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ext_proto::ListSkillRegistriesRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_skill_registries request: {e}"))?;
+        tracing::debug!(target: "extension", org_slug = %req.org_slug, "list skill registries");
         let resp = self.client.list_skill_registries_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -33,6 +34,7 @@ impl ExtensionService {
     pub async fn create_skill_registry_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ext_proto::CreateSkillRegistryRequest::decode(request_bytes)
             .map_err(|e| format!("decode create_skill_registry request: {e}"))?;
+        tracing::info!(target: "extension", org_slug = %req.org_slug, "create skill registry");
         let resp = self.client.create_skill_registry_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -40,6 +42,7 @@ impl ExtensionService {
     pub async fn sync_skill_registry_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ext_proto::SyncSkillRegistryRequest::decode(request_bytes)
             .map_err(|e| format!("decode sync_skill_registry request: {e}"))?;
+        tracing::info!(target: "extension", org_slug = %req.org_slug, registry_id = req.id, "sync skill registry");
         let resp = self.client.sync_skill_registry_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -47,6 +50,7 @@ impl ExtensionService {
     pub async fn delete_skill_registry_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ext_proto::DeleteSkillRegistryRequest::decode(request_bytes)
             .map_err(|e| format!("decode delete_skill_registry request: {e}"))?;
+        tracing::info!(target: "extension", org_slug = %req.org_slug, registry_id = req.id, "delete skill registry");
         let resp = self.client.delete_skill_registry_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -54,6 +58,7 @@ impl ExtensionService {
     pub async fn toggle_platform_registry_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ext_proto::TogglePlatformRegistryRequest::decode(request_bytes)
             .map_err(|e| format!("decode toggle_platform_registry request: {e}"))?;
+        tracing::info!(target: "extension", org_slug = %req.org_slug, registry_id = req.id, disabled = req.disabled, "toggle platform registry");
         let resp = self.client.toggle_platform_registry_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -61,6 +66,7 @@ impl ExtensionService {
     pub async fn list_skill_registry_overrides_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ext_proto::ListSkillRegistryOverridesRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_skill_registry_overrides request: {e}"))?;
+        tracing::debug!(target: "extension", org_slug = %req.org_slug, "list skill registry overrides");
         let resp = self.client.list_skill_registry_overrides_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -70,6 +76,7 @@ impl ExtensionService {
     pub async fn list_market_skills_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ext_proto::ListMarketSkillsRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_market_skills request: {e}"))?;
+        tracing::debug!(target: "extension", org_slug = %req.org_slug, "list market skills");
         let resp = self.client.list_market_skills_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -77,6 +84,7 @@ impl ExtensionService {
     pub async fn list_market_mcp_servers_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ext_proto::ListMarketMcpServersRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_market_mcp_servers request: {e}"))?;
+        tracing::debug!(target: "extension", org_slug = %req.org_slug, "list market mcp servers");
         let resp = self.client.list_market_mcp_servers_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -86,6 +94,7 @@ impl ExtensionService {
     pub async fn list_repo_skills_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ext_proto::ListRepoSkillsRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_repo_skills request: {e}"))?;
+        tracing::debug!(target: "extension", org_slug = %req.org_slug, repository_id = req.repository_id, "list repo skills");
         let resp = self.client.list_repo_skills_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -93,6 +102,7 @@ impl ExtensionService {
     pub async fn install_skill_from_market_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ext_proto::InstallSkillFromMarketRequest::decode(request_bytes)
             .map_err(|e| format!("decode install_skill_from_market request: {e}"))?;
+        tracing::info!(target: "extension", org_slug = %req.org_slug, repository_id = req.repository_id, market_item_id = req.market_item_id, "install skill from market");
         let resp = self.client.install_skill_from_market_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -100,6 +110,7 @@ impl ExtensionService {
     pub async fn install_skill_from_github_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ext_proto::InstallSkillFromGitHubRequest::decode(request_bytes)
             .map_err(|e| format!("decode install_skill_from_github request: {e}"))?;
+        tracing::info!(target: "extension", org_slug = %req.org_slug, repository_id = req.repository_id, "install skill from github");
         let resp = self.client.install_skill_from_github_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -107,6 +118,7 @@ impl ExtensionService {
     pub async fn presign_skill_upload_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ext_proto::PresignSkillUploadRequest::decode(request_bytes)
             .map_err(|e| format!("decode presign_skill_upload request: {e}"))?;
+        tracing::info!(target: "extension", org_slug = %req.org_slug, repository_id = req.repository_id, size = req.size, "presign skill upload");
         let resp = self.client.presign_skill_upload_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -114,6 +126,7 @@ impl ExtensionService {
     pub async fn install_skill_from_uploaded_file_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ext_proto::InstallSkillFromUploadedFileRequest::decode(request_bytes)
             .map_err(|e| format!("decode install_skill_from_uploaded_file request: {e}"))?;
+        tracing::info!(target: "extension", org_slug = %req.org_slug, repository_id = req.repository_id, "install skill from uploaded file");
         let resp = self.client.install_skill_from_uploaded_file_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -121,6 +134,7 @@ impl ExtensionService {
     pub async fn update_skill_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ext_proto::UpdateSkillRequest::decode(request_bytes)
             .map_err(|e| format!("decode update_skill request: {e}"))?;
+        tracing::info!(target: "extension", org_slug = %req.org_slug, repository_id = req.repository_id, install_id = req.install_id, "update skill");
         let resp = self.client.update_skill_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -128,6 +142,7 @@ impl ExtensionService {
     pub async fn uninstall_skill_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ext_proto::UninstallSkillRequest::decode(request_bytes)
             .map_err(|e| format!("decode uninstall_skill request: {e}"))?;
+        tracing::info!(target: "extension", org_slug = %req.org_slug, repository_id = req.repository_id, install_id = req.install_id, "uninstall skill");
         let resp = self.client.uninstall_skill_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -137,6 +152,7 @@ impl ExtensionService {
     pub async fn list_repo_mcp_servers_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ext_proto::ListRepoMcpServersRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_repo_mcp_servers request: {e}"))?;
+        tracing::debug!(target: "extension", org_slug = %req.org_slug, repository_id = req.repository_id, "list repo mcp servers");
         let resp = self.client.list_repo_mcp_servers_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -144,6 +160,7 @@ impl ExtensionService {
     pub async fn install_mcp_from_market_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ext_proto::InstallMcpFromMarketRequest::decode(request_bytes)
             .map_err(|e| format!("decode install_mcp_from_market request: {e}"))?;
+        tracing::info!(target: "extension", org_slug = %req.org_slug, repository_id = req.repository_id, market_item_id = req.market_item_id, "install mcp from market");
         let resp = self.client.install_mcp_from_market_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -151,6 +168,7 @@ impl ExtensionService {
     pub async fn install_custom_mcp_server_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ext_proto::InstallCustomMcpServerRequest::decode(request_bytes)
             .map_err(|e| format!("decode install_custom_mcp_server request: {e}"))?;
+        tracing::info!(target: "extension", org_slug = %req.org_slug, repository_id = req.repository_id, slug = %req.slug, "install custom mcp server");
         let resp = self.client.install_custom_mcp_server_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -158,6 +176,7 @@ impl ExtensionService {
     pub async fn update_mcp_server_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ext_proto::UpdateMcpServerRequest::decode(request_bytes)
             .map_err(|e| format!("decode update_mcp_server request: {e}"))?;
+        tracing::info!(target: "extension", org_slug = %req.org_slug, repository_id = req.repository_id, install_id = req.install_id, "update mcp server");
         let resp = self.client.update_mcp_server_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -165,6 +184,7 @@ impl ExtensionService {
     pub async fn uninstall_mcp_server_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ext_proto::UninstallMcpServerRequest::decode(request_bytes)
             .map_err(|e| format!("decode uninstall_mcp_server request: {e}"))?;
+        tracing::info!(target: "extension", org_slug = %req.org_slug, repository_id = req.repository_id, install_id = req.install_id, "uninstall mcp server");
         let resp = self.client.uninstall_mcp_server_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }

--- a/clients/core/crates/services/src/file.rs
+++ b/clients/core/crates/services/src/file.rs
@@ -25,6 +25,7 @@ impl FileService {
             content_type: content_type.to_string(),
             size: file_data.len() as i64,
         };
+        tracing::info!(target: "file", org_slug = %req.org_slug, content_type = %req.content_type, size = req.size, "upload file");
         let resp = self.client.presign_upload_connect(&req).await.map_err(crate::wire)?;
 
         self.client.put_raw_bytes(&resp.put_url, content_type, file_data)
@@ -35,6 +36,7 @@ impl FileService {
     pub async fn presign_upload_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = fp::PresignUploadRequest::decode(request_bytes)
             .map_err(|e| format!("decode presign_upload request: {e}"))?;
+        tracing::info!(target: "file", org_slug = %req.org_slug, content_type = %req.content_type, size = req.size, "presign upload");
         let resp = self.client.presign_upload_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }

--- a/clients/core/crates/services/src/grant.rs
+++ b/clients/core/crates/services/src/grant.rs
@@ -20,6 +20,7 @@ impl GrantService {
     pub async fn list_grants_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = gp::ListGrantsRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_grants request: {e}"))?;
+        tracing::debug!(target: "grant", org_slug = %req.org_slug, resource_type = %req.resource_type, resource_id = %req.resource_id, "list grants");
         let resp = self.client.list_grants_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -27,6 +28,7 @@ impl GrantService {
     pub async fn create_grant_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = gp::CreateGrantRequest::decode(request_bytes)
             .map_err(|e| format!("decode create_grant request: {e}"))?;
+        tracing::info!(target: "grant", org_slug = %req.org_slug, resource_type = %req.resource_type, resource_id = %req.resource_id, user_id = req.user_id, "create grant");
         let resp = self.client.create_grant_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -34,6 +36,7 @@ impl GrantService {
     pub async fn delete_grant_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = gp::DeleteGrantRequest::decode(request_bytes)
             .map_err(|e| format!("decode delete_grant request: {e}"))?;
+        tracing::info!(target: "grant", org_slug = %req.org_slug, resource_type = %req.resource_type, resource_id = %req.resource_id, grant_id = req.grant_id, "delete grant");
         let resp = self.client.delete_grant_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }

--- a/clients/core/crates/services/src/invitation.rs
+++ b/clients/core/crates/services/src/invitation.rs
@@ -27,6 +27,7 @@ impl InvitationService {
     pub async fn list_invitations_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = inv_proto::ListInvitationsRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_invitations request: {e}"))?;
+        tracing::debug!(target: "invitation", org_slug = %req.org_slug, "list invitations");
         let resp = self.client.list_invitations_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -34,6 +35,7 @@ impl InvitationService {
     pub async fn create_invitation_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = inv_proto::CreateInvitationRequest::decode(request_bytes)
             .map_err(|e| format!("decode create_invitation request: {e}"))?;
+        tracing::info!(target: "invitation", org_slug = %req.org_slug, role = %req.role, "create invitation");
         let resp = self.client.create_invitation_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -41,6 +43,7 @@ impl InvitationService {
     pub async fn revoke_invitation_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = inv_proto::RevokeInvitationRequest::decode(request_bytes)
             .map_err(|e| format!("decode revoke_invitation request: {e}"))?;
+        tracing::info!(target: "invitation", org_slug = %req.org_slug, invitation_id = req.id, "revoke invitation");
         let resp = self.client.revoke_invitation_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -48,6 +51,7 @@ impl InvitationService {
     pub async fn resend_invitation_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = inv_proto::ResendInvitationRequest::decode(request_bytes)
             .map_err(|e| format!("decode resend_invitation request: {e}"))?;
+        tracing::info!(target: "invitation", org_slug = %req.org_slug, invitation_id = req.id, "resend invitation");
         let resp = self.client.resend_invitation_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -55,6 +59,7 @@ impl InvitationService {
     pub async fn accept_invitation_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = inv_proto::AcceptInvitationRequest::decode(request_bytes)
             .map_err(|e| format!("decode accept_invitation request: {e}"))?;
+        tracing::info!(target: "invitation", "accept invitation");
         let resp = self.client.accept_invitation_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -62,6 +67,7 @@ impl InvitationService {
     pub async fn list_pending_invitations_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = inv_proto::ListPendingInvitationsRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_pending_invitations request: {e}"))?;
+        tracing::debug!(target: "invitation", "list pending invitations");
         let resp = self.client.list_pending_invitations_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -69,6 +75,7 @@ impl InvitationService {
     pub async fn get_invitation_by_token_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = inv_proto::GetInvitationByTokenRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_invitation_by_token request: {e}"))?;
+        tracing::debug!(target: "invitation", "get invitation by token");
         let resp = self.client.get_invitation_by_token_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }

--- a/clients/core/crates/services/src/loop_service.rs
+++ b/clients/core/crates/services/src/loop_service.rs
@@ -22,6 +22,7 @@ impl LoopService {
     pub async fn list_loops_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = lp::ListLoopsRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_loops request: {e}"))?;
+        tracing::debug!(target: "loop", org_slug = %req.org_slug, "list loops");
         let resp = self.client.list_loops_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -29,6 +30,7 @@ impl LoopService {
     pub async fn get_loop_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = lp::GetLoopRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_loop request: {e}"))?;
+        tracing::debug!(target: "loop", org_slug = %req.org_slug, loop_slug = %req.loop_slug, "get loop");
         let resp = self.client.get_loop_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -36,6 +38,7 @@ impl LoopService {
     pub async fn create_loop_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = lp::CreateLoopRequest::decode(request_bytes)
             .map_err(|e| format!("decode create_loop request: {e}"))?;
+        tracing::info!(target: "loop", org_slug = %req.org_slug, slug = %req.slug, agent_slug = %req.agent_slug, "create loop");
         let resp = self.client.create_loop_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -43,6 +46,7 @@ impl LoopService {
     pub async fn update_loop_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = lp::UpdateLoopRequest::decode(request_bytes)
             .map_err(|e| format!("decode update_loop request: {e}"))?;
+        tracing::info!(target: "loop", org_slug = %req.org_slug, loop_slug = %req.loop_slug, "update loop");
         let resp = self.client.update_loop_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -50,6 +54,7 @@ impl LoopService {
     pub async fn delete_loop_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = lp::DeleteLoopRequest::decode(request_bytes)
             .map_err(|e| format!("decode delete_loop request: {e}"))?;
+        tracing::info!(target: "loop", org_slug = %req.org_slug, loop_slug = %req.loop_slug, "delete loop");
         let resp = self.client.delete_loop_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -59,6 +64,7 @@ impl LoopService {
     ) -> Result<Vec<u8>, String> {
         let req = lp::LoopActionRequest::decode(request_bytes)
             .map_err(|e| format!("decode loop_action request: {e}"))?;
+        tracing::info!(target: "loop", org_slug = %req.org_slug, loop_slug = %req.loop_slug, action, "loop action");
         let resp = match action {
             "enable" => self.client.enable_loop_connect(&req).await,
             "disable" => self.client.disable_loop_connect(&req).await,
@@ -70,6 +76,7 @@ impl LoopService {
     pub async fn trigger_loop_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = lp::TriggerLoopRequest::decode(request_bytes)
             .map_err(|e| format!("decode trigger_loop request: {e}"))?;
+        tracing::info!(target: "loop", org_slug = %req.org_slug, loop_slug = %req.loop_slug, "trigger loop");
         let resp = self.client.trigger_loop_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -77,6 +84,7 @@ impl LoopService {
     pub async fn list_runs_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = lp::ListRunsRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_runs request: {e}"))?;
+        tracing::debug!(target: "loop", org_slug = %req.org_slug, loop_slug = %req.loop_slug, "list runs");
         let resp = self.client.list_loop_runs_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -84,6 +92,7 @@ impl LoopService {
     pub async fn cancel_run_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = lp::CancelRunRequest::decode(request_bytes)
             .map_err(|e| format!("decode cancel_run request: {e}"))?;
+        tracing::info!(target: "loop", org_slug = %req.org_slug, loop_slug = %req.loop_slug, run_id = req.run_id, "cancel run");
         let resp = self.client.cancel_loop_run_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }

--- a/clients/core/crates/services/src/mesh.rs
+++ b/clients/core/crates/services/src/mesh.rs
@@ -28,6 +28,7 @@ impl MeshService {
         let req = mp::GetMeshTopologyRequest {
             org_slug: self.client.current_org_slug(),
         };
+        tracing::debug!(target: "mesh", org_slug = %req.org_slug, "fetch topology");
         let topo = self.client
             .get_mesh_topology_connect(&req)
             .await.map_err(crate::wire)?;
@@ -46,6 +47,7 @@ macro_rules! connect_bridge {
         pub async fn $name(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
             let req = mp::$req::decode(request_bytes)
                 .map_err(|e| format!("decode {}: {e}", stringify!($req)))?;
+            tracing::debug!(target: "mesh", rpc = stringify!($req));
             let resp = self.client_ref().$client_call(&req).await.map_err(crate::wire)?;
             Ok(resp.encode_to_vec())
         }

--- a/clients/core/crates/services/src/notification.rs
+++ b/clients/core/crates/services/src/notification.rs
@@ -21,6 +21,7 @@ impl NotificationService {
     pub async fn list_preferences_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = np::ListPreferencesRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_preferences request: {e}"))?;
+        tracing::debug!(target: "notification", org_slug = %req.org_slug, "list preferences");
         let resp = self.client.list_notification_preferences_connect(&req)
             .await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
@@ -29,6 +30,7 @@ impl NotificationService {
     pub async fn set_preference_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = np::SetPreferenceRequest::decode(request_bytes)
             .map_err(|e| format!("decode set_preference request: {e}"))?;
+        tracing::info!(target: "notification", org_slug = %req.org_slug, source = %req.source, is_muted = req.is_muted, "set preference");
         let resp = self.client.set_notification_preference_connect(&req)
             .await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())

--- a/clients/core/crates/services/src/org.rs
+++ b/clients/core/crates/services/src/org.rs
@@ -26,6 +26,7 @@ impl OrgApiService {
     pub async fn list_my_orgs_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = org_proto::ListMyOrgsRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_my_orgs request: {e}"))?;
+        tracing::debug!(target: "org", "list my orgs");
         let resp = self.client.list_my_orgs_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -33,6 +34,7 @@ impl OrgApiService {
     pub async fn create_org_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = org_proto::CreateOrgRequest::decode(request_bytes)
             .map_err(|e| format!("decode create_org request: {e}"))?;
+        tracing::info!(target: "org", slug = %req.slug, "create org");
         let resp = self.client.create_org_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -40,6 +42,7 @@ impl OrgApiService {
     pub async fn create_personal_org_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = org_proto::CreatePersonalOrgRequest::decode(request_bytes)
             .map_err(|e| format!("decode create_personal_org request: {e}"))?;
+        tracing::info!(target: "org", "create personal org");
         let resp = self.client.create_personal_org_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -47,6 +50,7 @@ impl OrgApiService {
     pub async fn get_org_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = org_proto::GetOrgRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_org request: {e}"))?;
+        tracing::debug!(target: "org", org_slug = %req.org_slug, "get org");
         let resp = self.client.get_org_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -54,6 +58,7 @@ impl OrgApiService {
     pub async fn update_org_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = org_proto::UpdateOrgRequest::decode(request_bytes)
             .map_err(|e| format!("decode update_org request: {e}"))?;
+        tracing::info!(target: "org", org_slug = %req.org_slug, "update org");
         let resp = self.client.update_org_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -61,6 +66,7 @@ impl OrgApiService {
     pub async fn delete_org_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = org_proto::DeleteOrgRequest::decode(request_bytes)
             .map_err(|e| format!("decode delete_org request: {e}"))?;
+        tracing::info!(target: "org", org_slug = %req.org_slug, "delete org");
         let resp = self.client.delete_org_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -68,6 +74,7 @@ impl OrgApiService {
     pub async fn list_members_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = org_proto::ListMembersRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_members request: {e}"))?;
+        tracing::debug!(target: "org", org_slug = %req.org_slug, "list members");
         let resp = self.client.list_members_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -75,6 +82,7 @@ impl OrgApiService {
     pub async fn invite_member_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = org_proto::InviteMemberRequest::decode(request_bytes)
             .map_err(|e| format!("decode invite_member request: {e}"))?;
+        tracing::info!(target: "org", org_slug = %req.org_slug, user_id = req.user_id, "invite member");
         let resp = self.client.invite_member_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -82,6 +90,7 @@ impl OrgApiService {
     pub async fn remove_member_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = org_proto::RemoveMemberRequest::decode(request_bytes)
             .map_err(|e| format!("decode remove_member request: {e}"))?;
+        tracing::info!(target: "org", org_slug = %req.org_slug, user_id = req.user_id, "remove member");
         let resp = self.client.remove_member_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -89,6 +98,7 @@ impl OrgApiService {
     pub async fn update_member_role_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = org_proto::UpdateMemberRoleRequest::decode(request_bytes)
             .map_err(|e| format!("decode update_member_role request: {e}"))?;
+        tracing::info!(target: "org", org_slug = %req.org_slug, user_id = req.user_id, "update member role");
         let resp = self.client.update_member_role_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }

--- a/clients/core/crates/services/src/pod.rs
+++ b/clients/core/crates/services/src/pod.rs
@@ -21,6 +21,7 @@ impl PodService {
     pub async fn list_pods_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = pod_proto::ListPodsRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_pods request: {e}"))?;
+        tracing::debug!(target: "pod", org_slug = %req.org_slug, "list pods");
         let resp = self.client.list_pods_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -28,6 +29,7 @@ impl PodService {
     pub async fn get_pod_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = pod_proto::GetPodRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_pod request: {e}"))?;
+        tracing::debug!(target: "pod", org_slug = %req.org_slug, pod_key = %req.pod_key, "get pod");
         let resp = self.client.get_pod_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -35,6 +37,7 @@ impl PodService {
     pub async fn create_pod_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = pod_proto::CreatePodRequest::decode(request_bytes)
             .map_err(|e| format!("decode create_pod request: {e}"))?;
+        tracing::info!(target: "pod", org_slug = %req.org_slug, agent_slug = %req.agent_slug, runner_id = ?req.runner_id, "create pod");
         let resp = self.client.create_pod_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -42,6 +45,7 @@ impl PodService {
     pub async fn terminate_pod_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = pod_proto::TerminatePodRequest::decode(request_bytes)
             .map_err(|e| format!("decode terminate_pod request: {e}"))?;
+        tracing::info!(target: "pod", org_slug = %req.org_slug, pod_key = %req.pod_key, "terminate pod");
         let resp = self.client.terminate_pod_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -49,6 +53,7 @@ impl PodService {
     pub async fn update_pod_alias_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = pod_proto::UpdatePodAliasRequest::decode(request_bytes)
             .map_err(|e| format!("decode update_pod_alias request: {e}"))?;
+        tracing::info!(target: "pod", org_slug = %req.org_slug, pod_key = %req.pod_key, "update pod alias");
         let resp = self.client.update_pod_alias_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -56,6 +61,7 @@ impl PodService {
     pub async fn update_pod_perpetual_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = pod_proto::UpdatePodPerpetualRequest::decode(request_bytes)
             .map_err(|e| format!("decode update_pod_perpetual request: {e}"))?;
+        tracing::info!(target: "pod", org_slug = %req.org_slug, pod_key = %req.pod_key, perpetual = req.perpetual, "update pod perpetual");
         let resp = self.client.update_pod_perpetual_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -63,6 +69,7 @@ impl PodService {
     pub async fn get_pod_connection_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = pod_proto::GetPodConnectionRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_pod_connection request: {e}"))?;
+        tracing::debug!(target: "pod", org_slug = %req.org_slug, pod_key = %req.pod_key, "get pod connection");
         let resp = self.client.get_pod_connection_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -70,6 +77,7 @@ impl PodService {
     pub async fn send_pod_prompt_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = pod_proto::SendPodPromptRequest::decode(request_bytes)
             .map_err(|e| format!("decode send_pod_prompt request: {e}"))?;
+        tracing::info!(target: "pod", org_slug = %req.org_slug, pod_key = %req.pod_key, prompt_len = req.prompt.len(), "send pod prompt");
         let resp = self.client.send_pod_prompt_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -77,6 +85,7 @@ impl PodService {
     pub async fn list_pods_by_ticket_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = pod_proto::ListPodsByTicketRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_pods_by_ticket request: {e}"))?;
+        tracing::debug!(target: "pod", org_slug = %req.org_slug, ticket_id = req.ticket_id, "list pods by ticket");
         let resp = self.client.list_pods_by_ticket_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }

--- a/clients/core/crates/services/src/promocode.rs
+++ b/clients/core/crates/services/src/promocode.rs
@@ -21,6 +21,7 @@ impl PromoCodeService {
     pub async fn validate_promo_code_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = pc_proto::ValidatePromoCodeRequest::decode(request_bytes)
             .map_err(|e| format!("decode validate_promo_code request: {e}"))?;
+        tracing::debug!(target: "promocode", org_slug = %req.org_slug, "validate promo code");
         let resp = self.client.validate_promo_code_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -28,6 +29,7 @@ impl PromoCodeService {
     pub async fn redeem_promo_code_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = pc_proto::RedeemPromoCodeRequest::decode(request_bytes)
             .map_err(|e| format!("decode redeem_promo_code request: {e}"))?;
+        tracing::info!(target: "promocode", org_slug = %req.org_slug, "redeem promo code");
         let resp = self.client.redeem_promo_code_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -35,6 +37,7 @@ impl PromoCodeService {
     pub async fn get_redemption_history_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = pc_proto::GetRedemptionHistoryRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_redemption_history request: {e}"))?;
+        tracing::debug!(target: "promocode", org_slug = %req.org_slug, "get redemption history");
         let resp = self.client.get_redemption_history_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }

--- a/clients/core/crates/services/src/repository.rs
+++ b/clients/core/crates/services/src/repository.rs
@@ -22,6 +22,7 @@ impl RepositoryService {
     pub async fn list_repositories_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = repo_proto::ListRepositoriesRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_repositories request: {e}"))?;
+        tracing::debug!(target: "repository", org_slug = %req.org_slug, "list repositories");
         let resp = self.client.list_repositories_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -29,6 +30,7 @@ impl RepositoryService {
     pub async fn get_repository_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = repo_proto::GetRepositoryRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_repository request: {e}"))?;
+        tracing::debug!(target: "repository", org_slug = %req.org_slug, repository_id = req.id, "get repository");
         let resp = self.client.get_repository_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -36,6 +38,7 @@ impl RepositoryService {
     pub async fn create_repository_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = repo_proto::CreateRepositoryRequest::decode(request_bytes)
             .map_err(|e| format!("decode create_repository request: {e}"))?;
+        tracing::info!(target: "repository", org_slug = %req.org_slug, slug = %req.slug, provider_type = %req.provider_type, "create repository");
         let resp = self.client.create_repository_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -43,6 +46,7 @@ impl RepositoryService {
     pub async fn update_repository_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = repo_proto::UpdateRepositoryRequest::decode(request_bytes)
             .map_err(|e| format!("decode update_repository request: {e}"))?;
+        tracing::info!(target: "repository", org_slug = %req.org_slug, repository_id = req.id, "update repository");
         let resp = self.client.update_repository_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -50,6 +54,7 @@ impl RepositoryService {
     pub async fn delete_repository_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = repo_proto::DeleteRepositoryRequest::decode(request_bytes)
             .map_err(|e| format!("decode delete_repository request: {e}"))?;
+        tracing::info!(target: "repository", org_slug = %req.org_slug, repository_id = req.id, "delete repository");
         let resp = self.client.delete_repository_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -57,6 +62,7 @@ impl RepositoryService {
     pub async fn list_repository_branches_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = repo_proto::ListRepositoryBranchesRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_repository_branches request: {e}"))?;
+        tracing::debug!(target: "repository", org_slug = %req.org_slug, repository_id = req.id, "list repository branches");
         let resp = self.client.list_repository_branches_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -64,6 +70,7 @@ impl RepositoryService {
     pub async fn sync_repository_branches_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = repo_proto::SyncRepositoryBranchesRequest::decode(request_bytes)
             .map_err(|e| format!("decode sync_repository_branches request: {e}"))?;
+        tracing::info!(target: "repository", org_slug = %req.org_slug, repository_id = req.id, "sync repository branches");
         let resp = self.client.sync_repository_branches_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -71,6 +78,7 @@ impl RepositoryService {
     pub async fn list_repository_merge_requests_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = repo_proto::ListRepositoryMergeRequestsRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_repository_merge_requests request: {e}"))?;
+        tracing::debug!(target: "repository", org_slug = %req.org_slug, repository_id = req.id, "list repository merge requests");
         let resp = self.client.list_repository_merge_requests_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -78,6 +86,7 @@ impl RepositoryService {
     pub async fn register_repository_webhook_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = repo_proto::RegisterRepositoryWebhookRequest::decode(request_bytes)
             .map_err(|e| format!("decode register_repository_webhook request: {e}"))?;
+        tracing::info!(target: "repository", org_slug = %req.org_slug, repository_id = req.id, "register repository webhook");
         let resp = self.client.register_repository_webhook_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -85,6 +94,7 @@ impl RepositoryService {
     pub async fn delete_repository_webhook_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = repo_proto::DeleteRepositoryWebhookRequest::decode(request_bytes)
             .map_err(|e| format!("decode delete_repository_webhook request: {e}"))?;
+        tracing::info!(target: "repository", org_slug = %req.org_slug, repository_id = req.id, "delete repository webhook");
         let resp = self.client.delete_repository_webhook_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -92,6 +102,7 @@ impl RepositoryService {
     pub async fn get_repository_webhook_status_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = repo_proto::GetRepositoryWebhookStatusRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_repository_webhook_status request: {e}"))?;
+        tracing::debug!(target: "repository", org_slug = %req.org_slug, repository_id = req.id, "get repository webhook status");
         let resp = self.client.get_repository_webhook_status_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -99,6 +110,7 @@ impl RepositoryService {
     pub async fn get_repository_webhook_secret_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = repo_proto::GetRepositoryWebhookSecretRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_repository_webhook_secret request: {e}"))?;
+        tracing::debug!(target: "repository", org_slug = %req.org_slug, repository_id = req.id, "get repository webhook secret");
         let resp = self.client.get_repository_webhook_secret_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -106,6 +118,7 @@ impl RepositoryService {
     pub async fn mark_repository_webhook_configured_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = repo_proto::MarkRepositoryWebhookConfiguredRequest::decode(request_bytes)
             .map_err(|e| format!("decode mark_repository_webhook_configured request: {e}"))?;
+        tracing::info!(target: "repository", org_slug = %req.org_slug, repository_id = req.id, "mark repository webhook configured");
         let resp = self.client.mark_repository_webhook_configured_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }

--- a/clients/core/crates/services/src/runner.rs
+++ b/clients/core/crates/services/src/runner.rs
@@ -23,6 +23,7 @@ impl RunnerService {
         // helper used, just expressed as wire-aligned proto bytes.
         let req = runner_proto::GetRunnerAuthStatusRequest::decode(request_bytes)
             .map_err(|e| format!("decode GetRunnerAuthStatusRequest: {e}"))?;
+        tracing::debug!(target: "runner", "get runner auth status");
         let resp = self.client
             .get_runner_auth_status_connect(&req)
             .await.map_err(crate::wire)?;
@@ -39,6 +40,7 @@ impl RunnerService {
         if req.org_slug.is_empty() {
             req.org_slug = self.client.current_org_slug();
         }
+        tracing::info!(target: "runner", org_slug = %req.org_slug, node_id = %req.node_id, "authorize runner");
         let resp = self.client
             .authorize_runner_connect(&req)
             .await.map_err(crate::wire)?;
@@ -55,6 +57,7 @@ impl RunnerService {
     pub async fn list_runners_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = runner_proto::ListRunnersRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_runners request: {e}"))?;
+        tracing::debug!(target: "runner", org_slug = %req.org_slug, "list runners");
         let resp = self.client.list_runners_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -62,6 +65,7 @@ impl RunnerService {
     pub async fn list_available_runners_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = runner_proto::ListAvailableRunnersRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_available_runners request: {e}"))?;
+        tracing::debug!(target: "runner", org_slug = %req.org_slug, "list available runners");
         let resp = self.client.list_available_runners_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -69,6 +73,7 @@ impl RunnerService {
     pub async fn get_runner_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = runner_proto::GetRunnerRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_runner request: {e}"))?;
+        tracing::debug!(target: "runner", org_slug = %req.org_slug, runner_id = req.id, "get runner");
         let resp = self.client.get_runner_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -76,6 +81,7 @@ impl RunnerService {
     pub async fn update_runner_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = runner_proto::UpdateRunnerRequest::decode(request_bytes)
             .map_err(|e| format!("decode update_runner request: {e}"))?;
+        tracing::info!(target: "runner", org_slug = %req.org_slug, runner_id = req.id, "update runner");
         let resp = self.client.update_runner_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -83,6 +89,7 @@ impl RunnerService {
     pub async fn delete_runner_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = runner_proto::DeleteRunnerRequest::decode(request_bytes)
             .map_err(|e| format!("decode delete_runner request: {e}"))?;
+        tracing::info!(target: "runner", org_slug = %req.org_slug, runner_id = req.id, "delete runner");
         let resp = self.client.delete_runner_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -90,6 +97,7 @@ impl RunnerService {
     pub async fn upgrade_runner_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = runner_proto::UpgradeRunnerRequest::decode(request_bytes)
             .map_err(|e| format!("decode upgrade_runner request: {e}"))?;
+        tracing::info!(target: "runner", org_slug = %req.org_slug, runner_id = req.id, target_version = %req.target_version, "upgrade runner");
         let resp = self.client.upgrade_runner_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -97,6 +105,7 @@ impl RunnerService {
     pub async fn request_log_upload_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = runner_proto::RequestLogUploadRequest::decode(request_bytes)
             .map_err(|e| format!("decode request_log_upload request: {e}"))?;
+        tracing::info!(target: "runner", org_slug = %req.org_slug, runner_id = req.id, "request log upload");
         let resp = self.client.request_log_upload_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -104,6 +113,7 @@ impl RunnerService {
     pub async fn list_runner_logs_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = runner_proto::ListRunnerLogsRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_runner_logs request: {e}"))?;
+        tracing::debug!(target: "runner", org_slug = %req.org_slug, runner_id = req.id, "list runner logs");
         let resp = self.client.list_runner_logs_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -111,6 +121,7 @@ impl RunnerService {
     pub async fn query_sandboxes_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = runner_proto::QuerySandboxesRequest::decode(request_bytes)
             .map_err(|e| format!("decode query_sandboxes request: {e}"))?;
+        tracing::debug!(target: "runner", org_slug = %req.org_slug, runner_id = req.id, "query sandboxes");
         let resp = self.client.query_sandboxes_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -118,6 +129,7 @@ impl RunnerService {
     pub async fn create_runner_token_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = runner_proto::CreateRunnerTokenRequest::decode(request_bytes)
             .map_err(|e| format!("decode create_runner_token request: {e}"))?;
+        tracing::info!(target: "runner", org_slug = %req.org_slug, "create runner token");
         let resp = self.client.create_runner_token_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -125,6 +137,7 @@ impl RunnerService {
     pub async fn list_runner_tokens_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = runner_proto::ListRunnerTokensRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_runner_tokens request: {e}"))?;
+        tracing::debug!(target: "runner", org_slug = %req.org_slug, "list runner tokens");
         let resp = self.client.list_runner_tokens_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -132,6 +145,7 @@ impl RunnerService {
     pub async fn delete_runner_token_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = runner_proto::DeleteRunnerTokenRequest::decode(request_bytes)
             .map_err(|e| format!("decode delete_runner_token request: {e}"))?;
+        tracing::info!(target: "runner", org_slug = %req.org_slug, token_id = req.id, "delete runner token");
         let resp = self.client.delete_runner_token_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }

--- a/clients/core/crates/services/src/sso.rs
+++ b/clients/core/crates/services/src/sso.rs
@@ -22,6 +22,7 @@ impl SSOService {
     pub async fn discover_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = sso_proto::DiscoverRequest::decode(request_bytes)
             .map_err(|e| format!("decode discover request: {e}"))?;
+        tracing::debug!(target: "sso", "discover");
         let resp = self.client.sso_discover_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -29,6 +30,7 @@ impl SSOService {
     pub async fn ldap_auth_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = sso_proto::LdapAuthRequest::decode(request_bytes)
             .map_err(|e| format!("decode ldap_auth request: {e}"))?;
+        tracing::info!(target: "sso", domain = %req.domain, "ldap auth");
         let resp = self.client.sso_ldap_auth_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }

--- a/clients/core/crates/services/src/support_ticket.rs
+++ b/clients/core/crates/services/src/support_ticket.rs
@@ -25,6 +25,7 @@ impl SupportTicketService {
     ) -> Result<Vec<u8>, String> {
         let req = st_proto::ListSupportTicketsRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_support_tickets request: {e}"))?;
+        tracing::debug!(target: "support_ticket", "list support tickets");
         let resp = self.client.list_support_tickets_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -34,6 +35,7 @@ impl SupportTicketService {
     ) -> Result<Vec<u8>, String> {
         let req = st_proto::GetSupportTicketRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_support_ticket request: {e}"))?;
+        tracing::debug!(target: "support_ticket", ticket_id = req.id, "get support ticket");
         let resp = self.client.get_support_ticket_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -43,6 +45,7 @@ impl SupportTicketService {
     ) -> Result<Vec<u8>, String> {
         let req = st_proto::GetAttachmentUrlRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_attachment_url request: {e}"))?;
+        tracing::debug!(target: "support_ticket", attachment_id = req.attachment_id, "get attachment url");
         let resp = self.client.get_support_ticket_attachment_url_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -52,6 +55,7 @@ impl SupportTicketService {
     ) -> Result<Vec<u8>, String> {
         let req = st_proto::CreateSupportTicketRequest::decode(request_bytes)
             .map_err(|e| format!("decode create_support_ticket request: {e}"))?;
+        tracing::info!(target: "support_ticket", category = %req.category, "create support ticket");
         let resp = self.client.create_support_ticket_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -61,6 +65,7 @@ impl SupportTicketService {
     ) -> Result<Vec<u8>, String> {
         let req = st_proto::AddSupportTicketMessageRequest::decode(request_bytes)
             .map_err(|e| format!("decode add_support_ticket_message request: {e}"))?;
+        tracing::info!(target: "support_ticket", ticket_id = req.ticket_id, "add support ticket message");
         let resp = self.client.add_support_ticket_message_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -70,6 +75,7 @@ impl SupportTicketService {
     ) -> Result<Vec<u8>, String> {
         let req = st_proto::PresignAttachmentUploadRequest::decode(request_bytes)
             .map_err(|e| format!("decode presign_attachment_upload request: {e}"))?;
+        tracing::info!(target: "support_ticket", ticket_id = req.ticket_id, size = req.size, "presign attachment upload");
         let resp = self.client.presign_support_ticket_attachment_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -79,6 +85,7 @@ impl SupportTicketService {
     ) -> Result<Vec<u8>, String> {
         let req = st_proto::AssociateAttachmentsRequest::decode(request_bytes)
             .map_err(|e| format!("decode associate_attachments request: {e}"))?;
+        tracing::info!(target: "support_ticket", ticket_id = req.ticket_id, "associate attachments");
         let resp = self.client.associate_support_ticket_attachments_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }

--- a/clients/core/crates/services/src/ticket.rs
+++ b/clients/core/crates/services/src/ticket.rs
@@ -29,6 +29,7 @@ impl TicketService {
             ticket_slug: slug.to_string(),
             active_only,
         };
+        tracing::debug!(target: "ticket", ticket_slug = %req.ticket_slug, "get ticket pods");
         let proto_resp = self.client
             .get_ticket_pods_connect(&req)
             .await.map_err(crate::wire)?;
@@ -66,6 +67,7 @@ impl TicketService {
     pub async fn list_tickets_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ticket_proto::ListTicketsRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_tickets request: {e}"))?;
+        tracing::debug!(target: "ticket", org_slug = %req.org_slug, "list tickets");
         let resp = self.client.list_tickets_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -73,6 +75,7 @@ impl TicketService {
     pub async fn get_ticket_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ticket_proto::GetTicketRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_ticket request: {e}"))?;
+        tracing::debug!(target: "ticket", org_slug = %req.org_slug, ticket_slug = %req.ticket_slug, "get ticket");
         let resp = self.client.get_ticket_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -80,6 +83,7 @@ impl TicketService {
     pub async fn create_ticket_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ticket_proto::CreateTicketRequest::decode(request_bytes)
             .map_err(|e| format!("decode create_ticket request: {e}"))?;
+        tracing::info!(target: "ticket", org_slug = %req.org_slug, repository_id = ?req.repository_id, "create ticket");
         let resp = self.client.create_ticket_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -87,6 +91,7 @@ impl TicketService {
     pub async fn update_ticket_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ticket_proto::UpdateTicketRequest::decode(request_bytes)
             .map_err(|e| format!("decode update_ticket request: {e}"))?;
+        tracing::info!(target: "ticket", org_slug = %req.org_slug, ticket_slug = %req.ticket_slug, "update ticket");
         let resp = self.client.update_ticket_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -94,6 +99,7 @@ impl TicketService {
     pub async fn delete_ticket_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ticket_proto::DeleteTicketRequest::decode(request_bytes)
             .map_err(|e| format!("decode delete_ticket request: {e}"))?;
+        tracing::info!(target: "ticket", org_slug = %req.org_slug, ticket_slug = %req.ticket_slug, "delete ticket");
         let resp = self.client.delete_ticket_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -101,6 +107,7 @@ impl TicketService {
     pub async fn update_ticket_status_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ticket_proto::UpdateTicketStatusRequest::decode(request_bytes)
             .map_err(|e| format!("decode update_ticket_status request: {e}"))?;
+        tracing::info!(target: "ticket", org_slug = %req.org_slug, ticket_slug = %req.ticket_slug, status = %req.status, "update ticket status");
         let resp = self.client.update_ticket_status_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -108,6 +115,7 @@ impl TicketService {
     pub async fn get_active_tickets_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ticket_proto::GetActiveTicketsRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_active_tickets request: {e}"))?;
+        tracing::debug!(target: "ticket", org_slug = %req.org_slug, "get active tickets");
         let resp = self.client.get_active_tickets_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -115,6 +123,7 @@ impl TicketService {
     pub async fn get_board_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ticket_proto::GetBoardRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_board request: {e}"))?;
+        tracing::debug!(target: "ticket", org_slug = %req.org_slug, "get board");
         let resp = self.client.get_board_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -122,6 +131,7 @@ impl TicketService {
     pub async fn get_sub_tickets_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ticket_proto::GetSubTicketsRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_sub_tickets request: {e}"))?;
+        tracing::debug!(target: "ticket", org_slug = %req.org_slug, ticket_slug = %req.ticket_slug, "get sub tickets");
         let resp = self.client.get_sub_tickets_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -129,6 +139,7 @@ impl TicketService {
     pub async fn add_assignee_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ticket_proto::AddAssigneeRequest::decode(request_bytes)
             .map_err(|e| format!("decode add_assignee request: {e}"))?;
+        tracing::info!(target: "ticket", org_slug = %req.org_slug, ticket_slug = %req.ticket_slug, user_id = req.user_id, "add assignee");
         let resp = self.client.add_assignee_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -136,6 +147,7 @@ impl TicketService {
     pub async fn remove_assignee_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ticket_proto::RemoveAssigneeRequest::decode(request_bytes)
             .map_err(|e| format!("decode remove_assignee request: {e}"))?;
+        tracing::info!(target: "ticket", org_slug = %req.org_slug, ticket_slug = %req.ticket_slug, user_id = req.user_id, "remove assignee");
         let resp = self.client.remove_assignee_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -143,6 +155,7 @@ impl TicketService {
     pub async fn list_labels_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ticket_proto::ListLabelsRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_labels request: {e}"))?;
+        tracing::debug!(target: "ticket", org_slug = %req.org_slug, "list labels");
         let resp = self.client.list_labels_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -150,6 +163,7 @@ impl TicketService {
     pub async fn create_label_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ticket_proto::CreateLabelRequest::decode(request_bytes)
             .map_err(|e| format!("decode create_label request: {e}"))?;
+        tracing::info!(target: "ticket", org_slug = %req.org_slug, "create label");
         let resp = self.client.create_label_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -157,6 +171,7 @@ impl TicketService {
     pub async fn update_label_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ticket_proto::UpdateLabelRequest::decode(request_bytes)
             .map_err(|e| format!("decode update_label request: {e}"))?;
+        tracing::info!(target: "ticket", org_slug = %req.org_slug, label_id = req.id, "update label");
         let resp = self.client.update_label_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -164,6 +179,7 @@ impl TicketService {
     pub async fn delete_label_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ticket_proto::DeleteLabelRequest::decode(request_bytes)
             .map_err(|e| format!("decode delete_label request: {e}"))?;
+        tracing::info!(target: "ticket", org_slug = %req.org_slug, label_id = req.id, "delete label");
         let resp = self.client.delete_label_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -171,6 +187,7 @@ impl TicketService {
     pub async fn add_label_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ticket_proto::AddLabelRequest::decode(request_bytes)
             .map_err(|e| format!("decode add_label request: {e}"))?;
+        tracing::info!(target: "ticket", org_slug = %req.org_slug, ticket_slug = %req.ticket_slug, label_id = req.label_id, "add label");
         let resp = self.client.add_label_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -178,6 +195,7 @@ impl TicketService {
     pub async fn remove_label_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = ticket_proto::RemoveLabelRequest::decode(request_bytes)
             .map_err(|e| format!("decode remove_label request: {e}"))?;
+        tracing::info!(target: "ticket", org_slug = %req.org_slug, ticket_slug = %req.ticket_slug, label_id = req.label_id, "remove label");
         let resp = self.client.remove_label_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }

--- a/clients/core/crates/services/src/ticket_relations.rs
+++ b/clients/core/crates/services/src/ticket_relations.rs
@@ -21,6 +21,7 @@ impl TicketRelationsService {
     pub async fn list_relations_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = tr_proto::ListRelationsRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_relations request: {e}"))?;
+        tracing::debug!(target: "ticket_relations", org_slug = %req.org_slug, ticket_slug = %req.ticket_slug, "list relations");
         let resp = self.client.list_relations_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -28,6 +29,7 @@ impl TicketRelationsService {
     pub async fn create_relation_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = tr_proto::CreateRelationRequest::decode(request_bytes)
             .map_err(|e| format!("decode create_relation request: {e}"))?;
+        tracing::info!(target: "ticket_relations", org_slug = %req.org_slug, ticket_slug = %req.ticket_slug, target_slug = %req.target_slug, relation_type = %req.relation_type, "create relation");
         let resp = self.client.create_relation_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -35,6 +37,7 @@ impl TicketRelationsService {
     pub async fn delete_relation_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = tr_proto::DeleteRelationRequest::decode(request_bytes)
             .map_err(|e| format!("decode delete_relation request: {e}"))?;
+        tracing::info!(target: "ticket_relations", org_slug = %req.org_slug, ticket_slug = %req.ticket_slug, relation_id = req.relation_id, "delete relation");
         let resp = self.client.delete_relation_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -42,6 +45,7 @@ impl TicketRelationsService {
     pub async fn list_merge_requests_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = tr_proto::ListMergeRequestsRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_merge_requests request: {e}"))?;
+        tracing::debug!(target: "ticket_relations", org_slug = %req.org_slug, ticket_slug = %req.ticket_slug, "list merge requests");
         let resp = self.client.list_ticket_merge_requests_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -49,6 +53,7 @@ impl TicketRelationsService {
     pub async fn list_commits_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = tr_proto::ListCommitsRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_commits request: {e}"))?;
+        tracing::debug!(target: "ticket_relations", org_slug = %req.org_slug, ticket_slug = %req.ticket_slug, "list commits");
         let resp = self.client.list_ticket_commits_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -56,6 +61,7 @@ impl TicketRelationsService {
     pub async fn link_commit_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = tr_proto::LinkCommitRequest::decode(request_bytes)
             .map_err(|e| format!("decode link_commit request: {e}"))?;
+        tracing::info!(target: "ticket_relations", org_slug = %req.org_slug, ticket_slug = %req.ticket_slug, "link commit");
         let resp = self.client.link_commit_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -63,6 +69,7 @@ impl TicketRelationsService {
     pub async fn unlink_commit_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = tr_proto::UnlinkCommitRequest::decode(request_bytes)
             .map_err(|e| format!("decode unlink_commit request: {e}"))?;
+        tracing::info!(target: "ticket_relations", org_slug = %req.org_slug, ticket_slug = %req.ticket_slug, commit_id = req.commit_id, "unlink commit");
         let resp = self.client.unlink_commit_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -70,6 +77,7 @@ impl TicketRelationsService {
     pub async fn list_comments_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = tr_proto::ListCommentsRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_comments request: {e}"))?;
+        tracing::debug!(target: "ticket_relations", org_slug = %req.org_slug, ticket_slug = %req.ticket_slug, "list comments");
         let resp = self.client.list_comments_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -77,6 +85,7 @@ impl TicketRelationsService {
     pub async fn create_comment_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = tr_proto::CreateCommentRequest::decode(request_bytes)
             .map_err(|e| format!("decode create_comment request: {e}"))?;
+        tracing::info!(target: "ticket_relations", org_slug = %req.org_slug, ticket_slug = %req.ticket_slug, "create comment");
         let resp = self.client.create_comment_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -84,6 +93,7 @@ impl TicketRelationsService {
     pub async fn update_comment_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = tr_proto::UpdateCommentRequest::decode(request_bytes)
             .map_err(|e| format!("decode update_comment request: {e}"))?;
+        tracing::info!(target: "ticket_relations", org_slug = %req.org_slug, ticket_slug = %req.ticket_slug, comment_id = req.comment_id, "update comment");
         let resp = self.client.update_comment_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -91,6 +101,7 @@ impl TicketRelationsService {
     pub async fn delete_comment_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = tr_proto::DeleteCommentRequest::decode(request_bytes)
             .map_err(|e| format!("decode delete_comment request: {e}"))?;
+        tracing::info!(target: "ticket_relations", org_slug = %req.org_slug, ticket_slug = %req.ticket_slug, comment_id = req.comment_id, "delete comment");
         let resp = self.client.delete_comment_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }

--- a/clients/core/crates/services/src/user.rs
+++ b/clients/core/crates/services/src/user.rs
@@ -18,6 +18,7 @@ impl UserApiService {
     pub async fn get_me_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = user_proto::GetMeRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_me request: {e}"))?;
+        tracing::debug!(target: "user", "get me");
         let resp = self.client.get_me_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -25,6 +26,7 @@ impl UserApiService {
     pub async fn update_me_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = user_proto::UpdateMeRequest::decode(request_bytes)
             .map_err(|e| format!("decode update_me request: {e}"))?;
+        tracing::info!(target: "user", "update me");
         let resp = self.client.update_me_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -32,6 +34,7 @@ impl UserApiService {
     pub async fn change_password_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = user_proto::ChangePasswordRequest::decode(request_bytes)
             .map_err(|e| format!("decode change_password request: {e}"))?;
+        tracing::info!(target: "user", "change password");
         let resp = self.client.change_password_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -39,6 +42,7 @@ impl UserApiService {
     pub async fn list_identities_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = user_proto::ListIdentitiesRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_identities request: {e}"))?;
+        tracing::debug!(target: "user", "list identities");
         let resp = self.client.list_identities_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -46,6 +50,7 @@ impl UserApiService {
     pub async fn delete_identity_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = user_proto::DeleteIdentityRequest::decode(request_bytes)
             .map_err(|e| format!("decode delete_identity request: {e}"))?;
+        tracing::info!(target: "user", provider = %req.provider, "delete identity");
         let resp = self.client.delete_identity_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -53,6 +58,7 @@ impl UserApiService {
     pub async fn search_users_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = user_proto::SearchUsersRequest::decode(request_bytes)
             .map_err(|e| format!("decode search_users request: {e}"))?;
+        tracing::debug!(target: "user", "search users");
         let resp = self.client.search_users_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }

--- a/clients/core/crates/services/src/user_credential.rs
+++ b/clients/core/crates/services/src/user_credential.rs
@@ -30,6 +30,7 @@ impl UserCredentialService {
     pub async fn list_git_credentials_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let _ = uc_proto::ListGitCredentialsRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_git_credentials request: {e}"))?;
+        tracing::debug!(target: "credential", "list git credentials");
         let resp = self.client().list_git_credentials_connect().await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -37,6 +38,7 @@ impl UserCredentialService {
     pub async fn get_git_credential_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = uc_proto::GetGitCredentialRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_git_credential request: {e}"))?;
+        tracing::debug!(target: "credential", git_credential_id = req.id, "get git credential");
         let resp = self.client().get_git_credential_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -44,6 +46,7 @@ impl UserCredentialService {
     pub async fn create_git_credential_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = uc_proto::CreateGitCredentialRequest::decode(request_bytes)
             .map_err(|e| format!("decode create_git_credential request: {e}"))?;
+        tracing::info!(target: "credential", credential_type = %req.credential_type, "create git credential");
         let resp = self.client().create_git_credential_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -51,6 +54,7 @@ impl UserCredentialService {
     pub async fn update_git_credential_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = uc_proto::UpdateGitCredentialRequest::decode(request_bytes)
             .map_err(|e| format!("decode update_git_credential request: {e}"))?;
+        tracing::info!(target: "credential", git_credential_id = req.id, "update git credential");
         let resp = self.client().update_git_credential_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -58,6 +62,7 @@ impl UserCredentialService {
     pub async fn delete_git_credential_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = uc_proto::DeleteGitCredentialRequest::decode(request_bytes)
             .map_err(|e| format!("decode delete_git_credential request: {e}"))?;
+        tracing::info!(target: "credential", git_credential_id = req.id, "delete git credential");
         let resp = self.client().delete_git_credential_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -65,6 +70,7 @@ impl UserCredentialService {
     pub async fn get_default_git_credential_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let _ = uc_proto::GetDefaultGitCredentialRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_default_git_credential request: {e}"))?;
+        tracing::debug!(target: "credential", "get default git credential");
         let resp = self.client().get_default_git_credential_connect().await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -72,6 +78,7 @@ impl UserCredentialService {
     pub async fn set_default_git_credential_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = uc_proto::SetDefaultGitCredentialRequest::decode(request_bytes)
             .map_err(|e| format!("decode set_default_git_credential request: {e}"))?;
+        tracing::info!(target: "credential", credential_id = ?req.credential_id, "set default git credential");
         let resp = self.client().set_default_git_credential_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -79,6 +86,7 @@ impl UserCredentialService {
     pub async fn clear_default_git_credential_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let _ = uc_proto::ClearDefaultGitCredentialRequest::decode(request_bytes)
             .map_err(|e| format!("decode clear_default_git_credential request: {e}"))?;
+        tracing::info!(target: "credential", "clear default git credential");
         let resp = self.client().clear_default_git_credential_connect().await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -90,6 +98,7 @@ impl UserCredentialService {
     pub async fn list_agent_credentials_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let _ = uc_proto::ListAgentCredentialProfilesRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_agent_credentials request: {e}"))?;
+        tracing::debug!(target: "credential", "list agent credentials");
         let resp = self.client().list_agent_credentials_connect().await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -97,6 +106,7 @@ impl UserCredentialService {
     pub async fn list_agent_credentials_for_agent_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = uc_proto::ListAgentCredentialProfilesForAgentRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_agent_credentials_for_agent request: {e}"))?;
+        tracing::debug!(target: "credential", agent_slug = %req.agent_slug, "list agent credentials for agent");
         let resp = self.client().list_agent_credentials_for_agent_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -104,6 +114,7 @@ impl UserCredentialService {
     pub async fn get_agent_credential_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = uc_proto::GetAgentCredentialProfileRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_agent_credential request: {e}"))?;
+        tracing::debug!(target: "credential", agent_credential_id = req.id, "get agent credential");
         let resp = self.client().get_agent_credential_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -111,6 +122,7 @@ impl UserCredentialService {
     pub async fn create_agent_credential_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = uc_proto::CreateAgentCredentialProfileRequest::decode(request_bytes)
             .map_err(|e| format!("decode create_agent_credential request: {e}"))?;
+        tracing::info!(target: "credential", agent_slug = %req.agent_slug, "create agent credential");
         let resp = self.client().create_agent_credential_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -118,6 +130,7 @@ impl UserCredentialService {
     pub async fn update_agent_credential_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = uc_proto::UpdateAgentCredentialProfileRequest::decode(request_bytes)
             .map_err(|e| format!("decode update_agent_credential request: {e}"))?;
+        tracing::info!(target: "credential", agent_credential_id = req.id, "update agent credential");
         let resp = self.client().update_agent_credential_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -125,6 +138,7 @@ impl UserCredentialService {
     pub async fn delete_agent_credential_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = uc_proto::DeleteAgentCredentialProfileRequest::decode(request_bytes)
             .map_err(|e| format!("decode delete_agent_credential request: {e}"))?;
+        tracing::info!(target: "credential", agent_credential_id = req.id, "delete agent credential");
         let resp = self.client().delete_agent_credential_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -132,6 +146,7 @@ impl UserCredentialService {
     pub async fn set_default_agent_credential_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = uc_proto::SetDefaultAgentCredentialProfileRequest::decode(request_bytes)
             .map_err(|e| format!("decode set_default_agent_credential request: {e}"))?;
+        tracing::info!(target: "credential", agent_credential_id = req.id, "set default agent credential");
         let resp = self.client().set_default_agent_credential_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -143,6 +158,7 @@ impl UserCredentialService {
     pub async fn list_repository_providers_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let _ = uc_proto::ListRepositoryProvidersRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_repository_providers request: {e}"))?;
+        tracing::debug!(target: "credential", "list repository providers");
         let resp = self.client().list_repository_providers_connect().await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -150,6 +166,7 @@ impl UserCredentialService {
     pub async fn get_repository_provider_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = uc_proto::GetRepositoryProviderRequest::decode(request_bytes)
             .map_err(|e| format!("decode get_repository_provider request: {e}"))?;
+        tracing::debug!(target: "credential", repository_provider_id = req.id, "get repository provider");
         let resp = self.client().get_repository_provider_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -157,6 +174,7 @@ impl UserCredentialService {
     pub async fn create_repository_provider_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = uc_proto::CreateRepositoryProviderRequest::decode(request_bytes)
             .map_err(|e| format!("decode create_repository_provider request: {e}"))?;
+        tracing::info!(target: "credential", provider_type = %req.provider_type, "create repository provider");
         let resp = self.client().create_repository_provider_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -164,6 +182,7 @@ impl UserCredentialService {
     pub async fn update_repository_provider_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = uc_proto::UpdateRepositoryProviderRequest::decode(request_bytes)
             .map_err(|e| format!("decode update_repository_provider request: {e}"))?;
+        tracing::info!(target: "credential", repository_provider_id = req.id, "update repository provider");
         let resp = self.client().update_repository_provider_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -171,6 +190,7 @@ impl UserCredentialService {
     pub async fn delete_repository_provider_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = uc_proto::DeleteRepositoryProviderRequest::decode(request_bytes)
             .map_err(|e| format!("decode delete_repository_provider request: {e}"))?;
+        tracing::info!(target: "credential", repository_provider_id = req.id, "delete repository provider");
         let resp = self.client().delete_repository_provider_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -178,6 +198,7 @@ impl UserCredentialService {
     pub async fn set_default_repository_provider_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = uc_proto::SetDefaultRepositoryProviderRequest::decode(request_bytes)
             .map_err(|e| format!("decode set_default_repository_provider request: {e}"))?;
+        tracing::info!(target: "credential", repository_provider_id = req.id, "set default repository provider");
         let resp = self.client().set_default_repository_provider_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -185,6 +206,7 @@ impl UserCredentialService {
     pub async fn test_repository_provider_connection_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = uc_proto::TestRepositoryProviderConnectionRequest::decode(request_bytes)
             .map_err(|e| format!("decode test_repository_provider_connection request: {e}"))?;
+        tracing::debug!(target: "credential", repository_provider_id = req.id, "test repository provider connection");
         let resp = self.client().test_repository_provider_connection_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }
@@ -192,6 +214,7 @@ impl UserCredentialService {
     pub async fn list_provider_repositories_connect(&self, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
         let req = uc_proto::ListProviderRepositoriesRequest::decode(request_bytes)
             .map_err(|e| format!("decode list_provider_repositories request: {e}"))?;
+        tracing::debug!(target: "credential", repository_provider_id = req.id, "list provider repositories");
         let resp = self.client().list_provider_repositories_connect(&req).await.map_err(crate::wire)?;
         Ok(resp.encode_to_vec())
     }

--- a/clients/core/crates/state/src/autopilot_state.rs
+++ b/clients/core/crates/state/src/autopilot_state.rs
@@ -70,6 +70,7 @@ impl AutopilotState {
     }
 
     pub fn set_controllers(&mut self, controllers: Vec<AutopilotController>) {
+        tracing::debug!(target: "autopilot", count = controllers.len(), "set controllers (baseline)");
         self.controllers = controllers;
     }
 
@@ -78,10 +79,24 @@ impl AutopilotState {
     }
 
     pub fn add_controller(&mut self, controller: AutopilotController) {
+        tracing::info!(
+            target: "autopilot",
+            controller_key = %controller.autopilot_controller_key,
+            pod_key = %controller.pod_key,
+            status = ?controller.status,
+            "add controller"
+        );
         self.controllers.push(controller);
     }
 
     pub fn update_controller(&mut self, key: &str, controller: AutopilotController) {
+        tracing::info!(
+            target: "autopilot",
+            controller_key = key,
+            status = ?controller.status,
+            circuit_breaker_state = ?controller.circuit_breaker_state,
+            "update controller"
+        );
         for c in &mut self.controllers {
             if c.autopilot_controller_key == key {
                 *c = controller.clone();
@@ -95,6 +110,7 @@ impl AutopilotState {
     }
 
     pub fn remove_controller(&mut self, key: &str) {
+        tracing::info!(target: "autopilot", controller_key = key, "remove controller");
         self.controllers.retain(|c| c.autopilot_controller_key != key);
         if self.current_controller
             .as_ref()
@@ -109,10 +125,18 @@ impl AutopilotState {
     }
 
     pub fn set_iterations(&mut self, key: String, iters: Vec<AutopilotIteration>) {
+        tracing::debug!(target: "autopilot", controller_key = %key, count = iters.len(), "set iterations (baseline)");
         self.iterations.insert(key, iters);
     }
 
     pub fn add_iteration(&mut self, key: String, iteration: AutopilotIteration) {
+        tracing::info!(
+            target: "autopilot",
+            controller_key = %key,
+            iteration_id = iteration.id,
+            status = ?iteration.status,
+            "add iteration"
+        );
         let iters = self.iterations.entry(key).or_default();
         iters.push(iteration);
         if iters.len() > MAX_ITERATIONS {
@@ -130,6 +154,7 @@ impl AutopilotState {
     }
 
     pub fn update_thinking(&mut self, key: String, thinking: Value) {
+        tracing::debug!(target: "autopilot", controller_key = %key, "update thinking");
         self.thinking.insert(key.clone(), Some(thinking.clone()));
         let history = self.thinking_history.entry(key).or_default();
         history.push(thinking);

--- a/clients/core/crates/state/src/channel_state/channels.rs
+++ b/clients/core/crates/state/src/channel_state/channels.rs
@@ -20,6 +20,7 @@ impl ChannelState {
     /// last_message) that wire-side ListChannels won't carry — these are
     /// maintained by `on_new_message` and friends.
     pub fn set_channels(&mut self, channels: Vec<Channel>) {
+        tracing::debug!(target: "channel", count = channels.len(), "set channels (baseline)");
         let mut prev: HashMap<i64, (u32, u32, Option<MessagePreview>, Option<String>)> =
             HashMap::with_capacity(self.channels.len());
         for c in &self.channels {
@@ -49,6 +50,7 @@ impl ChannelState {
     }
 
     pub fn add_channel(&mut self, channel: Channel) {
+        tracing::info!(target: "channel", channel_id = channel.id, "add channel");
         if self.channels.iter().any(|c| c.id == channel.id) {
             return;
         }
@@ -59,6 +61,7 @@ impl ChannelState {
     }
 
     pub fn update_channel(&mut self, id: i64, channel: Channel) {
+        tracing::info!(target: "channel", channel_id = id, "update channel");
         if let Some(existing) = self.channels.iter_mut().find(|c| c.id == id) {
             *existing = channel.clone();
             if let Some(repo) = &self.channel_repo {
@@ -71,6 +74,7 @@ impl ChannelState {
     }
 
     pub fn remove_channel(&mut self, id: i64) {
+        tracing::info!(target: "channel", channel_id = id, "remove channel");
         self.channels.retain(|c| c.id != id);
         if self.current_channel.as_ref().is_some_and(|c| c.id == id) {
             self.current_channel = None;
@@ -93,6 +97,7 @@ impl ChannelState {
 
     /// Atomically: set current channel + clear unread + clear mentions.
     pub fn select_channel(&mut self, id: Option<i64>) -> Option<&Channel> {
+        tracing::debug!(target: "channel", channel_id = ?id, "select channel");
         self.set_current_channel(id);
         if let Some(id) = id {
             self.clear_channel_unread(id);

--- a/clients/core/crates/state/src/channel_state/counters.rs
+++ b/clients/core/crates/state/src/channel_state/counters.rs
@@ -10,6 +10,7 @@ use super::ChannelState;
 
 impl ChannelState {
     pub fn set_unread_counts(&mut self, counts: HashMap<i64, u32>) {
+        tracing::debug!(target: "channel", count = counts.len(), "set unread counts (baseline)");
         for c in self.channels.iter_mut() {
             c.unread_count = counts.get(&c.id).copied().unwrap_or(0);
         }
@@ -17,6 +18,7 @@ impl ChannelState {
     }
 
     pub fn increment_unread(&mut self, channel_id: i64) {
+        tracing::debug!(target: "channel", channel_id, "increment unread");
         if let Some(c) = self.channels.iter_mut().find(|c| c.id == channel_id) {
             c.unread_count = c.unread_count.saturating_add(1);
         }
@@ -24,6 +26,7 @@ impl ChannelState {
     }
 
     pub fn clear_channel_unread(&mut self, channel_id: i64) {
+        tracing::debug!(target: "channel", channel_id, "clear unread");
         if let Some(c) = self.channels.iter_mut().find(|c| c.id == channel_id) {
             c.unread_count = 0;
         }
@@ -47,6 +50,7 @@ impl ChannelState {
     }
 
     pub fn set_mention_counts(&mut self, counts: HashMap<i64, u32>) {
+        tracing::debug!(target: "channel", count = counts.len(), "set mention counts (baseline)");
         for c in self.channels.iter_mut() {
             c.mention_count = counts.get(&c.id).copied().unwrap_or(0);
         }
@@ -54,6 +58,7 @@ impl ChannelState {
     }
 
     pub fn increment_mention(&mut self, channel_id: i64) {
+        tracing::debug!(target: "channel", channel_id, "increment mention");
         if let Some(c) = self.channels.iter_mut().find(|c| c.id == channel_id) {
             c.mention_count = c.mention_count.saturating_add(1);
         }
@@ -61,6 +66,7 @@ impl ChannelState {
     }
 
     pub fn clear_channel_mentions(&mut self, channel_id: i64) {
+        tracing::debug!(target: "channel", channel_id, "clear mentions");
         if let Some(c) = self.channels.iter_mut().find(|c| c.id == channel_id) {
             c.mention_count = 0;
         }

--- a/clients/core/crates/state/src/channel_state/members.rs
+++ b/clients/core/crates/state/src/channel_state/members.rs
@@ -4,6 +4,7 @@ use crate::channel_types::ChannelMember;
 
 impl ChannelState {
     pub fn set_channel_members(&mut self, channel_id: i64, members: Vec<ChannelMember>) {
+        tracing::debug!(target: "channel", channel_id, count = members.len(), "set channel members");
         self.members_by_channel.insert(channel_id, members);
     }
 
@@ -12,16 +13,19 @@ impl ChannelState {
     }
 
     pub fn remove_channel_member(&mut self, channel_id: i64, user_id: i64) {
+        tracing::info!(target: "channel", channel_id, user_id, "remove channel member");
         if let Some(list) = self.members_by_channel.get_mut(&channel_id) {
             list.retain(|m| m.user_id != user_id);
         }
     }
 
     pub fn clear_channel_members(&mut self, channel_id: i64) {
+        tracing::debug!(target: "channel", channel_id, "clear channel members");
         self.members_by_channel.remove(&channel_id);
     }
 
     pub fn set_channel_pods(&mut self, channel_id: i64, pods: Vec<Pod>) {
+        tracing::debug!(target: "channel", channel_id, count = pods.len(), "set channel pods");
         self.pods_by_channel.insert(channel_id, pods);
     }
 
@@ -30,6 +34,7 @@ impl ChannelState {
     }
 
     pub fn clear_channel_pods(&mut self, channel_id: i64) {
+        tracing::debug!(target: "channel", channel_id, "clear channel pods");
         self.pods_by_channel.remove(&channel_id);
     }
 
@@ -38,6 +43,7 @@ impl ChannelState {
     /// arms — the event itself doesn't carry the new count, only the
     /// delta. Returns true if the channel exists and was updated.
     pub fn patch_member_count(&mut self, channel_id: i64, delta: i32) -> bool {
+        tracing::info!(target: "channel", channel_id, delta, "patch member count");
         if let Some(existing) = self.get_channel(channel_id).cloned() {
             let mut next = existing;
             let curr = next.member_count.unwrap_or(0);

--- a/clients/core/crates/state/src/channel_state/messages.rs
+++ b/clients/core/crates/state/src/channel_state/messages.rs
@@ -5,6 +5,7 @@ use crate::channel_types::ChannelMessage;
 
 impl ChannelState {
     pub fn add_message(&mut self, channel_id: i64, message: ChannelMessage) -> bool {
+        tracing::debug!(target: "channel", channel_id, msg_id = message.id, "add message");
         let cache = self
             .message_cache
             .entry(channel_id)
@@ -40,6 +41,7 @@ impl ChannelState {
     /// Returns true when the message was newly added (false on dup id).
     pub fn on_new_message(&mut self, mut msg: ChannelMessage) -> bool {
         let channel_id = msg.channel_id;
+        tracing::debug!(target: "channel", channel_id, msg_id = msg.id, "on new message");
         self.enrich_sender(&mut msg);
         let preview = Self::make_preview(&msg);
         self.set_last_message(channel_id, preview);
@@ -78,6 +80,7 @@ impl ChannelState {
     }
 
     pub fn update_message(&mut self, channel_id: i64, message: ChannelMessage) {
+        tracing::debug!(target: "channel", channel_id, msg_id = message.id, "update message");
         if let Some(cache) = self.message_cache.get_mut(&channel_id) {
             if let Some(m) = cache.messages.iter_mut().find(|m| m.id == message.id) {
                 if !message.body.is_empty() { m.body = message.body; }
@@ -98,6 +101,7 @@ impl ChannelState {
     }
 
     pub fn remove_message(&mut self, channel_id: i64, message_id: i64) {
+        tracing::debug!(target: "channel", channel_id, msg_id = message_id, "remove message");
         if let Some(cache) = self.message_cache.get_mut(&channel_id) {
             cache.messages.retain(|m| m.id != message_id);
             if let Some(repo) = &self.message_repo {
@@ -111,6 +115,7 @@ impl ChannelState {
     }
 
     pub fn set_messages(&mut self, channel_id: i64, messages: Vec<ChannelMessage>, has_more: bool) {
+        tracing::debug!(target: "channel", channel_id, count = messages.len(), has_more, "set messages (baseline)");
         if let Some(repo) = &self.message_repo {
             for msg in &messages {
                 let _ = repo.save_message(msg);
@@ -134,6 +139,7 @@ impl ChannelState {
     }
 
     pub fn prepend_messages(&mut self, channel_id: i64, older: Vec<ChannelMessage>, has_more: bool) {
+        tracing::debug!(target: "channel", channel_id, count = older.len(), has_more, "prepend messages");
         let cache = self
             .message_cache
             .entry(channel_id)

--- a/clients/core/crates/state/src/channel_state/preview.rs
+++ b/clients/core/crates/state/src/channel_state/preview.rs
@@ -14,6 +14,7 @@ impl ChannelState {
     /// renders read directly from `Channel.last_message` — no side-channel
     /// HashMap needed.
     pub fn set_last_message(&mut self, channel_id: i64, preview: MessagePreview) {
+        tracing::debug!(target: "channel", channel_id, msg_id = preview.message_id, "set last message");
         let ts = preview.timestamp.clone();
         if let Some(c) = self.channels.iter_mut().find(|c| c.id == channel_id) {
             c.last_activity_at = Some(ts.clone());

--- a/clients/core/crates/state/src/loop_state.rs
+++ b/clients/core/crates/state/src/loop_state.rs
@@ -141,6 +141,7 @@ impl LoopState {
     }
 
     pub fn set_loops(&mut self, loops: Vec<LoopData>) {
+        tracing::debug!(target: "loop", count = loops.len(), "set loops (baseline)");
         self.loops = loops;
         if let Some(repo) = &self.repo {
             for l in &self.loops { let _ = repo.save_loop(l); }
@@ -152,6 +153,7 @@ impl LoopState {
     }
 
     pub fn update_loop(&mut self, slug: &str, loop_data: LoopData) {
+        tracing::info!(target: "loop", slug, status = ?loop_data.status, "update loop");
         if let Some(l) = self.loops.iter_mut().find(|l| l.slug == slug) {
             *l = loop_data.clone();
             if let Some(repo) = &self.repo { let _ = repo.save_loop(l); }
@@ -162,19 +164,23 @@ impl LoopState {
     }
 
     pub fn add_run(&mut self, run: LoopRunData) {
+        tracing::info!(target: "loop", run_id = run.id, loop_slug = %run.loop_slug, status = %run.status, "add run");
         if let Some(repo) = &self.repo { let _ = repo.save_run(&run); }
         self.runs.push(run);
     }
 
     pub fn set_runs(&mut self, runs: Vec<LoopRunData>) {
+        tracing::debug!(target: "loop", count = runs.len(), "set runs (baseline)");
         self.runs = runs;
     }
 
     pub fn append_runs(&mut self, runs: Vec<LoopRunData>) {
+        tracing::debug!(target: "loop", count = runs.len(), "append runs");
         self.runs.extend(runs);
     }
 
     pub fn update_run_status(&mut self, run_id: i64, status: &str) {
+        tracing::info!(target: "loop", run_id, status, "run status changed");
         if let Some(run) = self.runs.iter_mut().find(|r| r.id == run_id) {
             run.status = status.to_string();
             if let Some(repo) = &self.repo { let _ = repo.save_run(run); }
@@ -182,6 +188,7 @@ impl LoopState {
     }
 
     pub fn clear_runs(&mut self) {
+        tracing::debug!(target: "loop", "clear runs");
         self.runs.clear();
     }
 }

--- a/clients/core/crates/state/src/mesh_state.rs
+++ b/clients/core/crates/state/src/mesh_state.rs
@@ -20,10 +20,12 @@ impl MeshState {
     }
 
     pub fn set_topology(&mut self, topology: MeshTopology) {
+        tracing::debug!(target: "mesh", nodes = topology.nodes.len(), edges = topology.edges.len(), "set topology");
         self.topology = Some(topology);
     }
 
     pub fn clear_topology(&mut self) {
+        tracing::debug!(target: "mesh", "clear topology");
         self.topology = None;
     }
 

--- a/clients/core/crates/state/src/pod_state.rs
+++ b/clients/core/crates/state/src/pod_state.rs
@@ -64,6 +64,7 @@ impl PodState {
     }
 
     pub fn upsert_pod(&mut self, pod: Pod, timestamp: Option<i64>) {
+        tracing::info!(target: "pod", pod_key = %pod.pod_key, status = %pod.status, "upsert pod");
         if let Some(ts) = timestamp {
             if !self.should_update(&pod.pod_key, ts) { return; }
             self.pod_timestamps.insert(pod.pod_key.clone(), ts);
@@ -83,6 +84,7 @@ impl PodState {
         &mut self, pod_key: &str, status: &str, agent_status: Option<&str>,
         error_code: Option<&str>, error_message: Option<&str>, timestamp: Option<i64>,
     ) {
+        tracing::info!(target: "pod", pod_key, status, "status changed");
         if let Some(ts) = timestamp {
             if !self.should_update(pod_key, ts) { return; }
             self.pod_timestamps.insert(pod_key.to_string(), ts);
@@ -107,6 +109,7 @@ impl PodState {
     }
 
     pub fn update_pod_title(&mut self, pod_key: &str, title: &str, timestamp: Option<i64>) {
+        tracing::debug!(target: "pod", pod_key, "title changed");
         if let Some(ts) = timestamp {
             if !self.should_update(pod_key, ts) { return; }
             self.pod_timestamps.insert(pod_key.to_string(), ts);
@@ -121,6 +124,7 @@ impl PodState {
     }
 
     pub fn update_agent_status(&mut self, pod_key: &str, agent_status: &str) {
+        tracing::info!(target: "pod", pod_key, agent_status, "agent status changed");
         if let Some(p) = self.pods.iter_mut().find(|p| p.pod_key == pod_key) {
             p.agent_status = agent_status.to_string();
             if let Some(ref mut cur) = self.current_pod {
@@ -131,6 +135,7 @@ impl PodState {
     }
 
     pub fn update_pod_alias(&mut self, pod_key: &str, alias: &str) {
+        tracing::info!(target: "pod", pod_key, "alias changed");
         if let Some(p) = self.pods.iter_mut().find(|p| p.pod_key == pod_key) {
             p.alias = Some(alias.to_string());
             if let Some(ref mut cur) = self.current_pod {
@@ -141,6 +146,7 @@ impl PodState {
     }
 
     pub fn update_init_progress(&mut self, pod_key: &str, phase: &str, progress: f64, message: Option<&str>) {
+        tracing::debug!(target: "pod", pod_key, phase, progress, "init progress");
         self.init_progress.insert(pod_key.to_string(), PodInitProgress {
             phase: phase.to_string(), progress, message: message.map(String::from),
         });
@@ -150,6 +156,7 @@ impl PodState {
     pub fn get_init_progress(&self, pod_key: &str) -> Option<&PodInitProgress> { self.init_progress.get(pod_key) }
 
     pub fn remove_pod(&mut self, pod_key: &str) {
+        tracing::info!(target: "pod", pod_key, "remove pod");
         self.pods.retain(|p| p.pod_key != pod_key);
         self.pod_timestamps.remove(pod_key);
         self.init_progress.remove(pod_key);
@@ -165,6 +172,7 @@ impl PodState {
     /// SRP patch — only the perpetual flag of an existing pod. No-op if
     /// pod not in cache (it'll arrive via a later upsert).
     pub fn patch_perpetual(&mut self, pod_key: &str, perpetual: bool) {
+        tracing::info!(target: "pod", pod_key, perpetual, "patch perpetual");
         if let Some(pos) = self.pods.iter().position(|p| p.pod_key == pod_key) {
             self.pods[pos].perpetual = perpetual;
             if let Some(repo) = &self.repo {
@@ -174,6 +182,7 @@ impl PodState {
     }
 
     pub fn set_pods(&mut self, pods: Vec<Pod>) {
+        tracing::debug!(target: "pod", count = pods.len(), "set pods (baseline)");
         self.pods = pods;
         if let Some(repo) = &self.repo {
             let _ = repo.clear();

--- a/clients/core/crates/state/src/repo_state.rs
+++ b/clients/core/crates/state/src/repo_state.rs
@@ -28,6 +28,7 @@ impl RepoState {
     pub fn branches(&self) -> &[Branch] { &self.branches }
 
     pub fn set_repositories(&mut self, repos: Vec<Repository>) {
+        tracing::debug!(target: "repo", count = repos.len(), "set repositories (baseline)");
         self.repositories = repos;
         if let Some(store) = &self.store { store.replace_all(&self.repositories, |r| r.id.to_string()); }
     }
@@ -36,6 +37,7 @@ impl RepoState {
     pub fn set_branches(&mut self, branches: Vec<Branch>) { self.branches = branches; }
 
     pub fn add_repository(&mut self, repo: Repository) {
+        tracing::info!(target: "repo", repo_id = repo.id, "add repository");
         if let Some(store) = &self.store {
             store.save(&repo.id.to_string(), &repo);
         }
@@ -43,6 +45,7 @@ impl RepoState {
     }
 
     pub fn update_repository(&mut self, id: &str, repo: Repository) {
+        tracing::info!(target: "repo", repo_id = id, "update repository");
         if let Some(r) = self.repositories.iter_mut().find(|r| r.id.to_string() == id) {
             *r = repo.clone();
             if let Some(store) = &self.store { store.save(id, r); }
@@ -53,6 +56,7 @@ impl RepoState {
     }
 
     pub fn remove_repository(&mut self, id: &str) {
+        tracing::info!(target: "repo", repo_id = id, "remove repository");
         self.repositories.retain(|r| r.id.to_string() != id);
         if self.current_repo.as_ref().is_some_and(|r| r.id.to_string() == id) {
             self.current_repo = None;

--- a/clients/core/crates/state/src/runner_state.rs
+++ b/clients/core/crates/state/src/runner_state.rs
@@ -37,6 +37,7 @@ impl RunnerState {
     pub fn current_runner(&self) -> Option<&Runner> { self.current_runner.as_ref() }
 
     pub fn set_runners(&mut self, runners: Vec<Runner>) {
+        tracing::debug!(target: "runner", count = runners.len(), "set runners (baseline)");
         self.runners = runners;
         if let Some(repo) = &self.repo {
             for r in &self.runners { let _ = repo.save(r); }
@@ -44,6 +45,7 @@ impl RunnerState {
     }
 
     pub fn set_available_runners(&mut self, runners: Vec<Runner>) {
+        tracing::debug!(target: "runner", count = runners.len(), "set available runners");
         self.available_runners = runners;
     }
 
@@ -56,6 +58,7 @@ impl RunnerState {
     }
 
     pub fn update_runner(&mut self, id: i64, runner: Runner) {
+        tracing::info!(target: "runner", runner_id = id, status = %runner.status, "update runner");
         if let Some(r) = self.runners.iter_mut().find(|r| r.id == id) {
             *r = runner.clone();
             if let Some(repo) = &self.repo { let _ = repo.save(r); }
@@ -71,6 +74,7 @@ impl RunnerState {
     /// Update in place if present, else append. Used by the realtime/fetch
     /// patch path (a runner can arrive before its first list fetch).
     pub fn upsert_runner(&mut self, runner: Runner) {
+        tracing::info!(target: "runner", runner_id = runner.id, status = %runner.status, "upsert runner");
         if self.runners.iter().any(|r| r.id == runner.id) {
             self.update_runner(runner.id, runner);
         } else {
@@ -80,6 +84,7 @@ impl RunnerState {
     }
 
     pub fn update_runner_status(&mut self, id: i64, status: &str) {
+        tracing::info!(target: "runner", runner_id = id, status, "status changed");
         for r in &mut self.runners {
             if r.id == id {
                 r.status = status.to_string();
@@ -106,6 +111,7 @@ impl RunnerState {
     }
 
     pub fn remove_runner(&mut self, id: i64) {
+        tracing::info!(target: "runner", runner_id = id, "remove runner");
         self.runners.retain(|r| r.id != id);
         self.available_runners.retain(|r| r.id != id);
         if let Some(ref cur) = self.current_runner {

--- a/clients/core/crates/state/src/ticket_state.rs
+++ b/clients/core/crates/state/src/ticket_state.rs
@@ -69,6 +69,7 @@ impl TicketState {
     }
 
     pub fn set_tickets(&mut self, tickets: Vec<Ticket>) {
+        tracing::debug!(target: "ticket", count = tickets.len(), "set tickets (baseline)");
         self.tickets = tickets;
         if let Some(repo) = &self.repo {
             let _ = repo.clear();
@@ -77,11 +78,13 @@ impl TicketState {
     }
 
     pub fn add_ticket(&mut self, ticket: Ticket) {
+        tracing::info!(target: "ticket", slug = %ticket.slug, status = %ticket.status, "add ticket");
         if let Some(repo) = &self.repo { save_ticket(repo, &ticket); }
         self.tickets.push(ticket);
     }
 
     pub fn update_ticket(&mut self, slug: &str, updated: Ticket) {
+        tracing::info!(target: "ticket", slug, "update ticket");
         if let Some(t) = self.tickets.iter_mut().find(|t| t.slug == slug) {
             *t = updated.clone();
             if let Some(repo) = &self.repo { save_ticket(repo, t); }
@@ -97,6 +100,7 @@ impl TicketState {
     }
 
     pub fn update_ticket_status(&mut self, slug: &str, status: &str) {
+        tracing::info!(target: "ticket", slug, status, "status changed");
         if let Some(t) = self.tickets.iter_mut().find(|t| t.slug == slug) {
             t.status = status.to_string();
             if let Some(repo) = &self.repo { save_ticket(repo, t); }
@@ -109,6 +113,7 @@ impl TicketState {
     }
 
     pub fn remove_ticket(&mut self, slug: &str) {
+        tracing::info!(target: "ticket", slug, "remove ticket");
         self.tickets.retain(|t| t.slug != slug);
         for col in &mut self.board_columns {
             col.tickets.retain(|t| t.slug != slug);
@@ -148,6 +153,7 @@ impl TicketState {
     // --- Board columns ---
 
     pub fn set_board_columns(&mut self, columns: Vec<BoardColumn>) {
+        tracing::debug!(target: "ticket", count = columns.len(), "set board columns (baseline)");
         self.tickets = columns.iter().flat_map(|c| c.tickets.clone()).collect();
         if let Some(repo) = &self.repo {
             let _ = repo.clear();
@@ -159,6 +165,7 @@ impl TicketState {
     pub fn get_board_columns(&self) -> &[BoardColumn] { &self.board_columns }
 
     pub fn append_column_tickets(&mut self, status: &str, tickets: Vec<Ticket>) {
+        tracing::debug!(target: "ticket", status, count = tickets.len(), "append column tickets");
         if let Some(col) = self.board_columns.iter_mut().find(|c| c.status == status) {
             for t in &tickets {
                 if let Some(repo) = &self.repo { save_ticket(repo, t); }
@@ -177,15 +184,22 @@ impl TicketState {
 
     pub fn get_labels(&self) -> &[Label] { &self.labels }
     pub fn set_labels(&mut self, labels: Vec<Label>) { self.labels = labels; }
-    pub fn add_label(&mut self, label: Label) { self.labels.push(label); }
+    pub fn add_label(&mut self, label: Label) {
+        tracing::info!(target: "ticket", label_id = label.id, "add label");
+        self.labels.push(label);
+    }
 
     pub fn update_label(&mut self, updated: Label) {
+        tracing::info!(target: "ticket", label_id = updated.id, "update label");
         if let Some(l) = self.labels.iter_mut().find(|l| l.id == updated.id) {
             *l = updated;
         }
     }
 
-    pub fn remove_label(&mut self, id: i64) { self.labels.retain(|l| l.id != id); }
+    pub fn remove_label(&mut self, id: i64) {
+        tracing::info!(target: "ticket", label_id = id, "remove label");
+        self.labels.retain(|l| l.id != id);
+    }
 
     // --- Current ticket ---
 
@@ -195,6 +209,7 @@ impl TicketState {
     // --- Pods per ticket cache ---
 
     pub fn set_ticket_pods(&mut self, slug: &str, pods: Vec<Pod>) {
+        tracing::debug!(target: "ticket", slug, count = pods.len(), "set ticket pods");
         self.pods_by_ticket_slug.insert(slug.to_string(), pods);
     }
 
@@ -203,6 +218,7 @@ impl TicketState {
     }
 
     pub fn clear_ticket_pods(&mut self, slug: &str) {
+        tracing::debug!(target: "ticket", slug, "clear ticket pods");
         self.pods_by_ticket_slug.remove(slug);
     }
 }

--- a/clients/desktop/src/main/connect-fetch.ts
+++ b/clients/desktop/src/main/connect-fetch.ts
@@ -7,8 +7,19 @@
 // hang. Shared by both main-process Connect callers (connectCall + the legacy
 // JSON aliases) so the retry/timeout policy can't drift between them.
 
+import { logEvent } from "@agentsmesh/node-bridge";
+
 const DEFAULT_TIMEOUT_MS = 30_000;
 const RETRY_BACKOFF_MS = 300;
+
+// Path only — strips host/query so a stray token in a query string never reaches the log.
+function rpcPath(url: string): string {
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return "?";
+  }
+}
 
 // HTTP 4xx/5xx never reach here — callers check `res.ok` and throw themselves —
 // so a TypeError (undici transport failure) or AbortError is the only thing
@@ -31,10 +42,13 @@ export async function connectFetch(
       return await fetch(url, { ...init, signal: controller.signal });
     } catch (err) {
       lastErr = err;
+      const name = err instanceof Error ? err.name : "Error";
       if (attempt === 0 && isTransientNetworkError(err)) {
+        logEvent("warn", "net", `${rpcPath(url)}: ${name} — retry`);
         await new Promise((r) => setTimeout(r, RETRY_BACKOFF_MS));
         continue;
       }
+      logEvent("warn", "net", `${rpcPath(url)}: ${name} — give up`);
       throw err;
     } finally {
       clearTimeout(timer);

--- a/clients/desktop/src/main/index.ts
+++ b/clients/desktop/src/main/index.ts
@@ -95,7 +95,9 @@ function createWindow() {
   }
 
   mainWindow = win;
+  logEvent("info", "electron-main", "window created");
   win.on("closed", () => {
+    logEvent("info", "electron-main", "window closed");
     if (mainWindow === win) mainWindow = null;
   });
   flushPendingUrl(getMainWindow);
@@ -137,11 +139,13 @@ function bindAppStateHandlers() {
     if (!IPC_ALLOWLIST_SET.has(name)) missingFromAllowlist.push(name);
   }
   if (missingFromBinary.length > 0) {
+    logEvent("warn", "ipc", `allowlist drift: ${missingFromBinary.length} listed but missing from binary`);
     console.warn(
       `[electron] IPC allowlist drift: ${missingFromBinary.length} methods listed but not in AppState.prototype — regenerate with \`pnpm --filter desktop e2e:gen\``,
     );
   }
   if (missingFromAllowlist.length > 0) {
+    logEvent("warn", "ipc", `allowlist drift: ${missingFromAllowlist.length} methods denied (not in allowlist)`);
     console.warn(
       `[electron] IPC allowlist drift: ${missingFromAllowlist.length} AppState methods not in allowlist (denied to renderer) — regenerate with \`pnpm --filter desktop e2e:gen\``,
     );
@@ -157,18 +161,22 @@ function bindAppStateHandlers() {
         }
         return await (appState as any)[m](...args);
       } catch (err) {
+        const msg = typeof err === "string" ? err : ((err as Error)?.message ?? String(err));
+        logEvent("warn", "ipc", `${m} failed: ${msg}`);
         throw typeof err === "string" ? new Error(err) : err;
       }
     });
     appStateHandlers.add(m);
     registered++;
   }
+  logEvent("info", "ipc", `registered ${registered} handlers (allowlist ${IPC_ALLOWLIST.length}, methods ${protoMethods.size})`);
   console.log(`[electron] Registered ${registered} IPC handlers (allowlist: ${IPC_ALLOWLIST.length}, AppState methods: ${protoMethods.size})`);
 }
 
 // Known leak: LocalRunnerManager / RelayManager have no shutdown hook, so their tokio
 // tasks may outlive the rebind. Rare in practice (server switches are uncommon).
 function rebindAppState(newApiUrl: string) {
+  logEvent("info", "electron-main", `rebind AppState → ${newApiUrl}`);
   console.log(`[electron] Rebinding AppState: ${currentApiUrl} → ${newApiUrl}`);
   // Dispose old realtime bridge before swapping AppState — its NAPI
   // callbacks would otherwise keep firing into a stale Rust handle.
@@ -283,6 +291,7 @@ function registerLegacyApiAliases() {
     });
     if (!res.ok) {
       const body = await res.text().catch(() => "");
+      logEvent("warn", "ipc-rpc", `${service}/${method} → ${res.status}`);
       // Surface the standard `auth_expired` token the desktop renderer +
       // e2e specs key off when the backend returned an Unauthorized.
       // The Connect-JSON error envelope is `{"code":"unauthenticated", ...}`
@@ -557,6 +566,10 @@ function registerLegacyApiAliases() {
       "Connect-Protocol-Version": "1",
     };
     if (token) headers.Authorization = `Bearer ${token}`;
+    // Desktop's renderer has no wasm, so ElectronXxxService RPCs egress HERE,
+    // bypassing the Rust api-client connect_call sink — this is the only place
+    // these calls are observable. Log method + byte count, never headers/body.
+    logEvent("debug", "ipc-rpc", `${service}/${method} (${bodyArr.length}B)`);
     const res = await connectFetch(url, {
       method: "POST",
       headers,
@@ -564,6 +577,7 @@ function registerLegacyApiAliases() {
     });
     if (!res.ok) {
       const text = await res.text().catch(() => "");
+      logEvent("warn", "ipc-rpc", `${service}/${method} → ${res.status}`);
       throw new Error(`${res.status} ${res.statusText} ${url} ${text}`.trim());
     }
     const bytes = new Uint8Array(await res.arrayBuffer());
@@ -596,7 +610,9 @@ function buildMenu() {
 
 app.whenReady().then(() => {
   try {
-    initLogger(logsDir, process.env.AGENTSMESH_LOG_LEVEL ?? "info");
+    // Default debug; the logging crate scopes third-party crates to info
+    // (clients/core/crates/logging/src/init.rs) so business logs stay readable.
+    initLogger(logsDir, process.env.AGENTSMESH_LOG_LEVEL ?? "debug");
     logEvent("info", "electron-main", `Starting, API: ${currentApiUrl}`);
   } catch (e) {
     console.warn("[electron] initLogger failed:", e);
@@ -613,6 +629,7 @@ app.whenReady().then(() => {
     pendingStartupErrorMsg = null;
   }
   appState = new AppState(currentApiUrl, storageDir);
+  logEvent("info", "electron-main", "AppState ready");
   if (isHeadlessTest) {
     stubs = createLocalRunnerStubs();
   }

--- a/clients/desktop/src/main/oauth_deep_link.ts
+++ b/clients/desktop/src/main/oauth_deep_link.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow } from "electron";
 import path from "path";
+import { logEvent } from "@agentsmesh/node-bridge";
 
 const PROTOCOL = "agentsmesh";
 const PROTOCOL_PREFIX = `${PROTOCOL}://`;
@@ -54,16 +55,20 @@ export function flushPendingUrl(getWindow: () => BrowserWindow | null): void {
 }
 
 function deliver(win: BrowserWindow | null, url: string): void {
+  // Never log `url` — the OAuth callback carries an authorization code (credential).
   if (!win) {
+    logEvent("info", "oauth", "deep-link received, window not ready — queued");
     pendingUrl = url;
     return;
   }
   // Cold-launch race: webContents may still be loading; wait for did-finish-load once.
   if (win.webContents.isLoading()) {
+    logEvent("info", "oauth", "deep-link received, deferring to did-finish-load");
     win.webContents.once("did-finish-load", () => {
       win.webContents.send(CALLBACK_CHANNEL, url);
     });
   } else {
+    logEvent("info", "oauth", "deep-link delivered to renderer");
     win.webContents.send(CALLBACK_CHANNEL, url);
   }
 }

--- a/clients/desktop/src/main/realtime.ts
+++ b/clients/desktop/src/main/realtime.ts
@@ -1,5 +1,5 @@
 import { BrowserWindow, ipcMain, app, powerMonitor } from "electron";
-import type { AppState } from "@agentsmesh/node-bridge";
+import { logEvent, type AppState } from "@agentsmesh/node-bridge";
 
 // Bridges the backend EventBus realtime stream into the Electron renderer.
 //
@@ -205,17 +205,21 @@ export async function setupRealtimeBridge(
     pushRunnerSnapshot(appState, eventJson, send);
     pushAutopilotSnapshot(appState, eventJson, send);
   });
+  logEvent("info", "realtime", "bridge subscribed");
   const stateSubId = await appState.eventsOnConnectionStateChange((_err: unknown, next: string) => {
     if (typeof next === "string" && next.length > 0) {
+      if (next !== state) logEvent("info", "realtime", `state ${state} → ${next}`);
       state = next as RealtimeState;
     }
     send("realtime:state", next);
   });
 
   const connectHandler = async (): Promise<void> => {
+    logEvent("info", "realtime", "connect requested");
     await appState.eventsConnect();
   };
   const disconnectHandler = async (): Promise<void> => {
+    logEvent("info", "realtime", "disconnect requested");
     await appState.eventsDisconnect();
   };
   const getStateHandler = (): RealtimeState => state;
@@ -229,6 +233,7 @@ export async function setupRealtimeBridge(
   // retry now. nudge() is a no-op when already connected, so firing it on every
   // focus is harmless. powerMonitor covers system resume the renderer can't see.
   const reArm = () => {
+    logEvent("debug", "realtime", "re-arm (resume/focus) → nudge");
     void appState.eventsNudge();
   };
   powerMonitor.on("resume", reArm);
@@ -237,6 +242,7 @@ export async function setupRealtimeBridge(
   return {
     currentState: () => state,
     dispose: async () => {
+      logEvent("info", "realtime", "bridge disposed");
       ipcMain.removeHandler("realtime:connect");
       ipcMain.removeHandler("realtime:disconnect");
       ipcMain.removeHandler("realtime:nudge");

--- a/clients/desktop/src/main/relay.ts
+++ b/clients/desktop/src/main/relay.ts
@@ -1,5 +1,5 @@
 import { BrowserWindow, ipcMain } from "electron";
-import type { AppState } from "@agentsmesh/node-bridge";
+import { logEvent, type AppState } from "@agentsmesh/node-bridge";
 
 // Bridges the Rust `RelayConnectionPool` (terminal data plane SSOT, owned by the
 // main process) to the renderer. Renderer → main: `relay:*` invoke handlers map
@@ -60,9 +60,11 @@ export function setupRelayBridge(
       const subs = rendererSubs.get(podKey);
       if (subs) {
         subs.add(subId);
+        logEvent("debug", "relay", `subscribe ${podKey} (reuse, ${subs.size} subs)`);
         return;
       }
       rendererSubs.set(podKey, new Set([subId]));
+      logEvent("info", "relay", `subscribe ${podKey} (new link)`);
       await appState.relaySubscribe(podKey, BRIDGE_SUB, url, token, onOutput(podKey));
       if (!listenersWired.has(podKey)) {
         listenersWired.add(podKey);
@@ -78,8 +80,12 @@ export function setupRelayBridge(
       const subs = rendererSubs.get(podKey);
       if (!subs) return undefined;
       subs.delete(subId);
-      if (subs.size > 0) return undefined;
+      if (subs.size > 0) {
+        logEvent("debug", "relay", `unsubscribe ${podKey} (${subs.size} left)`);
+        return undefined;
+      }
       rendererSubs.delete(podKey);
+      logEvent("info", "relay", `unsubscribe ${podKey} (last, dropping link)`);
       return appState.relayUnsubscribe(podKey, BRIDGE_SUB);
     },
     "relay:send": (podKey: string, data: string) => appState.relaySend(podKey, data),
@@ -103,6 +109,7 @@ export function setupRelayBridge(
   // tell the renderer's mirror to drop its guards too.
   void appState.relayOnPodDisconnected((_e: unknown, podKey: string) => {
     listenersWired.delete(podKey);
+    logEvent("info", "relay", `pod disconnected ${podKey}`);
     send("relay:pod-disconnected", { podKey });
   });
 

--- a/clients/desktop/src/renderer/lib/platform-init.ts
+++ b/clients/desktop/src/renderer/lib/platform-init.ts
@@ -2,7 +2,14 @@ import { createElectronServiceProvider } from "@agentsmesh/electron-adapter";
 import {
   registerServiceProvider, markServiceReady, setPlatformInit,
 } from "@agentsmesh/service-runtime";
+import { installConsoleCapture } from "@/lib/console-capture";
 import { installRealtimeMirror } from "./realtime-mirror";
+
+// Desktop aliases @/lib/wasm-core to a shim (electron.vite.config.ts), so web's
+// install site (wasm-core.ts) never runs here. Wire it explicitly — main.tsx
+// imports this module before React renders — so renderer console.warn/error
+// fans out via electronAPI.log → main core:log → Rust rolling file.
+installConsoleCapture();
 
 setPlatformInit(async () => {
   const provider = createElectronServiceProvider();

--- a/clients/desktop/src/renderer/lib/realtime-mirror.ts
+++ b/clients/desktop/src/renderer/lib/realtime-mirror.ts
@@ -104,11 +104,20 @@ export function installRealtimeMirror(): void {
     try {
       snap = JSON.parse(json) as { domain?: string };
     } catch {
+      // eslint-disable-next-line no-console
+      console.warn("realtime-mirror: malformed snapshot — dropped");
       return;
     }
-    if (snap.domain === "channel") applyChannelSnapshot(snap as ChannelSnapshot);
-    else if (snap.domain === "pod") applyPodSnapshot(snap as PodSnapshot);
-    else if (snap.domain === "runner") applyRunnerSnapshot(snap as RunnerSnapshot);
-    else if (snap.domain === "autopilot") applyAutopilotSnapshot(snap as AutopilotSnapshot);
+    try {
+      if (snap.domain === "channel") applyChannelSnapshot(snap as ChannelSnapshot);
+      else if (snap.domain === "pod") applyPodSnapshot(snap as PodSnapshot);
+      else if (snap.domain === "runner") applyRunnerSnapshot(snap as RunnerSnapshot);
+      else if (snap.domain === "autopilot") applyAutopilotSnapshot(snap as AutopilotSnapshot);
+    } catch {
+      // Apply failure = renderer view silently stops tracking the SSOT. Log the
+      // domain (never the payload) so the stuck view is diagnosable.
+      // eslint-disable-next-line no-console
+      console.warn(`realtime-mirror: apply failed for domain=${snap.domain ?? "?"}`);
+    }
   });
 }

--- a/packages/electron-adapter/src/electron-relay-manager.ts
+++ b/packages/electron-adapter/src/electron-relay-manager.ts
@@ -35,14 +35,28 @@ export class ElectronRelayManager {
       if (m) for (const cb of m.values()) cb(data);
     });
     api.onRelayStatus(({ podKey, json }) => {
-      const info = JSON.parse(json) as { status: string; runnerDisconnected: boolean };
+      let info: { status: string; runnerDisconnected: boolean };
+      try {
+        info = JSON.parse(json) as { status: string; runnerDisconnected: boolean };
+      } catch {
+        // eslint-disable-next-line no-console
+        console.warn(`relay: malformed status frame for pod ${podKey}`);
+        return;
+      }
       const s = this.statusCbs.get(podKey);
       if (s) for (const cb of s) cb(info);
     });
     api.onRelayAcp(({ podKey, json }) => {
-      const { msgType, payload } = JSON.parse(json) as { msgType: number; payload: unknown };
+      let parsed: { msgType: number; payload: unknown };
+      try {
+        parsed = JSON.parse(json) as { msgType: number; payload: unknown };
+      } catch {
+        // eslint-disable-next-line no-console
+        console.warn(`relay: malformed acp frame for pod ${podKey}`);
+        return;
+      }
       const s = this.acpCbs.get(podKey);
-      if (s) for (const cb of s) cb(msgType, payload);
+      if (s) for (const cb of s) cb(parsed.msgType, parsed.payload);
     });
     api.onRelayPodDisconnected?.(({ podKey }) => {
       // Pool tore the pod down + cleared its Rust listeners. Drop our mirror's

--- a/packages/electron-adapter/src/realtime.ts
+++ b/packages/electron-adapter/src/realtime.ts
@@ -34,9 +34,11 @@ export class ElectronEventsManager {
     const api = (globalThis as { window?: { electronAPI?: RealtimeBridgeApi } }).window
       ?.electronAPI;
     if (!api?.onRealtimeEvent || !api?.onRealtimeState) {
-      // Preload didn't expose realtime IPC channels — running outside
-      // Electron or with a stale preload bundle. Stay silent; subscribers
-      // will register but no events will be dispatched.
+      // Preload didn't expose realtime IPC channels — stale preload bundle or
+      // non-Electron host. Subscribers still register but nothing dispatches;
+      // warn so a dead realtime stream is diagnosable from the log file.
+      // eslint-disable-next-line no-console
+      console.warn("realtime: IPC channels unavailable — preload stale? events will not dispatch");
       return;
     }
     this.unsubFns.push(


### PR DESCRIPTION
## 背景

从 desktop(GitHub v0.41.1)排查「runner pod 列表刷新 sandbox 后 resume 报错」时发现:日志文件里只有连接层日志,整个业务链路几乎无埋点,renderer console 也未落盘。本 PR 系统性补齐 desktop + Rust core 的可观测性。

## 改动

**Rust core(tracing 埋点,默认 debug)**
- services ×27 / state ×12 / relay / events / api-client / logging:按 target 分域埋点
- `logging/src/init.rs`:默认 debug,12 个噪音 crate(hyper/rustls/tokio/…)钉 info

**node-bridge build fix**
- `napi_rust_library` 缺 `@crates//:tracing` dep(只加在了 `rust_library`)→ `.node` 编译 E0433。双 target 同步修复。

**desktop main TS(29 logEvent)**
- IPC dispatch / **connectCall egress**(renderer RPC 唯一可观测点,绕过 Rust sink)/ connectFetch 网络重试 / realtime 状态机 / relay bridge / 窗口 + oauth 生命周期

**desktop renderer**
- **Fix A**:`installConsoleCapture()` 接线 — console.warn/error 经 `electronAPI.log` → main → Rust 滚动文件
- adapter 层 3 处静默盲区补 `console.warn`:realtime IPC 缺失(preload stale)/ relay status·acp 帧 malformed / SSOT mirror apply 失败

## PII 安全
全程只记 id/slug/podKey/枚举/count/字节数;**绝不记** body/token/header/payload/email/prompt。oauth 深链不记 url,connectFetch 只记 pathname。

## 验证
- `//clients/desktop:out` ✅ / `:lint` PASSED
- `//packages/electron-adapter:electron_adapter` ✅
- `//clients/core/crates/node-bridge:node_bridge` ✅(聚合所有改动 crate)
- PII 红线 grep 干净