### PR TITLE
fix(events): heal desktop realtime-disconnect storm via keepalive sentinel

### DIFF
--- a/backend/internal/api/connect/events/BUILD.bazel
+++ b/backend/internal/api/connect/events/BUILD.bazel
@@ -1,9 +1,10 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "events",
     srcs = [
         "events.go",
+        "sentinel_frames.go",
         "subscribe.go",
     ],
     importpath = "github.com/anthropics/agentsmesh/backend/internal/api/connect/events",
@@ -15,6 +16,20 @@ go_library(
         "//backend/internal/middleware",
         "//proto/events/v1:events_go_proto",
         "@com_connectrpc_connect//:connect",
+    ],
+)
+
+go_test(
+    name = "events_test",
+    srcs = ["subscribe_test.go"],
+    embed = [":events"],
+    deps = [
+        "//backend/internal/infra/websocket",
+        "//backend/internal/middleware",
+        "//proto/events/v1:events_go_proto",
+        "@com_connectrpc_connect//:connect",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )
 

--- a/backend/internal/api/connect/events/sentinel_frames.go
+++ b/backend/internal/api/connect/events/sentinel_frames.go
@@ -1,0 +1,17 @@
+package eventsconnect
+
+import (
+	"time"
+
+	eventsv1 "github.com/anthropics/agentsmesh/proto/gen/go/events/v1"
+)
+
+// connect-go server-stream 的 HTTP 200 header 直到首个 Send 才 flush;静默 org
+// 下不发,客户端枯等到 15s connect timeout 死循环。sentinelFrame 是无业务载荷的
+// liveness 帧(keepalive=true):订阅建立时发一个(flush header + 让客户端翻
+// Connected),之后每 25s 发一个保活(< 客户端 60s idle 与网关 idle 回收窗口)。
+const keepaliveInterval = 25 * time.Second
+
+func sentinelFrame() *eventsv1.Event {
+	return &eventsv1.Event{Keepalive: true}
+}

--- a/backend/internal/api/connect/events/subscribe.go
+++ b/backend/internal/api/connect/events/subscribe.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"time"
 
 	"connectrpc.com/connect"
 
@@ -37,12 +38,28 @@ func (s *Server) Subscribe(
 	client := websocket.NewConnectEventsClient(s.hub, tenant.UserID, tenant.OrganizationID)
 	s.hub.Register(client)
 	defer s.hub.Unregister(client)
+	slog.InfoContext(ctx, "events stream opened",
+		"user_id", tenant.UserID, "org_id", tenant.OrganizationID)
+	defer slog.InfoContext(ctx, "events stream closed", "user_id", tenant.UserID)
+
+	// 立即发 liveness 帧强制 flush HTTP header + 让客户端 data-ready 翻 Connected;
+	// 否则静默 org 下客户端枯等 header 到 15s connect timeout 后死循环重连。
+	if err := stream.Send(sentinelFrame()); err != nil {
+		return nil
+	}
+
+	ticker := time.NewTicker(keepaliveInterval)
+	defer ticker.Stop()
 
 	outbound := client.Outbound()
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
+		case <-ticker.C:
+			if err := stream.Send(sentinelFrame()); err != nil {
+				return nil
+			}
 		case raw, ok := <-outbound:
 			if !ok {
 				return nil
@@ -54,9 +71,11 @@ func (s *Server) Subscribe(
 				continue
 			}
 			if err := stream.Send(evt); err != nil {
-				// Client disconnect — exit cleanly.
 				return nil
 			}
+			// 业务帧本身已刷新客户端 idle;重置 ticker 推迟下次 keepalive,
+			// 让 keepalive 只在真正静默时发,不在活跃流上发多余哨兵。
+			ticker.Reset(keepaliveInterval)
 		}
 	}
 }

