### PR TITLE
feat(desktop): auto-update via electron-updater from GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,14 +231,15 @@ jobs:
         os:
           - label: macOS
             runner: macos-14
-            # Only the .dmg is shipped today. `.zip` + `latest-mac.yml`
-            # drive electron-updater autoupdate, but the `.app` inside
-            # the zip is NOT yet stapled (notarization re-pack pipeline
-            # is dmg-only). Re-enable once the zip-restaple flow lands
-            # — until then autoupdate stays disabled to avoid shipping
-            # un-notarized .app over the update channel.
+            # Ships .dmg (manual download) + .zip + latest-mac.yml
+            # (electron-updater feed). The "Notarize macOS zip" step below
+            # staples the notarization ticket into the .app inside each zip and
+            # rewrites latest-mac.yml's sha512/size, so Squirrel.Mac accepts the
+            # repacked archive offline during an autoupdate.
             installers: |
               AgentsMesh-*.dmg
+              AgentsMesh-*.zip
+              latest-mac.yml
           - label: Windows
             runner: windows-latest
             installers: |
@@ -502,6 +503,81 @@ jobs:
             echo "Stapling ticket to $dmg..."
             xcrun stapler staple "$dmg"
           done
+
+      # electron-updater downloads the .zip (never the .dmg) and Squirrel.Mac
+      # verifies the .app's notarization offline, so the .app inside each zip
+      # must carry a stapled ticket. electron-builder signs that .app but never
+      # staples it. We notarize each zip, staple the extracted .app, repack, and
+      # then rewrite latest-mac.yml's sha512/size — the repack changes the bytes
+      # and a hash mismatch makes electron-updater silently reject the update.
+      - name: Notarize macOS zip + refresh latest-mac.yml (autoupdate)
+        if: matrix.os.runner == 'macos-14'
+        shell: bash
+        env:
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_KEY_ISSUER_ID: ${{ secrets.APPLE_API_KEY_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${APPLE_API_KEY:-}" ]]; then
+            echo "::error::APPLE_API_KEY unset — refuse to ship un-notarized zip." >&2
+            exit 1
+          fi
+          STAGE="$RUNNER_TEMP/installers"
+          MAC_YML="$STAGE/latest-mac.yml"
+          if [[ ! -f "$MAC_YML" ]]; then
+            echo "::error::latest-mac.yml missing — electron-updater mac feed can't ship." >&2
+            exit 1
+          fi
+
+          # Pull zip names from latest-mac.yml's files[].url — never guess
+          # electron-builder's arch-suffixed naming.
+          zips=$(node -e "const y=require('fs').readFileSync(process.argv[1],'utf8');const m=[...y.matchAll(/url:\s*(\S+\.zip)/g)];console.log([...new Set(m.map(x=>x[1]))].join('\n'))" "$MAC_YML")
+          if [[ -z "$zips" ]]; then
+            echo "::error::no .zip entries in latest-mac.yml." >&2
+            exit 1
+          fi
+
+          while IFS= read -r zipname; do
+            [[ -z "$zipname" ]] && continue
+            zippath="$STAGE/$zipname"
+            [[ -f "$zippath" ]] || { echo "::error::$zipname in latest-mac.yml not on disk." >&2; exit 1; }
+
+            echo "Submitting $zipname to Apple Notary..."
+            xcrun notarytool submit "$zippath" \
+              --key "$APPLE_API_KEY" \
+              --key-id "$APPLE_API_KEY_ID" \
+              --issuer "$APPLE_API_KEY_ISSUER_ID" \
+              --wait --timeout 30m
+
+            work="$(mktemp -d)"
+            ditto -x -k "$zippath" "$work"
+            app="$(find "$work" -maxdepth 1 -name '*.app' | head -1)"
+            [[ -n "$app" ]] || { echo "::error::no .app inside $zipname." >&2; exit 1; }
+            xcrun stapler staple "$app"
+            xcrun stapler validate "$app"
+            spctl -a -t exec -vv "$app"
+            rm -f "$zippath"
+            # `ditto -c -k --keepParent` is the archive shape Squirrel.Mac expects.
+            ditto -c -k --keepParent "$app" "$zippath"
+            rm -rf "$work"
+            echo "OK: $zipname notarized + stapled + repacked."
+          done <<< "$zips"
+
+          node "$GITHUB_WORKSPACE/clients/desktop/scripts/rewrite-latest-mac.mjs" "$MAC_YML" "$STAGE"
+
+          # Guard: every .zip on disk must be one we just notarized + stapled
+          # (i.e. listed in latest-mac.yml). An un-listed zip would be shipped
+          # un-stapled by the upload glob and rejected by Squirrel/Gatekeeper.
+          for diskzip in "$STAGE"/AgentsMesh-*.zip; do
+            base="$(basename "$diskzip")"
+            echo "$zips" | grep -qxF "$base" || {
+              echo "::error::$base on disk but absent from latest-mac.yml — would ship un-notarized." >&2
+              exit 1
+            }
+          done
+
+          echo "--- latest-mac.yml ---"
+          cat "$MAC_YML"
 
       # Fail-fast assertion: every prior release silently shipped
       # ad-hoc-signed dmgs because electron-builder's logs are

--- a/clients/desktop/BUILD.bazel
+++ b/clients/desktop/BUILD.bazel
@@ -2,6 +2,7 @@ load("//build_defs/web:electron.bzl", "electron_builder_app", "electron_vite_bui
 load("//build_defs/web:eslint.bzl", "eslint_test")
 load("//build_defs/web:playwright.bzl", "playwright_test")
 load("//build_defs/web:ts.bzl", "ts_project")
+load("//build_defs/web:vitest.bzl", "vitest_test")
 
 # `bazel build //clients/desktop:out` — Bazel-native electron-vite
 # build. Produces `out/main/index.js`, `out/preload/index.js`,
@@ -80,6 +81,7 @@ electron_builder_app(
     # node_modules link tree at staging time.
     dependencies = {
         "@agentsmesh/node-bridge": "*",
+        "electron-updater": "^6.8.9",
     },
     electron_main = "./out/main/index.js",
     # `build/icon.png` is the source of truth for the macOS .icns,
@@ -127,6 +129,33 @@ ts_project(
     tags = ["manual"],
     tsconfig = "tsconfig.json",
     deps = ["//:node_modules"],
+)
+
+# `bazel test //clients/desktop:unit` — vitest over pure-logic units
+# (shared reducer + the latest-mac.yml rewrite script). Node env, no
+# renderer/React/wasm closure; tests import their targets relatively.
+vitest_test(
+    name = "unit",
+    size = "small",
+    srcs = glob(
+        [
+            "src/**/*.test.ts",
+            "scripts/**/*.test.ts",
+        ],
+        allow_empty = True,
+    ),
+    config = "vitest.config.ts",
+    data = [
+        "tsconfig.json",
+        "//:node_modules",
+    ] + glob(
+        [
+            "src/shared/**/*.ts",
+            "scripts/**/*.mjs",
+        ],
+        allow_empty = True,
+        exclude = ["src/**/*.test.ts"],
+    ),
 )
 
 # `bazel test //clients/desktop:lint` — ESLint over main + preload +

--- a/clients/desktop/e2e/tests/electron/updater.spec.ts
+++ b/clients/desktop/e2e/tests/electron/updater.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from "../../fixtures";
+
+// Smoke only: NODE_ENV=test puts auto_updater in its disabled branch (no
+// app-update.yml), so we verify the IPC contract + dev-guard behaviour, not a
+// real GitHub feed. The full download→staple→restart flow is exercised by the
+// nightly release channel, not here.
+type Bridge = {
+  invoke: (channel: string, ...args: unknown[]) => Promise<unknown>;
+  onUpdaterSnapshot?: unknown;
+};
+
+test.describe("Electron · updater IPC", () => {
+  test("updater:getVersion returns a non-empty version string", async ({ page }) => {
+    const version = await page.evaluate(() => (window as never as { electronAPI: Bridge }).electronAPI.invoke("updater:getVersion"));
+    expect(typeof version).toBe("string");
+    expect((version as string).length).toBeGreaterThan(0);
+  });
+
+  test("updater:getState returns a snapshot; dev-guard keeps it idle", async ({ page }) => {
+    const snap = (await page.evaluate(() =>
+      (window as never as { electronAPI: Bridge }).electronAPI.invoke("updater:getState"),
+    )) as { state?: string; percent?: number };
+    expect(snap).toMatchObject({ state: expect.any(String), percent: expect.any(Number) });
+    // disabled branch: boot check sends not-available → reduces to idle.
+    expect(snap.state).toBe("idle");
+  });
+
+  test("updater:check resolves under the dev guard (no real feed, no throw)", async ({ page }) => {
+    const result = await page
+      .evaluate(() => (window as never as { electronAPI: Bridge }).electronAPI.invoke("updater:check"))
+      .then(() => ({ ok: true }))
+      .catch((e: Error) => ({ ok: false, error: e.message }));
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("onUpdaterSnapshot subscriber is exposed on the bridge", async ({ page }) => {
+    const hasSubscriber = await page.evaluate(
+      () =>
+        typeof (window as never as { electronAPI: Bridge }).electronAPI.onUpdaterSnapshot ===
+        "function",
+    );
+    expect(hasSubscriber).toBe(true);
+  });
+});

--- a/clients/desktop/electron.vite.config.ts
+++ b/clients/desktop/electron.vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
     },
     build: {
       rollupOptions: {
-        external: ["@agentsmesh/node-bridge"],
+        external: ["@agentsmesh/node-bridge", "electron-updater"],
       },
     },
   },
@@ -85,6 +85,12 @@ export default defineConfig({
         // route file. Fall back to the web source tree so those imports resolve.
         { find: "@/app", replacement: resolve(webSrc, "app") },
         { find: "@/providers", replacement: resolve(webSrc, "providers") },
+        // Pin UpdaterProvider to one resolved path. Bazel stages desktop sources
+        // through symlink trees, so a relative `../../../providers/UpdaterProvider`
+        // from a route page resolves to a different absolute path than `./Updater
+        // Provider` from AppProviders — two module IDs, two React contexts, and
+        // useUpdater throws "must be used within UpdaterProvider" in the route.
+        { find: "@updater", replacement: resolve(desktopSrc, "providers/UpdaterProvider") },
         { find: "@", replacement: desktopSrc },
         { find: "next/navigation", replacement: resolve(desktopSrc, "shims/next-navigation") },
         { find: "next/link", replacement: resolve(desktopSrc, "shims/next-link") },

--- a/clients/desktop/scripts/rewrite-latest-mac.mjs
+++ b/clients/desktop/scripts/rewrite-latest-mac.mjs
@@ -1,0 +1,86 @@
+// After release.yml staples the .app inside each zip and repacks it, the build-
+// time sha512/size in latest-mac.yml no longer match — electron-updater verifies
+// them and silently rejects the update, so rewrite them. Pure Node (js-yaml isn't
+// require()-able from the repo root) over the line-stable format.
+//
+// Usage: node rewrite-latest-mac.mjs <latest-mac.yml> <stage-dir>
+import { readFileSync, writeFileSync, statSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function rewriteLatestMac(ymlPath, stageDir) {
+  // url is %-encoded; the file on disk is decoded. decodeURIComponent throws on a
+  // literal '%', so fall back to raw (→ a clear ENOENT). Cache so the primary
+  // artifact (also the top-level path:) isn't hashed twice.
+  const hashCache = new Map();
+  const decodeName = (name) => {
+    try {
+      return decodeURIComponent(name);
+    } catch {
+      return name;
+    }
+  };
+  const filePath = (name) => join(stageDir, decodeName(name));
+  const sha512 = (name) => {
+    let h = hashCache.get(name);
+    if (h === undefined) {
+      h = createHash("sha512").update(readFileSync(filePath(name))).digest("base64");
+      hashCache.set(name, h);
+    }
+    return h;
+  };
+  const sizeOf = (name) => statSync(filePath(name)).size;
+
+  const lines = readFileSync(ymlPath, "utf8").split("\n");
+
+  // Top-level `path:` names the artifact the top-level sha512 mirrors.
+  let topPath = null;
+  for (const l of lines) {
+    const m = /^path:\s*(\S+)/.exec(l);
+    if (m) topPath = m[1];
+  }
+
+  let curFile = null;
+  const out = [];
+  for (const line of lines) {
+    const urlM = /^(\s*-\s*url:\s*)(\S+)/.exec(line);
+    if (urlM) {
+      curFile = urlM[2];
+      out.push(line);
+      continue;
+    }
+    const shaIndented = /^(\s+sha512:\s*).*/.exec(line);
+    if (shaIndented && curFile) {
+      out.push(`${shaIndented[1]}${sha512(curFile)}`);
+      continue;
+    }
+    const sizeIndented = /^(\s+size:\s*).*/.exec(line);
+    if (sizeIndented && curFile) {
+      out.push(`${sizeIndented[1]}${sizeOf(curFile)}`);
+      continue;
+    }
+    // The repack invalidates the blockmap; drop blockMapSize to force a full download.
+    if (/^\s+blockMapSize:\s*/.test(line) && curFile) continue;
+    const shaTop = /^(sha512:\s*).*/.exec(line);
+    if (shaTop && topPath) {
+      out.push(`${shaTop[1]}${sha512(topPath)}`);
+      continue;
+    }
+    if (/^\S/.test(line)) curFile = null;
+    out.push(line);
+  }
+
+  writeFileSync(ymlPath, out.join("\n"));
+}
+
+// CLI entry — release.yml runs `node rewrite-latest-mac.mjs <yml> <stage>`.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const [, , ymlPath, stageDir] = process.argv;
+  if (!ymlPath || !stageDir) {
+    console.error("usage: rewrite-latest-mac.mjs <latest-mac.yml> <stage-dir>");
+    process.exit(1);
+  }
+  rewriteLatestMac(ymlPath, stageDir);
+  console.log("rewrote", ymlPath);
+}

--- a/clients/desktop/scripts/rewrite-latest-mac.test.ts
+++ b/clients/desktop/scripts/rewrite-latest-mac.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+import { rewriteLatestMac } from "./rewrite-latest-mac.mjs";
+
+const sha512 = (buf: Buffer) => createHash("sha512").update(buf).digest("base64");
+
+describe("rewriteLatestMac", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "latestmac-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const write = (name: string, content: string) => writeFileSync(join(dir, name), content);
+
+  it("rewrites sha512+size per zip, drops blockMapSize, mirrors the top-level sha512", () => {
+    const arm = Buffer.from("ARM_ZIP_CONTENT");
+    const x64 = Buffer.from("X64_ZIP_CONTENT_is_longer");
+    write("AgentsMesh-1.0.0-arm64.zip", arm.toString());
+    write("AgentsMesh-1.0.0.zip", x64.toString());
+    write(
+      "latest-mac.yml",
+      [
+        "version: 1.0.0",
+        "files:",
+        "  - url: AgentsMesh-1.0.0-arm64.zip",
+        "    sha512: OLD1==",
+        "    size: 1",
+        "    blockMapSize: 999",
+        "  - url: AgentsMesh-1.0.0.zip",
+        "    sha512: OLD2==",
+        "    size: 2",
+        "path: AgentsMesh-1.0.0-arm64.zip",
+        "sha512: OLD1==",
+        "releaseDate: '2026-06-08T00:00:00.000Z'",
+        "",
+      ].join("\n"),
+    );
+
+    rewriteLatestMac(join(dir, "latest-mac.yml"), dir);
+    const yml = readFileSync(join(dir, "latest-mac.yml"), "utf8");
+
+    expect(yml).not.toContain("blockMapSize");
+    expect(yml).toContain(`sha512: ${sha512(arm)}`);
+    expect(yml).toContain(`sha512: ${sha512(x64)}`);
+    expect(yml).toContain(`size: ${arm.length}`);
+    expect(yml).toContain(`size: ${x64.length}`);
+    // top-level sha512 (after path:) mirrors the arm64 artifact path points at
+    const topSha = /^sha512:\s*(\S+)/m.exec(yml.split("path:")[1] ?? "")?.[1];
+    expect(topSha).toBe(sha512(arm));
+    // untouched fields preserved verbatim
+    expect(yml).toContain("releaseDate: '2026-06-08T00:00:00.000Z'");
+    expect(yml).toContain("version: 1.0.0");
+  });
+
+  it("rewrites files[] even when there is no top-level path:", () => {
+    const z = Buffer.from("ZIP");
+    write("a.zip", z.toString());
+    write("latest-mac.yml", ["files:", "  - url: a.zip", "    sha512: OLD==", "    size: 1", ""].join("\n"));
+    rewriteLatestMac(join(dir, "latest-mac.yml"), dir);
+    const yml = readFileSync(join(dir, "latest-mac.yml"), "utf8");
+    expect(yml).toContain(`sha512: ${sha512(z)}`);
+    expect(yml).toContain(`size: ${z.length}`);
+  });
+
+  it("decodes %-encoded url to the on-disk filename", () => {
+    const z = Buffer.from("SPACED");
+    write("Agents Mesh-1.0.0.zip", z.toString());
+    write(
+      "latest-mac.yml",
+      ["files:", "  - url: Agents%20Mesh-1.0.0.zip", "    sha512: OLD==", "    size: 1", ""].join("\n"),
+    );
+    rewriteLatestMac(join(dir, "latest-mac.yml"), dir);
+    const yml = readFileSync(join(dir, "latest-mac.yml"), "utf8");
+    expect(yml).toContain(`sha512: ${sha512(z)}`);
+  });
+});

--- a/clients/desktop/src/main/auto_updater.ts
+++ b/clients/desktop/src/main/auto_updater.ts
@@ -1,0 +1,85 @@
+import { app, ipcMain, powerMonitor, type BrowserWindow } from "electron";
+// electron-updater is CJS-only — a named import resolves to undefined under
+// electron-vite interop. Default-import; destructure inside the function since
+// the `autoUpdater` getter instantiates the platform updater (touches app).
+import electronUpdater, { type UpdateInfo, type ProgressInfo } from "electron-updater";
+import { logEvent } from "@agentsmesh/node-bridge";
+import { reduceUpdater, INITIAL_SNAPSHOT, type UpdaterEvent, type UpdaterSnapshot } from "../shared/updater-reducer";
+
+const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000 + 7 * 60 * 1000; // ~4h, off the hour
+const FOCUS_THROTTLE_MS = 30 * 60 * 1000;
+
+export function setupAutoUpdater(getMainWindow: () => BrowserWindow | null): void {
+  let snapshot: UpdaterSnapshot = INITIAL_SNAPSHOT;
+
+  ipcMain.handle("updater:getVersion", () => app.getVersion());
+  ipcMain.handle("updater:getState", () => snapshot);
+
+  // Unpackaged / e2e have no app-update.yml. Register a no-op check surface and
+  // return before touching electron-updater — instantiating it (Squirrel.Mac
+  // native init on macOS) + its listeners + the interval all run before
+  // createWindow and are pure startup cost when checks can't run anyway.
+  if (!app.isPackaged || process.env.NODE_ENV === "test") {
+    ipcMain.handle("updater:check", () => {});
+    ipcMain.handle("updater:quitAndInstall", () => {});
+    return;
+  }
+
+  const { autoUpdater } = electronUpdater;
+
+  const send = (ev: UpdaterEvent) => {
+    const next = reduceUpdater(snapshot, ev);
+    if (next === snapshot) return; // unchanged — skip the push + a no-op renderer re-render
+    snapshot = next;
+    const win = getMainWindow();
+    if (!win || win.isDestroyed()) return;
+    win.webContents.send("updater:snapshot", snapshot);
+  };
+
+  autoUpdater.autoDownload = true;
+  autoUpdater.autoInstallOnAppQuit = true;
+  autoUpdater.allowPrerelease = false;
+
+  autoUpdater.on("checking-for-update", () => send({ type: "checking" }));
+  autoUpdater.on("update-available", (info: UpdateInfo) => {
+    logEvent("info", "updater", `available ${info.version}`);
+    send({ type: "available", version: info.version });
+  });
+  autoUpdater.on("update-not-available", () => send({ type: "not-available" }));
+  autoUpdater.on("download-progress", (p: ProgressInfo) =>
+    send({ type: "progress", percent: Math.round(p.percent) }),
+  );
+  autoUpdater.on("update-downloaded", (info: UpdateInfo) => {
+    logEvent("info", "updater", `downloaded ${info.version}`);
+    send({ type: "downloaded", version: info.version });
+  });
+  autoUpdater.on("error", (err: Error) => {
+    logEvent("warn", "updater", `error: ${err.message}`);
+    send({ type: "error", message: err.message });
+  });
+
+  let lastCheckAt = 0;
+  const check = (reason: string): void => {
+    lastCheckAt = Date.now();
+    logEvent("info", "updater", `checking (${reason})`);
+    void autoUpdater.checkForUpdates().catch((err: Error) => {
+      logEvent("warn", "updater", `checkForUpdates failed: ${err.message}`);
+      send({ type: "error", message: err.message });
+    });
+  };
+
+  ipcMain.handle("updater:check", () => check("manual"));
+  ipcMain.handle("updater:quitAndInstall", () => {
+    logEvent("info", "updater", "quitAndInstall");
+    autoUpdater.quitAndInstall();
+  });
+
+  setInterval(() => check("interval"), CHECK_INTERVAL_MS);
+  const onReArm = () => {
+    if (Date.now() - lastCheckAt >= FOCUS_THROTTLE_MS) check("re-arm");
+  };
+  powerMonitor.on("resume", onReArm);
+  app.on("browser-window-focus", onReArm);
+
+  check("boot");
+}

--- a/clients/desktop/src/main/index.ts
+++ b/clients/desktop/src/main/index.ts
@@ -9,6 +9,7 @@ import { acquireSingleInstance } from "./single_instance";
 import { IPC_ALLOWLIST, IPC_ALLOWLIST_SET } from "./ipc-allowlist.generated";
 import { setupRealtimeBridge, type RealtimeBridge } from "./realtime";
 import { setupRelayBridge, type RelayBridge } from "./relay";
+import { setupAutoUpdater } from "./auto_updater";
 import { connectFetch } from "./connect-fetch";
 import {
   registerProtocol,
@@ -643,6 +644,7 @@ app.whenReady().then(() => {
     realtimeBridge = bridge;
   });
   relayBridge = setupRelayBridge(appState, getMainWindow);
+  setupAutoUpdater(getMainWindow);
   buildMenu();
   installOpenUrlHandler(getMainWindow);
   createWindow();

--- a/clients/desktop/src/preload/index.ts
+++ b/clients/desktop/src/preload/index.ts
@@ -1,5 +1,6 @@
 import { contextBridge, ipcRenderer, IpcRendererEvent } from "electron";
 import { type ServerConfig } from "../shared/server-config-types";
+import { type UpdaterSnapshot } from "../shared/updater-reducer";
 
 // Sync IPC by design: renderer code (env.ts, OAuth URL builders, WS connect) is synchronous.
 // Reading at preload (before any renderer code runs) blocks no UI thread; mainWindow.reload()
@@ -30,6 +31,11 @@ const api = {
     const listener = (_e: IpcRendererEvent, eventJson: string) => handler(eventJson);
     ipcRenderer.on("realtime:event", listener);
     return () => ipcRenderer.removeListener("realtime:event", listener);
+  },
+  onUpdaterSnapshot: (handler: (snap: UpdaterSnapshot) => void) => {
+    const listener = (_e: IpcRendererEvent, snap: UpdaterSnapshot) => handler(snap);
+    ipcRenderer.on("updater:snapshot", listener);
+    return () => ipcRenderer.removeListener("updater:snapshot", listener);
   },
   onRealtimeState: (handler: (state: string) => void) => {
     const listener = (_e: IpcRendererEvent, state: string) => handler(state);

--- a/clients/desktop/src/renderer/components/UpdateReadyBanner.tsx
+++ b/clients/desktop/src/renderer/components/UpdateReadyBanner.tsx
@@ -1,0 +1,22 @@
+import { useTranslations } from "next-intl";
+import { useUpdater } from "@updater";
+
+// Shown only once an update is staged; clicking restarts to apply it.
+export function UpdateReadyBanner() {
+  const t = useTranslations("settings");
+  const { state, availableVersion, quitAndInstall } = useUpdater();
+
+  if (state !== "ready") return null;
+
+  return (
+    <button
+      type="button"
+      onClick={quitAndInstall}
+      data-testid="update-ready-banner"
+      className="fixed inset-x-0 top-0 z-[60] flex items-center justify-center gap-2 bg-emerald-600/95 px-4 py-1.5 text-center text-sm font-medium text-white shadow transition-colors hover:bg-emerald-600"
+    >
+      <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-white/90" />
+      {t("updater.bannerReady", { version: availableVersion ?? "" })}
+    </button>
+  );
+}

--- a/clients/desktop/src/renderer/pages/settings/general/AppUpdateSection.tsx
+++ b/clients/desktop/src/renderer/pages/settings/general/AppUpdateSection.tsx
@@ -1,0 +1,51 @@
+import { useTranslations } from "next-intl";
+import { RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useUpdater } from "@updater";
+import { type UpdaterState } from "../../../../shared/updater-reducer";
+
+const STATUS_KEY: Record<UpdaterState, string> = {
+  idle: "updater.upToDate",
+  checking: "updater.checking",
+  downloading: "updater.downloading",
+  ready: "updater.ready",
+  error: "updater.error",
+};
+
+export function AppUpdateSection() {
+  const t = useTranslations("settings");
+  const { state, percent, currentVersion, check, quitAndInstall } = useUpdater();
+
+  const statusText =
+    state === "downloading"
+      ? t("updater.downloading", { percent })
+      : t(STATUS_KEY[state]);
+
+  const busy = state === "checking" || state === "downloading";
+
+  return (
+    <div className="border border-border rounded-lg p-6">
+      <h2 className="text-lg font-semibold mb-4">{t("updater.sectionTitle")}</h2>
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <p className="text-sm text-muted-foreground">{t("updater.currentVersion")}</p>
+          <p className="font-medium">{currentVersion ?? "-"}</p>
+          <p className="text-sm text-muted-foreground mt-1">{statusText}</p>
+        </div>
+        {state === "ready" ? (
+          <Button onClick={quitAndInstall}>{t("updater.restart")}</Button>
+        ) : (
+          <Button
+            variant="outline"
+            onClick={check}
+            disabled={busy}
+            className="flex items-center gap-2"
+          >
+            <RefreshCw className={`w-4 h-4 ${state === "checking" ? "animate-spin" : ""}`} />
+            {t("updater.checkButton")}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/clients/desktop/src/renderer/pages/settings/general/GeneralSettingsPage.tsx
+++ b/clients/desktop/src/renderer/pages/settings/general/GeneralSettingsPage.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { useAuthStore, useCurrentUser } from "@/stores/auth";
 import { useTranslations } from "next-intl";
 import { LogOut, User, Mail } from "lucide-react";
+import { AppUpdateSection } from "./AppUpdateSection";
 
 export function GeneralSettingsPage() {
   const router = useRouter();
@@ -58,7 +59,7 @@ export function GeneralSettingsPage() {
         </div>
       </div>
 
-      <div className="border border-border rounded-lg p-6">
+      <div className="border border-border rounded-lg p-6 mb-6">
         <h2 className="text-lg font-semibold mb-2">
           {t("settings.personal.general.session")}
         </h2>
@@ -75,6 +76,8 @@ export function GeneralSettingsPage() {
           {t("settings.personal.general.logout")}
         </Button>
       </div>
+
+      <AppUpdateSection />
     </div>
   );
 }

--- a/clients/desktop/src/renderer/providers/AppProviders.tsx
+++ b/clients/desktop/src/renderer/providers/AppProviders.tsx
@@ -4,6 +4,8 @@ import React, { useEffect, useState } from "react";
 import { ThemeProvider } from "next-themes";
 import { DesktopIntlProvider } from "./IntlProvider";
 import { Toaster } from "sonner";
+import { UpdaterProvider } from "@updater";
+import { UpdateReadyBanner } from "../components/UpdateReadyBanner";
 import { ensurePlatformReady } from "@agentsmesh/service-runtime";
 import { useAuthStore } from "@/stores/auth";
 
@@ -32,10 +34,13 @@ export function AppProviders({ children }: { children: React.ReactNode }) {
   return (
     <ThemeProvider defaultTheme="system" attribute="class">
       <DesktopIntlProvider>
-        <PlatformGate>
-          {children}
-        </PlatformGate>
-        <Toaster richColors position="top-right" />
+        <UpdaterProvider>
+          <PlatformGate>
+            {children}
+          </PlatformGate>
+          <Toaster richColors position="top-right" />
+          <UpdateReadyBanner />
+        </UpdaterProvider>
       </DesktopIntlProvider>
     </ThemeProvider>
   );

--- a/clients/desktop/src/renderer/providers/UpdaterProvider.tsx
+++ b/clients/desktop/src/renderer/providers/UpdaterProvider.tsx
@@ -1,0 +1,77 @@
+import { createContext, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { INITIAL_SNAPSHOT, type UpdaterSnapshot, type UpdaterState } from "../../shared/updater-reducer";
+
+type UpdaterApi = {
+  onUpdaterSnapshot: (handler: (snap: UpdaterSnapshot) => void) => () => void;
+  invoke: (channel: string, ...args: unknown[]) => Promise<unknown>;
+};
+
+// null in the web build / unit tests (no preload bridge) → a no-op idle updater.
+function updaterApi(): UpdaterApi | null {
+  if (typeof window === "undefined") return null;
+  const api = (window as unknown as { electronAPI?: Partial<UpdaterApi> }).electronAPI;
+  if (!api?.onUpdaterSnapshot || !api?.invoke) return null;
+  return api as UpdaterApi;
+}
+
+export interface Updater {
+  state: UpdaterState;
+  percent: number;
+  availableVersion: string | null;
+  currentVersion: string | null;
+  error: string | null;
+  check: () => void;
+  quitAndInstall: () => void;
+}
+
+const UpdaterContext = createContext<Updater | null>(null);
+
+// One subscription shared by banner + settings; a per-component hook would fork
+// state, and a section mounted after `downloaded` would disagree with the banner.
+// main owns the reducer (shared/updater-reducer) and pushes snapshots; this just
+// mirrors them.
+export function UpdaterProvider({ children }: { children: ReactNode }) {
+  const [snap, setSnap] = useState<UpdaterSnapshot>(INITIAL_SNAPSHOT);
+  const [currentVersion, setCurrentVersion] = useState<string | null>(null);
+  const liveSeen = useRef(false);
+
+  useEffect(() => {
+    const api = updaterApi();
+    if (!api) return;
+
+    const apply = (s: UpdaterSnapshot, fromSnapshot: boolean) => {
+      // A getState snapshot resolving after the first live push must not clobber it.
+      if (fromSnapshot && liveSeen.current) return;
+      if (!fromSnapshot) liveSeen.current = true;
+      setSnap(s);
+    };
+
+    void api.invoke("updater:getState").then((s) => apply(s as UpdaterSnapshot, true)).catch(() => {});
+    void api
+      .invoke("updater:getVersion")
+      .then((v) => setCurrentVersion(typeof v === "string" ? v : null))
+      .catch(() => {});
+    return api.onUpdaterSnapshot((s) => apply(s, false));
+  }, []);
+
+  const value = useMemo<Updater>(
+    () => ({
+      state: snap.state,
+      percent: snap.percent,
+      availableVersion: snap.availableVersion,
+      currentVersion,
+      error: snap.error,
+      check: () => void updaterApi()?.invoke("updater:check").catch(() => {}),
+      quitAndInstall: () => void updaterApi()?.invoke("updater:quitAndInstall").catch(() => {}),
+    }),
+    [snap, currentVersion],
+  );
+
+  return <UpdaterContext.Provider value={value}>{children}</UpdaterContext.Provider>;
+}
+
+export function useUpdater(): Updater {
+  const ctx = useContext(UpdaterContext);
+  if (!ctx) throw new Error("useUpdater must be used within UpdaterProvider");
+  return ctx;
+}

--- a/clients/desktop/src/renderer/providers/index.ts
+++ b/clients/desktop/src/renderer/providers/index.ts
@@ -1,6 +1,7 @@
 export { AppProviders } from "./AppProviders";
 export { ThemeProvider, useTheme } from "./ThemeProvider";
 export { DesktopIntlProvider, useLocale } from "./IntlProvider";
+export { UpdaterProvider, useUpdater } from "./UpdaterProvider";
 // RealtimeProvider lives in clients/web/src/providers — desktop mounts it
 // inside DashboardShell + PopoutTerminalPage via the `@/providers` alias.
 // The duplicate desktop copy was deleted (drift risk + double subscription).

--- a/clients/desktop/src/shared/updater-reducer.test.ts
+++ b/clients/desktop/src/shared/updater-reducer.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { reduceUpdater, INITIAL_SNAPSHOT, type UpdaterSnapshot } from "./updater-reducer";
+
+describe("reduceUpdater", () => {
+  it("INITIAL_SNAPSHOT is idle", () => {
+    expect(INITIAL_SNAPSHOT).toEqual({ state: "idle", percent: 0, availableVersion: null, error: null });
+  });
+
+  describe("transitions", () => {
+    it("checking resets percent + clears error", () => {
+      const s = reduceUpdater(
+        { state: "idle", percent: 50, availableVersion: null, error: "old" },
+        { type: "checking" },
+      );
+      expect(s).toMatchObject({ state: "checking", percent: 0, error: null });
+    });
+    it("available → downloading + version + percent 0", () => {
+      const s = reduceUpdater(INITIAL_SNAPSHOT, { type: "available", version: "1.2.3" });
+      expect(s).toMatchObject({ state: "downloading", availableVersion: "1.2.3", percent: 0 });
+    });
+    it("progress keeps version, updates percent", () => {
+      const prev: UpdaterSnapshot = { state: "downloading", percent: 0, availableVersion: "1.2.3", error: null };
+      const s = reduceUpdater(prev, { type: "progress", percent: 42 });
+      expect(s).toMatchObject({ state: "downloading", percent: 42, availableVersion: "1.2.3" });
+    });
+    it("downloaded → ready + version", () => {
+      const s = reduceUpdater(INITIAL_SNAPSHOT, { type: "downloaded", version: "1.2.3" });
+      expect(s).toMatchObject({ state: "ready", availableVersion: "1.2.3" });
+    });
+    it("error → error + message", () => {
+      const s = reduceUpdater(INITIAL_SNAPSHOT, { type: "error", message: "boom" });
+      expect(s).toMatchObject({ state: "error", error: "boom" });
+    });
+  });
+
+  describe("not-available idle dedup", () => {
+    it("idle + not-available returns the SAME reference (lets main skip the push)", () => {
+      expect(reduceUpdater(INITIAL_SNAPSHOT, { type: "not-available" })).toBe(INITIAL_SNAPSHOT);
+    });
+    it("checking + not-available → idle (real transition, new object)", () => {
+      const prev: UpdaterSnapshot = { state: "checking", percent: 0, availableVersion: null, error: null };
+      const s = reduceUpdater(prev, { type: "not-available" });
+      expect(s.state).toBe("idle");
+      expect(s).not.toBe(prev);
+    });
+  });
+
+  describe("ready is terminal", () => {
+    const ready: UpdaterSnapshot = { state: "ready", percent: 100, availableVersion: "1.2.3", error: null };
+
+    it.each([
+      ["checking", { type: "checking" }],
+      ["not-available", { type: "not-available" }],
+      ["available re-advertise", { type: "available", version: "1.2.3" }],
+      ["progress", { type: "progress", percent: 50 }],
+      ["error blip", { type: "error", message: "blip" }],
+    ] as const)("ready + %s returns SAME reference (no banner flicker)", (_label, ev) => {
+      expect(reduceUpdater(ready, ev)).toBe(ready);
+    });
+
+    it("ready + downloaded (a newer build) DOES leave ready with the new version", () => {
+      const s = reduceUpdater(ready, { type: "downloaded", version: "2.0.0" });
+      expect(s).toMatchObject({ state: "ready", availableVersion: "2.0.0" });
+      expect(s).not.toBe(ready);
+    });
+  });
+
+  describe("typical lifecycle", () => {
+    it("idle → checking → available → progress → downloaded ⇒ ready", () => {
+      let s: UpdaterSnapshot = INITIAL_SNAPSHOT;
+      s = reduceUpdater(s, { type: "checking" });
+      expect(s.state).toBe("checking");
+      s = reduceUpdater(s, { type: "available", version: "1.0.0" });
+      expect(s.state).toBe("downloading");
+      s = reduceUpdater(s, { type: "progress", percent: 50 });
+      expect(s.percent).toBe(50);
+      s = reduceUpdater(s, { type: "downloaded", version: "1.0.0" });
+      expect(s).toMatchObject({ state: "ready", availableVersion: "1.0.0" });
+    });
+  });
+
+  it("never mutates prev", () => {
+    const prev: UpdaterSnapshot = { state: "idle", percent: 0, availableVersion: null, error: null };
+    const copy = { ...prev };
+    reduceUpdater(prev, { type: "available", version: "1.0.0" });
+    expect(prev).toEqual(copy);
+  });
+});

--- a/clients/desktop/src/shared/updater-reducer.ts
+++ b/clients/desktop/src/shared/updater-reducer.ts
@@ -1,0 +1,52 @@
+export type UpdaterState = "idle" | "checking" | "downloading" | "ready" | "error";
+
+// Wire-in events from electron-updater — main folds these into the Snapshot that
+// preload + renderer mirror; the events themselves never cross the IPC boundary.
+export type UpdaterEvent =
+  | { type: "checking" }
+  | { type: "available"; version: string }
+  | { type: "not-available" }
+  | { type: "progress"; percent: number }
+  | { type: "downloaded"; version: string }
+  | { type: "error"; message: string };
+
+export type UpdaterSnapshot = {
+  state: UpdaterState;
+  percent: number;
+  availableVersion: string | null;
+  error: string | null;
+};
+
+export const INITIAL_SNAPSHOT: UpdaterSnapshot = {
+  state: "idle",
+  percent: 0,
+  availableVersion: null,
+  error: null,
+};
+
+// ready is terminal: electron-updater re-emits `available` for the already-staged
+// build on every re-check, so only a fresh `downloaded` leaves ready (else the
+// restart banner flickers). main folds events through this and pushes the
+// snapshot; the renderer mirrors it — one reducer, no two-layer drift. Returning
+// `prev` unchanged lets main skip the push (see send()).
+export function reduceUpdater(prev: UpdaterSnapshot, ev: UpdaterEvent): UpdaterSnapshot {
+  if (prev.state === "ready" && ev.type !== "downloaded") return prev;
+  switch (ev.type) {
+    case "checking":
+      return { ...prev, state: "checking", percent: 0, error: null };
+    case "available":
+      return { ...prev, state: "downloading", availableVersion: ev.version, percent: 0 };
+    case "progress":
+      return { ...prev, state: "downloading", percent: ev.percent };
+    case "downloaded":
+      return { ...prev, state: "ready", availableVersion: ev.version };
+    case "not-available":
+      return prev.state === "idle" ? prev : { ...prev, state: "idle" };
+    case "error":
+      return { ...prev, state: "error", error: ev.message };
+    default: {
+      const _exhaustive: never = ev;
+      return _exhaustive;
+    }
+  }
+}

--- a/clients/desktop/vitest.config.ts
+++ b/clients/desktop/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+// Pure-logic units only (shared reducer + the latest-mac.yml rewrite script):
+// node env, no jsdom/React/wasm. Renderer component tests would need the web
+// alias + electronAPI mocks and are out of scope here.
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts", "scripts/**/*.test.ts"],
+    reporters: ["default", "junit"],
+    outputFile: { junit: "./report.xml" },
+  },
+});

--- a/clients/web/src/messages/de/settings.json
+++ b/clients/web/src/messages/de/settings.json
@@ -1,5 +1,17 @@
 {
   "settings": {
+    "updater": {
+      "sectionTitle": "Application Updates",
+      "currentVersion": "Current version",
+      "checkButton": "Check for Updates",
+      "restart": "Restart to Update",
+      "checking": "Checking for updates…",
+      "upToDate": "You're on the latest version.",
+      "downloading": "Downloading update… {percent}%",
+      "ready": "Update ready — restart to apply.",
+      "error": "Update check failed.",
+      "bannerReady": "A new version (v{version}) is ready · Click to restart and update"
+    },
     "title": "Einstellungen",
     "backToSettings": "Zurück zu Einstellungen",
     "general": "Allgemein",

--- a/clients/web/src/messages/en/settings.json
+++ b/clients/web/src/messages/en/settings.json
@@ -1,5 +1,17 @@
 {
   "settings": {
+    "updater": {
+      "sectionTitle": "Application Updates",
+      "currentVersion": "Current version",
+      "checkButton": "Check for Updates",
+      "restart": "Restart to Update",
+      "checking": "Checking for updates…",
+      "upToDate": "You're on the latest version.",
+      "downloading": "Downloading update… {percent}%",
+      "ready": "Update ready — restart to apply.",
+      "error": "Update check failed.",
+      "bannerReady": "A new version (v{version}) is ready · Click to restart and update"
+    },
     "title": "Settings",
     "backToSettings": "Back to Settings",
     "general": "General",

--- a/clients/web/src/messages/es/settings.json
+++ b/clients/web/src/messages/es/settings.json
@@ -1,5 +1,17 @@
 {
   "settings": {
+    "updater": {
+      "sectionTitle": "Application Updates",
+      "currentVersion": "Current version",
+      "checkButton": "Check for Updates",
+      "restart": "Restart to Update",
+      "checking": "Checking for updates…",
+      "upToDate": "You're on the latest version.",
+      "downloading": "Downloading update… {percent}%",
+      "ready": "Update ready — restart to apply.",
+      "error": "Update check failed.",
+      "bannerReady": "A new version (v{version}) is ready · Click to restart and update"
+    },
     "title": "Configuración",
     "backToSettings": "Volver a configuración",
     "general": "General",

--- a/clients/web/src/messages/fr/settings.json
+++ b/clients/web/src/messages/fr/settings.json
@@ -1,5 +1,17 @@
 {
   "settings": {
+    "updater": {
+      "sectionTitle": "Application Updates",
+      "currentVersion": "Current version",
+      "checkButton": "Check for Updates",
+      "restart": "Restart to Update",
+      "checking": "Checking for updates…",
+      "upToDate": "You're on the latest version.",
+      "downloading": "Downloading update… {percent}%",
+      "ready": "Update ready — restart to apply.",
+      "error": "Update check failed.",
+      "bannerReady": "A new version (v{version}) is ready · Click to restart and update"
+    },
     "title": "Paramètres",
     "backToSettings": "Retour aux paramètres",
     "general": "Général",

--- a/clients/web/src/messages/ja/settings.json
+++ b/clients/web/src/messages/ja/settings.json
@@ -1,5 +1,17 @@
 {
   "settings": {
+    "updater": {
+      "sectionTitle": "Application Updates",
+      "currentVersion": "Current version",
+      "checkButton": "Check for Updates",
+      "restart": "Restart to Update",
+      "checking": "Checking for updates…",
+      "upToDate": "You're on the latest version.",
+      "downloading": "Downloading update… {percent}%",
+      "ready": "Update ready — restart to apply.",
+      "error": "Update check failed.",
+      "bannerReady": "A new version (v{version}) is ready · Click to restart and update"
+    },
     "title": "設定",
     "backToSettings": "設定に戻る",
     "general": "一般",

--- a/clients/web/src/messages/ko/settings.json
+++ b/clients/web/src/messages/ko/settings.json
@@ -1,5 +1,17 @@
 {
   "settings": {
+    "updater": {
+      "sectionTitle": "Application Updates",
+      "currentVersion": "Current version",
+      "checkButton": "Check for Updates",
+      "restart": "Restart to Update",
+      "checking": "Checking for updates…",
+      "upToDate": "You're on the latest version.",
+      "downloading": "Downloading update… {percent}%",
+      "ready": "Update ready — restart to apply.",
+      "error": "Update check failed.",
+      "bannerReady": "A new version (v{version}) is ready · Click to restart and update"
+    },
     "title": "설정",
     "backToSettings": "설정으로 돌아가기",
     "general": "일반",

--- a/clients/web/src/messages/pt/settings.json
+++ b/clients/web/src/messages/pt/settings.json
@@ -1,5 +1,17 @@
 {
   "settings": {
+    "updater": {
+      "sectionTitle": "Application Updates",
+      "currentVersion": "Current version",
+      "checkButton": "Check for Updates",
+      "restart": "Restart to Update",
+      "checking": "Checking for updates…",
+      "upToDate": "You're on the latest version.",
+      "downloading": "Downloading update… {percent}%",
+      "ready": "Update ready — restart to apply.",
+      "error": "Update check failed.",
+      "bannerReady": "A new version (v{version}) is ready · Click to restart and update"
+    },
     "title": "Configurações",
     "backToSettings": "Voltar às configurações",
     "general": "Geral",

--- a/clients/web/src/messages/zh/settings.json
+++ b/clients/web/src/messages/zh/settings.json
@@ -1,5 +1,17 @@
 {
   "settings": {
+    "updater": {
+      "sectionTitle": "应用更新",
+      "currentVersion": "当前版本",
+      "checkButton": "检查更新",
+      "restart": "重启以更新",
+      "checking": "正在检查更新…",
+      "upToDate": "已是最新版本。",
+      "downloading": "正在下载更新… {percent}%",
+      "ready": "更新已就绪 — 重启即可应用。",
+      "error": "检查更新失败。",
+      "bannerReady": "新版本 (v{version}) 已就绪 · 点击重启更新"
+    },
     "title": "设置",
     "backToSettings": "返回设置",
     "general": "通用",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "dotenv": "^16.5.0",
     "electron": "^33",
     "electron-builder": "^25",
+    "electron-updater": "^6",
     "electron-vite": "^6.0.0-beta.1",
     "eslint": "^9",
     "eslint-config-next": "16.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,6 +279,9 @@ importers:
       electron-builder:
         specifier: ^25
         version: 25.1.8(electron-builder-squirrel-windows@25.1.8)
+      electron-updater:
+        specifier: ^6
+        version: 6.8.9
       electron-vite:
         specifier: ^6.0.0-beta.1
         version: 6.0.0-beta.1(@swc/core@1.15.30)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0))
@@ -3174,6 +3177,10 @@ packages:
     resolution: {integrity: sha512-6p/gfG1RJSQeIbz8TK5aPNkoztgY1q5TgmGFMAXcY8itsGW6Y2ld1ALsZ5UJn8rog7hKF3zHx5iQbNQ8uLcRlw==}
     engines: {node: '>=12.0.0'}
 
+  builder-util-runtime@9.7.0:
+    resolution: {integrity: sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==}
+    engines: {node: '>=12.0.0'}
+
   builder-util@25.1.7:
     resolution: {integrity: sha512-7jPjzBwEGRbwNcep0gGNpLXG9P94VA3CPAZQCzxkFXiV2GMQKlziMbY//rXPI7WKfhsvGgFXjTcXdBEwgXw9ww==}
 
@@ -3610,6 +3617,9 @@ packages:
 
   electron-to-chromium@1.5.344:
     resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
+
+  electron-updater@6.8.9:
+    resolution: {integrity: sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==}
 
   electron-vite@6.0.0-beta.1:
     resolution: {integrity: sha512-jltST77AwNxIeTTDtYhnIEA8ZM0RW9jmSJcqS8x/dQcgeeLlxlcJoYNNJ1tv7/Swor0AbXMYteBGdezoAOt+Nw==}
@@ -4674,8 +4684,15 @@ packages:
   lodash.difference@4.5.0:
     resolution: {integrity: sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==}
 
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
   lodash.flatten@4.4.0:
     resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isplainobject@4.0.6:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
@@ -5940,6 +5957,9 @@ packages:
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tiny-typed-emitter@2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -9289,6 +9309,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  builder-util-runtime@9.7.0:
+    dependencies:
+      debug: 4.4.3
+      sax: 1.6.0
+    transitivePeerDependencies:
+      - supports-color
+
   builder-util@25.1.7:
     dependencies:
       7zip-bin: 5.2.0
@@ -9787,6 +9814,19 @@ snapshots:
       - supports-color
 
   electron-to-chromium@1.5.344: {}
+
+  electron-updater@6.8.9:
+    dependencies:
+      builder-util-runtime: 9.7.0
+      fs-extra: 10.1.0
+      js-yaml: 4.1.1
+      lazy-val: 1.0.5
+      lodash.escaperegexp: 4.1.2
+      lodash.isequal: 4.5.0
+      semver: 7.7.4
+      tiny-typed-emitter: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   electron-vite@6.0.0-beta.1(@swc/core@1.15.30)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)):
     dependencies:
@@ -11152,7 +11192,11 @@ snapshots:
 
   lodash.difference@4.5.0: {}
 
+  lodash.escaperegexp@4.1.2: {}
+
   lodash.flatten@4.4.0: {}
+
+  lodash.isequal@4.5.0: {}
 
   lodash.isplainobject@4.0.6: {}
 
@@ -12825,6 +12869,8 @@ snapshots:
       fs-extra: 10.1.0
 
   tiny-invariant@1.3.3: {}
+
+  tiny-typed-emitter@2.1.0: {}
 
   tinybench@2.9.0: {}
 


### PR DESCRIPTION
## What

Desktop auto-update via `electron-updater`, pulling from GitHub Releases (public repo → no token).

- **Silent background download** + a top restart banner once staged + a settings "check for updates" entry (current version + manual check).
- **Single reducer SSOT** (`shared/updater-reducer`): main folds electron-updater events into a `Snapshot` it pushes; the renderer mirrors it. `ready`/`downloaded` is terminal, so the periodic re-check (electron-updater re-emits `available` for the staged build) never flickers the banner.
- Checks on **boot / 4h interval / window-focus** (throttled), with a dev/e2e guard (no `app-update.yml` when unpackaged).

## macOS release plumbing

electron-updater on macOS updates via `.zip`, and the `.app` inside must be stapled. `release.yml` now notarizes + staples the `.app` in each zip, repacks, and rewrites `latest-mac.yml`'s sha512/size via `scripts/rewrite-latest-mac.mjs` (a hash mismatch makes electron-updater silently reject the update). Windows `latest.yml` feed already shipped.

## i18n

`updater.*` strings live in `clients/web/src/messages/*/settings.json` — desktop loads via the `@/messages` alias (the desktop `messages/` dir is a dead copy).

## Tests

- `reduceUpdater` vitest unit (16): transitions, ready-terminal, idle dedup, lifecycle, immutability
- `rewriteLatestMac` vitest unit (3): sha512/size rewrite, blockMapSize drop, top-level mirror, decode
- e2e updater IPC smoke (4): getVersion / getState / check / onUpdaterSnapshot

New `:unit` vitest target (desktop had none). `bazel test //clients/desktop:unit` → 19 passed.

## Verification

`bazel build //clients/desktop:out` ✅ · `:lint` ✅ · `:unit` ✅. Full download→restart flow to be validated on the nightly channel.