### PR TITLE
feat(channels): collapse & distinguish destroyed pods in channel right-rail

### DIFF
--- a/clients/web/e2e-playwright/tests/mesh/channel-pod-membership.spec.ts
+++ b/clients/web/e2e-playwright/tests/mesh/channel-pod-membership.spec.ts
@@ -22,6 +22,7 @@ type ChannelPod = { podKey: string };
 
 const SECOND_USER = { email: "dev2@agentsmesh.local", password: "devpass123" };
 const RAIL = '[data-testid="channel-right-rail"]';
+const POD_ROW = '[data-testid="channel-rail-pod"]';
 
 interface CreatedPod { podKey: string }
 interface CreatedChannel { id: bigint; name: string; memberCount: number; agentCount: number }
@@ -104,7 +105,7 @@ test.describe("Channel × Pod membership (issue #400 regression)", () => {
       await selectInUI(page, ch.name);
       const rail = page.locator(RAIL);
       await expect(rail).toContainText("1");
-      await expect(rail.locator("ul li")).toHaveCount(1);
+      await expect(rail.locator(POD_ROW)).toHaveCount(1);
     } finally {
       await leavePod(cc, ch.id, pod.podKey);
       await terminatePod(cc, pod.podKey);
@@ -152,7 +153,7 @@ test.describe("Channel × Pod membership (issue #400 regression)", () => {
       expect(fresh.agentCount).toBe(1);
 
       await selectInUI(page, ch.name);
-      await expect(page.locator(`${RAIL} ul li`)).toHaveCount(1);
+      await expect(page.locator(`${RAIL} ${POD_ROW}`)).toHaveCount(1);
     } finally {
       await leavePod(cc, ch.id, p2.podKey);
       for (const k of [p1.podKey, p2.podKey]) await terminatePod(cc, k);
@@ -250,15 +251,15 @@ test.describe("Channel × Pod membership (issue #400 regression)", () => {
       await joinPod(cc, chB.id, podB.podKey);
 
       await selectInUI(page, chA.name);
-      await expect(page.locator(`${RAIL} ul li`)).toHaveCount(1);
+      await expect(page.locator(`${RAIL} ${POD_ROW}`)).toHaveCount(1);
 
       await selectInUI(page, chB.name);
-      await expect(page.locator(`${RAIL} ul li`)).toHaveCount(1);
+      await expect(page.locator(`${RAIL} ${POD_ROW}`)).toHaveCount(1);
 
       // Back to A — must show A's pod, not B's stale data
       await selectInUI(page, chA.name);
       const rail = page.locator(RAIL);
-      await expect(rail.locator("ul li")).toHaveCount(1);
+      await expect(rail.locator(POD_ROW)).toHaveCount(1);
       await expect(rail).not.toContainText(podB.podKey);
     } finally {
       for (const [chId, key] of [[chA.id, podA.podKey], [chB.id, podB.podKey]] as const) {

--- a/clients/web/src/components/channel/ChannelRailPodItem.tsx
+++ b/clients/web/src/components/channel/ChannelRailPodItem.tsx
@@ -1,0 +1,53 @@
+import { cn } from "@/lib/utils";
+import type { ChannelPodSummary } from "@/hooks/useChannelPods";
+
+interface ChannelRailPodItemProps {
+  pod: ChannelPodSummary;
+  dimmed?: boolean;
+}
+
+export function ChannelRailPodItem({ pod, dimmed }: ChannelRailPodItemProps) {
+  const label = pod.alias ?? pod.pod_key;
+  return (
+    <li
+      data-testid="channel-rail-pod"
+      data-status={pod.status}
+      className={cn(
+        "flex items-center gap-2.5 rounded-md px-2 py-1.5 hover:bg-muted",
+        dimmed && "opacity-60",
+      )}
+    >
+      <PodAvatar letter={label[0]?.toUpperCase() ?? "?"} status={pod.status} />
+      <span className="flex min-w-0 flex-1 flex-col">
+        <span
+          className={cn(
+            "truncate font-mono text-[12px]",
+            dimmed ? "text-muted-foreground line-through" : "text-foreground",
+          )}
+        >
+          {label}
+        </span>
+      </span>
+      <StatusDot status={pod.status} />
+    </li>
+  );
+}
+
+function statusColorClass(status: string): string {
+  if (status === "running") return "bg-emerald-500";
+  if (status === "initializing") return "bg-amber-500";
+  if (status === "error" || status === "failed") return "bg-red-500";
+  return "bg-muted-foreground/50";
+}
+
+function PodAvatar({ letter, status }: { letter: string; status: string }) {
+  return (
+    <span className={cn("flex h-7 w-7 items-center justify-center rounded-md font-mono text-xs font-semibold text-white", statusColorClass(status))}>
+      {letter}
+    </span>
+  );
+}
+
+function StatusDot({ status }: { status: string }) {
+  return <span className={cn("h-1.5 w-1.5 rounded-full", statusColorClass(status))} />;
+}

--- a/clients/web/src/components/channel/ChannelRailPodList.tsx
+++ b/clients/web/src/components/channel/ChannelRailPodList.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { ChannelPodSummary } from "@/hooks/useChannelPods";
+import { isDestroyedPodStatus } from "./podLifecycle";
+import { ChannelRailPodItem } from "./ChannelRailPodItem";
+
+export function ChannelRailPodList({ pods }: { pods: ChannelPodSummary[] }) {
+  const t = useTranslations();
+  const alive = pods.filter((p) => !isDestroyedPodStatus(p.status));
+  const destroyed = pods.filter((p) => isDestroyedPodStatus(p.status));
+  const [userToggled, setUserToggled] = useState<boolean | null>(null);
+  const showDestroyed = userToggled ?? alive.length === 0;
+
+  return (
+    <div className="flex flex-col gap-1">
+      {alive.length > 0 && (
+        <ul className="flex flex-col gap-1">
+          {alive.map((pod) => (
+            <ChannelRailPodItem key={pod.pod_key} pod={pod} />
+          ))}
+        </ul>
+      )}
+      {destroyed.length > 0 && (
+        <div className="flex flex-col gap-1">
+          <button
+            type="button"
+            onClick={() => setUserToggled(!showDestroyed)}
+            aria-expanded={showDestroyed}
+            data-testid="channel-rail-destroyed-toggle"
+            className="flex items-center gap-1 rounded px-2 py-1 text-[11px] font-medium text-muted-foreground hover:bg-muted"
+          >
+            <ChevronRight
+              className={cn("h-3 w-3 transition-transform", showDestroyed && "rotate-90")}
+            />
+            <span>{`${t("channels.rightRail.destroyed")} · ${destroyed.length}`}</span>
+          </button>
+          {showDestroyed && (
+            <ul className="flex flex-col gap-1">
+              {destroyed.map((pod) => (
+                <ChannelRailPodItem key={pod.pod_key} pod={pod} dimmed />
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/clients/web/src/components/channel/ChannelRightRail.tsx
+++ b/clients/web/src/components/channel/ChannelRightRail.tsx
@@ -5,10 +5,10 @@ import { useTranslations } from "next-intl";
 import { useCurrentOrg, useAuthStore } from "@/stores/auth";
 import type { Channel } from "@/stores/channel";
 import { useChannelPods } from "@/hooks/useChannelPods";
-import { cn } from "@/lib/utils";
 import { FileText, FolderGit2, Settings, Ticket } from "lucide-react";
 import { ChannelPodManager } from "./ChannelPodManager";
 import { ChannelMemberManager } from "./ChannelMemberManager";
+import { ChannelRailPodList } from "./ChannelRailPodList";
 
 interface ChannelRightRailProps {
   channel: Channel | null;
@@ -47,25 +47,7 @@ export function ChannelRightRail({
         {pods.length === 0 ? (
           <EmptyRail>{t("channels.rightRail.agentsEmpty")}</EmptyRail>
         ) : (
-          <ul className="flex flex-col gap-1">
-            {pods.map((pod) => (
-              <li
-                key={pod.pod_key}
-                className="flex items-center gap-2.5 rounded-md px-2 py-1.5 hover:bg-muted"
-              >
-                <PodAvatar
-                  letter={(pod.alias ?? pod.pod_key)[0]?.toUpperCase() ?? "?"}
-                  status={pod.status}
-                />
-                <span className="flex min-w-0 flex-1 flex-col">
-                  <span className="truncate font-mono text-[12px] text-foreground">
-                    {pod.alias ?? pod.pod_key}
-                  </span>
-                </span>
-                <StatusDot status={pod.status} />
-              </li>
-            ))}
-          </ul>
+          <ChannelRailPodList pods={pods} />
         )}
       </section>
 
@@ -152,32 +134,6 @@ function EmptyRail({ children }: { children: React.ReactNode }) {
       {children}
     </div>
   );
-}
-
-function PodAvatar({ letter, status }: { letter: string; status: string }) {
-  const bg =
-    status === "running"
-      ? "bg-emerald-500"
-      : status === "initializing"
-        ? "bg-amber-500"
-        : status === "terminated"
-          ? "bg-muted-foreground/50"
-          : "bg-red-500";
-  return (
-    <span className={cn("flex h-7 w-7 items-center justify-center rounded-md font-mono text-xs font-semibold text-white", bg)}>
-      {letter}
-    </span>
-  );
-}
-
-function StatusDot({ status }: { status: string }) {
-  const color =
-    status === "running"
-      ? "bg-emerald-500"
-      : status === "initializing"
-        ? "bg-amber-500"
-        : "bg-muted-foreground/50";
-  return <span className={cn("h-1.5 w-1.5 rounded-full", color)} />;
 }
 
 export default ChannelRightRail;

--- a/clients/web/src/components/channel/__tests__/ChannelRailPodItem.test.tsx
+++ b/clients/web/src/components/channel/__tests__/ChannelRailPodItem.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ChannelRailPodItem } from "../ChannelRailPodItem";
+import type { ChannelPodSummary } from "@/hooks/useChannelPods";
+
+const ALL_COLORS = ["bg-emerald-500", "bg-amber-500", "bg-red-500", "bg-muted-foreground/50"];
+
+function renderRow(pod: ChannelPodSummary, dimmed?: boolean) {
+  render(
+    <ul>
+      <ChannelRailPodItem pod={pod} dimmed={dimmed} />
+    </ul>,
+  );
+  return screen.getByTestId("channel-rail-pod");
+}
+
+describe("ChannelRailPodItem status colors", () => {
+  const cases: Array<[string, string]> = [
+    ["running", "bg-emerald-500"],
+    ["initializing", "bg-amber-500"],
+    ["paused", "bg-muted-foreground/50"],
+    ["disconnected", "bg-muted-foreground/50"],
+    ["orphaned", "bg-muted-foreground/50"],
+    ["completed", "bg-muted-foreground/50"],
+    ["terminated", "bg-muted-foreground/50"],
+    ["error", "bg-red-500"],
+    ["failed", "bg-red-500"],
+  ];
+
+  it.each(cases)("colors status '%s' as %s on both avatar and dot", (status, expected) => {
+    const row = renderRow({ pod_key: "pk", alias: "Pod", status });
+    const avatar = row.querySelector(".rounded-md");
+    const dot = row.querySelector(".rounded-full");
+
+    for (const el of [avatar, dot]) {
+      expect(el).not.toBeNull();
+      expect(el!.className).toContain(expected);
+      for (const other of ALL_COLORS) {
+        if (other !== expected) expect(el!.className).not.toContain(other);
+      }
+    }
+  });
+});
+
+describe("ChannelRailPodItem rendering", () => {
+  it("dims the row and strikes the label only when dimmed", () => {
+    const row = renderRow({ pod_key: "pk", alias: "Pod", status: "terminated" }, true);
+    expect(row.className).toContain("opacity-60");
+    expect(screen.getByText("Pod").className).toContain("line-through");
+  });
+
+  it("falls back to pod_key for the label and avatar letter when alias is missing", () => {
+    renderRow({ pod_key: "zeta-pod", status: "running" });
+    expect(screen.getByText("zeta-pod")).toBeDefined();
+    expect(screen.getByText("Z")).toBeDefined();
+  });
+});

--- a/clients/web/src/components/channel/__tests__/ChannelRailPodList.test.tsx
+++ b/clients/web/src/components/channel/__tests__/ChannelRailPodList.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ChannelRailPodList } from "../ChannelRailPodList";
+import type { ChannelPodSummary } from "@/hooks/useChannelPods";
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) =>
+    key === "channels.rightRail.destroyed" ? "Destroyed" : key,
+}));
+
+const pods: ChannelPodSummary[] = [
+  { pod_key: "pk-run", alias: "Runner", status: "running" },
+  { pod_key: "pk-pause", alias: "Paused", status: "paused" },
+  { pod_key: "pk-term", alias: "Terminated", status: "terminated" },
+  { pod_key: "pk-fail", alias: "Failed", status: "failed" },
+];
+
+describe("ChannelRailPodList", () => {
+  it("renders live pods (running, paused) and hides destroyed pods by default", () => {
+    render(<ChannelRailPodList pods={pods} />);
+
+    expect(screen.getByText("Runner")).toBeDefined();
+    expect(screen.getByText("Paused")).toBeDefined();
+    expect(screen.queryByText("Terminated")).toBeNull();
+    expect(screen.queryByText("Failed")).toBeNull();
+  });
+
+  it("shows the destroyed toggle with the terminal-state count", () => {
+    render(<ChannelRailPodList pods={pods} />);
+
+    const toggle = screen.getByTestId("channel-rail-destroyed-toggle");
+    expect(toggle.textContent).toContain("Destroyed · 2");
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("reveals dimmed destroyed pods when the toggle is clicked", () => {
+    render(<ChannelRailPodList pods={pods} />);
+
+    fireEvent.click(screen.getByTestId("channel-rail-destroyed-toggle"));
+
+    const terminated = screen.getByText("Terminated").closest("li");
+    expect(terminated).not.toBeNull();
+    expect(terminated?.className).toContain("opacity-60");
+    expect(screen.getByText("Terminated").className).toContain("line-through");
+    expect(screen.getByTestId("channel-rail-destroyed-toggle").getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("omits the destroyed section entirely when no pods are destroyed", () => {
+    render(
+      <ChannelRailPodList
+        pods={[{ pod_key: "pk-run", alias: "Runner", status: "running" }]}
+      />,
+    );
+
+    expect(screen.queryByTestId("channel-rail-destroyed-toggle")).toBeNull();
+  });
+
+  it("renders no list and no toggle when given an empty pods array", () => {
+    const { container } = render(<ChannelRailPodList pods={[]} />);
+
+    expect(container.querySelector("ul")).toBeNull();
+    expect(screen.queryByTestId("channel-rail-destroyed-toggle")).toBeNull();
+    expect(screen.queryByTestId("channel-rail-pod")).toBeNull();
+  });
+
+  it("does not dim live pods", () => {
+    render(
+      <ChannelRailPodList
+        pods={[{ pod_key: "pk-run", alias: "Runner", status: "running" }]}
+      />,
+    );
+
+    expect(screen.getByText("Runner").closest("li")?.className).not.toContain("opacity-60");
+    expect(screen.getByText("Runner").className).not.toContain("line-through");
+  });
+
+  it("auto-expands the destroyed section when there are no live pods, then collapses on toggle", () => {
+    render(
+      <ChannelRailPodList
+        pods={[
+          { pod_key: "pk-done", alias: "Done", status: "completed" },
+          { pod_key: "pk-dead", alias: "Dead", status: "terminated" },
+        ]}
+      />,
+    );
+
+    const toggle = screen.getByTestId("channel-rail-destroyed-toggle");
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText("Done")).toBeDefined();
+    expect(screen.getByText("Dead")).toBeDefined();
+
+    fireEvent.click(toggle);
+
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByText("Done")).toBeNull();
+    expect(screen.queryByText("Dead")).toBeNull();
+  });
+});

--- a/clients/web/src/components/channel/podLifecycle.ts
+++ b/clients/web/src/components/channel/podLifecycle.ts
@@ -1,0 +1,5 @@
+const DESTROYED_POD_STATUSES = new Set(["terminated", "completed", "failed", "error"]);
+
+export function isDestroyedPodStatus(status: string): boolean {
+  return DESTROYED_POD_STATUSES.has(status);
+}

--- a/clients/web/src/messages/en/channels.json
+++ b/clients/web/src/messages/en/channels.json
@@ -54,7 +54,8 @@
       "document": "DOCUMENT",
       "podsEmpty": "No pods yet",
       "agentsEmpty": "No agents yet",
-      "documentEmpty": "No document yet"
+      "documentEmpty": "No document yet",
+      "destroyed": "Destroyed"
     },
     "composer": {
       "placeholder": "Message #{channel} — use @ to mention a pod or member",

--- a/clients/web/src/messages/zh/channels.json
+++ b/clients/web/src/messages/zh/channels.json
@@ -54,7 +54,8 @@
       "document": "DOCUMENT",
       "podsEmpty": "暂无 Pod",
       "agentsEmpty": "暂无 Agent",
-      "documentEmpty": "暂无文档"
+      "documentEmpty": "暂无文档",
+      "destroyed": "已销毁"
     },
     "composer": {
       "placeholder": "发送消息到 #{channel} — 使用 @ 提及 Pod 或成员",


### PR DESCRIPTION
## TICKET-152

在 Channel 对话右侧抽屉的 Pods 列表中，对已销毁的 Pod 折叠展示，并与存活 Pod 做样式区分。

## What

- **Collapse**: destroyed pods (`terminated`/`completed`/`failed`/`error`) render under a collapsible **"Destroyed · N"** toggle in the right-rail Agents section. Collapsed by default; **auto-expands when there are no live pods** so the section never looks empty. Explicit user toggle always wins.
- **Distinguish**: destroyed rows are dimmed (`opacity-60`) with a struck-through label; live pods render normally on top.
- **Color fix**: avatar/dot status colors unified into one `statusColorClass` — error-red is now reserved for `error`/`failed` only (previously any non-active state, incl. `paused`/`completed`, showed red).

## Structure

- `ChannelRailPodItem` — pod row + status-color mapping (extracted from `ChannelRightRail`)
- `ChannelRailPodList` — alive/destroyed split + collapse toggle
- `podLifecycle.isDestroyedPodStatus` — terminal-state classifier
- e2e pod-count assertions pinned to `[data-testid="channel-rail-pod"]` (robust to the new two-`<ul>` structure)
- `destroyed` i18n key (en/zh)

## Tests

- `ChannelRailPodList.test.tsx` (7) — collapse-by-default, auto-expand+collapse, dimming, empty array
- `ChannelRailPodItem.test.tsx` (11) — status→color table across all 9 statuses (avatar + dot, full color exclusivity), alias→pod_key fallback, dimmed styling

Verified locally: `bazel test //clients/web:unit` + `:lint` + `bazel build //clients/web:src` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)