--- a/backend/internal/api/connect/events/subscribe_test.go
+++ b/backend/internal/api/connect/events/subscribe_test.go
@@ -1,0 +1,80 @@
+package eventsconnect
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anthropics/agentsmesh/backend/internal/infra/websocket"
+	"github.com/anthropics/agentsmesh/backend/internal/middleware"
+	eventsv1 "github.com/anthropics/agentsmesh/proto/gen/go/events/v1"
+)
+
+type fakeOrg struct{ slug string }
+
+func (f fakeOrg) GetID() int64    { return 7 }
+func (f fakeOrg) GetSlug() string { return f.slug }
+func (f fakeOrg) GetName() string { return f.slug }
+
+type fakeOrgService struct{}
+
+func (fakeOrgService) GetBySlug(_ context.Context, slug string) (middleware.OrganizationGetter, error) {
+	return fakeOrg{slug: slug}, nil
+}
+func (fakeOrgService) IsMember(context.Context, int64, int64) (bool, error) { return true, nil }
+func (fakeOrgService) GetMemberRole(context.Context, int64, int64) (string, error) {
+	return "member", nil
+}
+
+// tenantInjector 是测试用 streaming interceptor:绕过 JWT,把固定 tenant 注入
+// ctx,让 Subscribe 通过 auth + org-scope。生产由真实 auth interceptor 完成。
+type tenantInjector struct{ userID int64 }
+
+func (tenantInjector) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc { return next }
+func (tenantInjector) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return next
+}
+func (t tenantInjector) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return func(ctx context.Context, conn connect.StreamingHandlerConn) error {
+		ctx = middleware.SetTenant(ctx, &middleware.TenantContext{UserID: t.userID})
+		return next(ctx, conn)
+	}
+}
+
+// 静默 org(hub 不广播任何业务 event)下,客户端必须立即收到 ready 哨兵帧。
+// 回归锁:修复前 handler 阻塞等 outbound、connect-go 不 flush HTTP header,
+// 客户端枯等到 15s connect timeout 后死循环重连(desktop「实时更新已断开」)。
+func TestSubscribe_SilentOrg_ReceivesReadySentinelImmediately(t *testing.T) {
+	hub := websocket.NewHub()
+	defer hub.Close()
+	srv := NewServer(hub, fakeOrgService{})
+	mux := http.NewServeMux()
+	Mount(mux, srv, connect.WithInterceptors(tenantInjector{userID: 42}))
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client := connect.NewClient[eventsv1.SubscribeRequest, eventsv1.Event](
+		ts.Client(), ts.URL+SubscribeProcedure,
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	stream, err := client.CallServerStream(ctx,
+		connect.NewRequest(&eventsv1.SubscribeRequest{OrgSlug: "acme"}))
+	require.NoError(t, err)
+	defer stream.Close()
+
+	require.True(t, stream.Receive(), "no frame from silent org: %v", stream.Err())
+	// 阈值取 2s 而非贴实测 ~1ms:bug 表现为 15s connect timeout,2s 足以证明
+	// 「立即返回而非超时」,又远离 CI sandbox 负载抖动,避免 flaky。
+	assert.Less(t, time.Since(start), 2*time.Second,
+		"ready sentinel must arrive immediately, not after a connect timeout")
+	assert.True(t, stream.Msg().GetKeepalive(), "first frame must be the liveness sentinel")
+}

--- a/clients/core/crates/events/src/connection_loop.rs
+++ b/clients/core/crates/events/src/connection_loop.rs
@@ -9,7 +9,7 @@ use parking_lot::RwLock;
 use tracing::{debug, error, info, warn};
 
 use crate::reconnect::ReconnectPolicy;
-use crate::stream_source::EventStreamSource;
+use crate::stream_source::{EventStreamSource, StreamFrame};
 use crate::subscription_manager::{dispatch_event, set_state, Inner};
 use crate::types::{ConnectionState, EventSubscriptionManagerOptions};
 
@@ -141,7 +141,7 @@ async fn run_session<R: Runtime>(
 
         futures::select! {
             item = next_fut => match item {
-                Some(Ok(evt)) => {
+                Some(Ok(frame)) => {
                     if !data_ready {
                         data_ready = true;
                         // First real frame proves the link is alive: reset
@@ -151,7 +151,11 @@ async fn run_session<R: Runtime>(
                         policy.reset();
                         set_state(inner, ConnectionState::Connected);
                     }
-                    dispatch_event(inner, &evt);
+                    // Keepalive sentinels only prove liveness — Connected + idle
+                    // reset are both handled above. Only business events dispatch.
+                    if let StreamFrame::Event(evt) = frame {
+                        dispatch_event(inner, &evt);
+                    }
                 }
                 Some(Err(e)) => {
                     warn!("events: stream error: {:?}", e);

--- a/clients/core/crates/events/src/stream_source.rs
+++ b/clients/core/crates/events/src/stream_source.rs
@@ -17,10 +17,19 @@ use tracing::debug;
 use crate::event_types::EventType;
 use crate::types::{EventCategory, RealtimeEvent};
 
+/// One item off the realtime stream: a business event to dispatch, or a liveness
+/// sentinel (server keepalive, `Event.keepalive=true`) that only proves the link
+/// is alive. Distinct at the type level so a sentinel can never be dispatched as
+/// a business event.
+pub enum StreamFrame {
+    Event(RealtimeEvent),
+    Keepalive,
+}
+
 #[cfg(not(target_arch = "wasm32"))]
-pub type BoxEventStream = Pin<Box<dyn Stream<Item = Result<RealtimeEvent, ApiError>> + Send>>;
+pub type BoxEventStream = Pin<Box<dyn Stream<Item = Result<StreamFrame, ApiError>> + Send>>;
 #[cfg(target_arch = "wasm32")]
-pub type BoxEventStream = Pin<Box<dyn Stream<Item = Result<RealtimeEvent, ApiError>>>>;
+pub type BoxEventStream = Pin<Box<dyn Stream<Item = Result<StreamFrame, ApiError>>>>;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) type SubscribeFuture = Pin<Box<dyn Future<Output = Result<BoxEventStream, ApiError>> + Send>>;
@@ -90,9 +99,10 @@ impl EventStreamSource for ApiClientStreamSource {
     }
 }
 
-async fn map_proto(item: Result<ProtoEvent, ApiError>) -> Option<Result<RealtimeEvent, ApiError>> {
+async fn map_proto(item: Result<ProtoEvent, ApiError>) -> Option<Result<StreamFrame, ApiError>> {
     match item {
-        Ok(evt) => proto_to_realtime(evt).map(Ok),
+        Ok(p) if p.keepalive => Some(Ok(StreamFrame::Keepalive)),
+        Ok(p) => proto_to_realtime(p).map(|e| Ok(StreamFrame::Event(e))),
         Err(e) => Some(Err(e)),
     }
 }

--- a/clients/core/crates/events/src/tests/integration_tests.rs
+++ b/clients/core/crates/events/src/tests/integration_tests.rs
@@ -14,11 +14,11 @@ use agentsmesh_transport::runtime::PlatformRuntime;
 use futures::channel::mpsc::{self, UnboundedSender};
 use parking_lot::Mutex;
 
-use crate::stream_source::{BoxEventStream, EventStreamSource, SubscribeFuture};
+use crate::stream_source::{BoxEventStream, EventStreamSource, StreamFrame, SubscribeFuture};
 use crate::types::{ConnectionState, EventSubscriptionManagerOptions, RealtimeEvent};
 use crate::{EventHandler, EventSubscriptionManager, EventType};
 
-type EvResult = Result<RealtimeEvent, ApiError>;
+type EvResult = Result<StreamFrame, ApiError>;
 type Mgr = EventSubscriptionManager<PlatformRuntime>;
 
 /// Scriptable source. `subscribe()` hands back a fresh channel whose sender the
@@ -47,7 +47,12 @@ impl Shared {
     }
     fn push_event(&self) {
         if let Some(tx) = self.senders.lock().last() {
-            let _ = tx.unbounded_send(Ok(make_event()));
+            let _ = tx.unbounded_send(Ok(StreamFrame::Event(make_event())));
+        }
+    }
+    fn push_keepalive(&self) {
+        if let Some(tx) = self.senders.lock().last() {
+            let _ = tx.unbounded_send(Ok(StreamFrame::Keepalive));
         }
     }
     fn close_last(&self) {
@@ -289,5 +294,42 @@ async fn nudge_skips_backoff() {
         wait_count(&shared, before + 1, Duration::from_secs(2)).await,
         "nudge did not interrupt the 10s backoff to reconnect",
     );
+    mgr.disconnect().await;
+}
+
+#[tokio::test]
+async fn keepalive_sentinels_flip_connected_without_dispatch() {
+    // backend 订阅建立后发 liveness 哨兵帧(keepalive=true)+ 周期保活。它们让
+    // 链路翻 Connected / 刷新 idle,但绝不能进业务 handler——否则每次心跳都
+    // bump tick / 污染 AppState。connection_loop 按 StreamFrame::Keepalive 跳过。
+    let shared = Shared::new(0, 0);
+    let mgr = manager(&shared, opts(5, 2000, 200));
+    let got = Arc::new(AtomicU32::new(0));
+    let g = Arc::clone(&got);
+    let h: EventHandler = Arc::new(move |_| {
+        g.fetch_add(1, SeqCst);
+    });
+    mgr.subscribe_all(h).await;
+    mgr.connect().await;
+    assert!(wait_count(&shared, 1, Duration::from_secs(2)).await, "never subscribed");
+
+    // keepalive 哨兵:翻 Connected(链路活着),但不是业务 event。
+    shared.push_keepalive();
+    assert!(
+        wait_state(&mgr, ConnectionState::Connected, Duration::from_secs(2)).await,
+        "keepalive sentinel must flip the link to Connected",
+    );
+    shared.push_keepalive();
+    tokio::time::sleep(Duration::from_millis(40)).await;
+    assert_eq!(got.load(SeqCst), 0, "sentinels must not reach business handlers");
+
+    // 真实 event 才派发。
+    shared.push_event();
+    let start = Instant::now();
+    while got.load(SeqCst) == 0 {
+        assert!(start.elapsed() < Duration::from_secs(2), "real event not delivered");
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    assert_eq!(got.load(SeqCst), 1, "exactly one business event dispatched");
     mgr.disconnect().await;
 }

--- a/proto/events/v1/events.proto
+++ b/proto/events/v1/events.proto
@@ -17,9 +17,13 @@
 // leaked into proxy logs. Connect Server Streaming uses HTTP semantics
 // like every other RPC, so the auth interceptor pipeline applies as-is.
 //
-// Heartbeat: HTTP/2 PING frames + stream-idle timeout on the client
-// side. No application-level ping/pong (the legacy `ping`/`pong` event
-// types are dropped — Event payloads now only carry domain events).
+// Liveness: the handler sends a keepalive sentinel frame (Event.keepalive=true,
+// no business payload) the instant the stream opens — connect-go only flushes
+// the HTTP 200 header on the first Send, so without it a silent org leaves the
+// client blocked until its 15s connect timeout, then reconnect-storms — and one
+// every 25s thereafter to keep the link warm under client idle + gateway idle
+// reaping. The events crate connection_loop flips Connected / refreshes idle on
+// these but skips dispatch. See backend/internal/api/connect/events/sentinel_frames.go.
 //
 // Payload schema: 35+ heterogeneous event types (pod / channel / ticket
 // / runner / autopilot / mr / pipeline / loop_run / blockstore /
@@ -67,4 +71,10 @@ message Event {
   string data_json = 8;
   // Unix milliseconds.
   int64 timestamp = 9;
+  // Liveness sentinel marker: the server's ready/keepalive frames set this and
+  // carry no business payload. A dedicated field (not a reserved `type` value)
+  // keeps liveness orthogonal to the business type namespace, so no business
+  // event can collide with a sentinel; the client flips Connected / refreshes
+  // idle on these frames but never dispatches them.
+  bool keepalive = 10;
 }


### PR DESCRIPTION
## Problem

`connect-go` server-streaming flushes the HTTP 200 header only on the handler's first `Send`. The events handler blocked in its `for-select` waiting for hub events, so a **silent org** (no pod/ticket/channel activity) never sent a frame → the desktop client's `subscribe()` blocked until its **15s connect timeout**, then reconnect-stormed. Result: the "实时更新已断开" banner stuck on, terminals stale.

Root cause confirmed by a local connect-go probe: a handler that blocks N seconds before `Send` delays the client's response header by exactly N seconds; sending one frame immediately drops it to ~1ms.

## Fix

- **proto**: add `Event.keepalive` — a dedicated wire field marking liveness frames, orthogonal to the `type` namespace, so no business event can collide with a sentinel.
- **backend**: the handler sends a `{keepalive:true}` sentinel the instant the stream opens (forces the header flush + flips the client Connected) and every 25s thereafter (< client 60s idle, < gateway idle reaping). `slog` covers stream open/close.
- **client** (Rust events crate, shared by web/desktop/iOS): stream items are modeled as `StreamFrame::{Event, Keepalive}`. Liveness frames flip Connected / refresh idle but **never reach business dispatch** — enforced at the type level, not by string matching.

## Tests

- backend `subscribe_test.go`: silent org receives the first frame in <2s (regression lock on the 15s-timeout storm).
- client `integration_tests.rs`: keepalive sentinels flip Connected without dispatching to business handlers.

Verified locally: backend `events_test`, events crate `events_test`, wasm/node-bridge/ffi builds, state crate `state_test` — all green.
