### PR TITLE
refactor(tickets): move Spawn Pod into the right-side rail

### DIFF
--- a/clients/web/src/components/tickets/TicketDetail.tsx
+++ b/clients/web/src/components/tickets/TicketDetail.tsx
@@ -11,7 +11,6 @@ import { useTicketExtraData } from "./hooks";
 import { LabelsList, CommentsList, SubTicketsList, RelationsList, CommitsList } from "./shared";
 import { TicketDetailSidebar } from "./TicketDetailSidebar";
 import { InlineEditableText } from "./InlineEditableText";
-import { SpawnPodButton } from "./SpawnPodButton";
 import { StatusSelect } from "./StatusSelect";
 
 const BlockEditor = lazy(() => import("@/components/ui/block-editor"));
@@ -192,38 +191,27 @@ export function TicketDetail({ slug }: TicketDetailProps) {
               )}
             </div>
 
-            <div className="flex shrink-0 flex-col items-end gap-2 w-[260px]">
-              <SpawnPodButton
-                ticket={currentTicket}
-                ticketSlug={slug}
-                size="lg"
-                className="h-11 w-full gap-2 text-sm font-semibold shadow-sm"
-              />
-              <p className="text-right text-[11px] text-muted-foreground">
-                {currentTicket.repository?.name ?? "—"} · {t("tickets.detail.lastUsedAgent")}
-              </p>
-              <div className="flex items-center gap-1.5">
-                <Button variant="outline" size="sm" className="h-7 px-3 text-xs">
-                  {t("common.edit")}
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-7 px-3 text-xs"
-                  onClick={() => handleStatusChange("done" as TicketStatus)}
-                >
-                  {t("tickets.detail.markDone")}
-                </Button>
-                <Button
-                  variant="outline"
-                  size="icon"
-                  className="h-7 w-7"
-                  onClick={handleDelete}
-                  aria-label={t("common.more")}
-                >
-                  ⋯
-                </Button>
-              </div>
+            <div className="flex shrink-0 items-center gap-1.5">
+              <Button variant="outline" size="sm" className="h-7 px-3 text-xs">
+                {t("common.edit")}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 px-3 text-xs"
+                onClick={() => handleStatusChange("done" as TicketStatus)}
+              >
+                {t("tickets.detail.markDone")}
+              </Button>
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-7 w-7"
+                onClick={handleDelete}
+                aria-label={t("common.more")}
+              >
+                ⋯
+              </Button>
             </div>
           </div>
         </div>

--- a/clients/web/src/components/tickets/TicketDetailSidebar.tsx
+++ b/clients/web/src/components/tickets/TicketDetailSidebar.tsx
@@ -11,6 +11,7 @@ import { useTicketPods } from "@/hooks/useTicketPods";
 import { useWorkspaceStore } from "@/stores/workspace";
 import { getShortPodKey } from "@/lib/pod-display-name";
 import { AgentStatusBadge } from "@/components/shared/AgentStatusBadge";
+import { SpawnPodButton } from "./SpawnPodButton";
 
 interface TicketDetailSidebarProps {
   ticket: Ticket;
@@ -52,6 +53,18 @@ export function TicketDetailSidebar({
 
   return (
     <aside className="lg:w-80 shrink-0 space-y-4">
+      <div className="space-y-1.5">
+        <SpawnPodButton
+          ticket={ticket}
+          ticketSlug={ticketSlug}
+          size="lg"
+          className="h-11 w-full gap-2 text-sm font-semibold shadow-sm"
+        />
+        <p className="text-[11px] text-muted-foreground">
+          {ticket.repository?.name ?? "—"} · {t("tickets.detail.lastUsedAgent")}
+        </p>
+      </div>
+
       <RailSection title={t("tickets.rail.workingPods")} count={activePods.length}>
         {podsLoading ? (
           <RailEmpty icon={<Terminal className="h-4 w-4" />} text={t("common.loading")} />


### PR DESCRIPTION
## What

Moves the **Spawn Pod** button out of the ticket detail header title area and into the right-side functional rail (`TicketDetailSidebar`), placed directly above the **Working Pods** section — its natural context.

Addresses TICKET-153: the Spawn Pod control sat alone in the title area, which looked out of place.

## Changes

- **`TicketDetailSidebar.tsx`**: import `SpawnPodButton`; render the full-width button + its `repository · last used agent` caption as the first block in the rail, above Working Pods.
- **`TicketDetail.tsx`**: remove Spawn Pod + caption from the header; simplify the header's right cluster to a compact inline row of Edit / Mark Done / ⋯ actions (dropped the fixed `260px` column); drop the now-unused import.

No new prop wiring needed — the sidebar already received `ticket` and `ticketSlug`.

## Verification

- `bazel build //clients/web:src` (tsc) — passes
- `bazel test //clients/web:lint` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)