### PR TITLE
fix(desktop): heal Connect RPC routing 404s + fail-closed routing guard

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -287,6 +287,14 @@ jobs:
       # Lint, type-check + Vitest all run via Bazel.
       - name: Lint + Type-check + Vitest (Bazel)
         run: bazel test //clients/web:lint //clients/web:unit && bazel build //clients/web:src //clients/web-admin:src
+      # Desktop renderer reuses clients/web but routes Connect RPCs through the
+      # electron-adapter proxy. Enforce its type-check + unit tests, and the
+      # fail-closed routing guard that catches a desktop-only 404 (a wasm verb
+      # diverging from its proto name with no override map) at CI instead of prod.
+      - name: Desktop adapter (type-check + unit + connect-routing guard)
+        run: |
+          bazel test //packages/electron-adapter:unit //packages/electron-adapter:electron_adapter_typecheck_test
+          python3 packages/electron-adapter/scripts/check-connect-routing.py
 
   web-admin:
     name: Web-Admin (lint + vitest)

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@
 *.swo
 *~
 
+# Python bytecode (packages/electron-adapter/scripts guard + generators)
+__pycache__/
+*.pyc
+
 # IDE
 .idea/
 .vscode/

--- a/clients/desktop/e2e/helpers/ipc-contract.ts
+++ b/clients/desktop/e2e/helpers/ipc-contract.ts
@@ -30,6 +30,8 @@ const WIRE_FAULT_PATTERNS = [
   /No such IPC handler/i,
   /No handler registered/i,
   /Handler did not respond/i,
+  // ServeMux 404 for an unregistered route — distinct from a connect not_found.
+  /\bpage not found\b/i,
 ];
 
 function isWireFault(msg: string): boolean {

--- a/clients/desktop/e2e/tests/ipc/connect-routing.spec.ts
+++ b/clients/desktop/e2e/tests/ipc/connect-routing.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "../../fixtures/electron-shared.fixture";
+
+// Proxy-routed Connect services have no napi channel, so they're absent from the
+// _generated/*.api.spec.ts contract — a wrong withConnectFallback derivation 404'd
+// on desktop undetected (#434). Unregistered route → ServeMux "page not found";
+// a reached handler → 200 or a connect-framed typed error.
+test.describe.configure({ mode: "serial" });
+
+// Routes mirror the override maps in packages/electron-adapter/src/connect-fallback.ts.
+const ROUTES = [
+  { label: "autopilot — reported 404", service: "proto.autopilot.v1.AutopilotControllerService", method: "ListAutopilotControllers" },
+  { label: "billing — Subscription-suffix verb", service: "proto.billing.v1.BillingService", method: "ReactivateSubscription" },
+  { label: "billing — public sibling service", service: "proto.billing.v1.BillingPublicService", method: "GetPublicPricing" },
+  { label: "grant — newly wired facade", service: "proto.grant.v1.GrantService", method: "ListGrants" },
+  { label: "pod — default 1:1 derivation", service: "proto.pod.v1.PodService", method: "ListPods" },
+] as const;
+
+test.describe("IPC · connect routing reaches the backend", () => {
+  for (const { label, service, method } of ROUTES) {
+    test(`${label}: ${service.split(".").pop()}/${method}`, async ({ sharedPage }) => {
+      const err = await sharedPage.evaluate(async ({ s, m }) => {
+        const api = (window as unknown as { electronAPI: { invoke: (c: string, ...a: unknown[]) => Promise<unknown> } }).electronAPI;
+        try { await api.invoke("connectCall", s, m, []); return null; }
+        catch (e) { return e instanceof Error ? e.message : String(e); }
+      }, { s: service, m: method });
+
+      if (err !== null) {
+        expect(err, `${service}/${method} is unregistered — desktop-only 404`).not.toMatch(/page not found/i);
+      }
+    });
+  }
+});

--- a/packages/electron-adapter/BUILD.bazel
+++ b/packages/electron-adapter/BUILD.bazel
@@ -1,5 +1,6 @@
 load("//build_defs/web:internal_package.bzl", "internal_npm_package")
 load("//build_defs/web:ts.bzl", "ts_project")
+load("//build_defs/web:vitest.bzl", "vitest_test")
 
 # Electron adapter — thin glue that lets the desktop renderer talk to
 # the N-API addon via typed IPC. Consumed by clients/desktop.
@@ -40,4 +41,21 @@ internal_npm_package(
         "@bufbuild/protobuf": "*",
     },
     main = "src/index.ts",
+)
+
+vitest_test(
+    name = "unit",
+    size = "small",
+    srcs = glob(
+        ["src/**/*.test.ts"],
+        allow_empty = True,
+    ),
+    config = "vitest.config.ts",
+    data = [
+        "tsconfig.json",
+        "//:node_modules",
+    ] + glob(
+        ["src/**/*.ts"],
+        exclude = ["src/**/*.test.ts"],
+    ),
 )

--- a/packages/electron-adapter/scripts/check-connect-routing.py
+++ b/packages/electron-adapter/scripts/check-connect-routing.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Static guard: every desktop renderer Connect call must derive a real proto path.
+
+Why this exists: the desktop renderer has no wasm, so `getXxxService().<verb>Connect`
+calls fall through `withConnectFallback` (packages/electron-adapter/src/connect-fallback.ts),
+which derives a backend `(service, method)` by string-munging the verb plus a few
+hand-maintained override maps. When a wasm verb diverges from its proto RPC name
+(suffix/prefix/sibling-service) and nobody updates the map, the derived path is a
+VALID-looking name that the backend never registered → silent desktop-only 404
+(web is unaffected; it routes through the wasm api-client). #429-era billing was
+exactly this: 6 verbs 404'd because the facade had no override map.
+
+This catches that class even when a unit test for the specific verb is missing:
+it greps the live renderer call sites, replays the EXACT derivation against the
+real wiring, and asserts each result against the authoritative proto paths the
+Rust api-client encodes — failing closed instead of shipping a 404.
+
+Run:  python3 packages/electron-adapter/scripts/check-connect-routing.py
+Exits non-zero (and lists the offenders) on any unrouteable or unknown call.
+"""
+from __future__ import annotations  # PEP 604 `X | None` annotations on Python <3.10
+
+import os
+import re
+import subprocess
+import sys
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, "..", "..", ".."))
+ADAPTER = "packages/electron-adapter/src"
+
+
+def sh(cmd: str) -> str:
+    r = subprocess.run(cmd, shell=True, cwd=REPO_ROOT, capture_output=True, text=True)
+    # grep exits 1 on "no matches" (legitimate) but >1 on real errors (bad path /
+    # bad regex). Fail loud on the latter — a swallowed error would silently empty
+    # the result set and turn this guard into a green no-op.
+    if r.returncode > 1:
+        sys.exit(f"check-connect-routing: command errored ({r.returncode}): {cmd}\n{r.stderr.strip()}")
+    return r.stdout
+
+
+def authoritative_paths() -> set[str]:
+    """The proto paths the Rust api-client actually targets — the backend SSOT."""
+    out = sh(
+        "grep -rhoE '\"/proto\\.[a-z_]+\\.v[0-9]+\\.[A-Za-z]+/[A-Za-z0-9]+\"' "
+        "clients/core/crates/api-client/src/modules/*.rs"
+    )
+    return {line.strip().strip('"').lower() for line in out.splitlines()}
+
+
+def override_maps() -> dict[str, dict[str, str]]:
+    src = open(os.path.join(REPO_ROOT, ADAPTER, "connect-fallback.ts")).read()
+    maps: dict[str, dict[str, str]] = {}
+    for m in re.finditer(r"export const (\w+):[^=]*=\s*\{(.*?)\};", src, re.S):
+        maps[m.group(1)] = {
+            kv.group(1): kv.group(2)
+            for kv in re.finditer(r'(\w+):\s*"([^"]+)"', m.group(2))
+        }
+    return maps
+
+
+def getter_to_key() -> dict[str, str]:
+    src = open(os.path.join(REPO_ROOT, "packages/service-runtime/src/service-getters.ts")).read()
+    return {
+        m.group(1): m.group(2)
+        for m in re.finditer(r'export const (get\w+) = \(\)[^=]*=>\s*g\("(\w+)"\)', src)
+    }
+
+
+def provider_wiring() -> tuple[dict, dict]:
+    src = open(os.path.join(REPO_ROOT, ADAPTER, "provider.ts")).read()
+    cls2file = {
+        m.group(1): m.group(2)[2:]
+        for m in re.finditer(r"import\s*\{\s*(Electron\w+)\s*\}\s*from\s*'(\./[\w_]+)'", src)
+    }
+    var2cls = {m.group(1): m.group(2) for m in re.finditer(r"const (\w+) = new (Electron\w+)\(\)", src)}
+    wiring: dict[str, dict] = {}
+    for m in re.finditer(
+        r"(\w+):\s*withConnectFallback\(\s*(new (Electron\w+)\(\)|\w+)\s*,\s*\"([^\"]+)\""
+        r"\s*(?:,\s*(\w+|undefined))?\s*(?:,\s*(\w+))?\s*,?\s*\)",
+        src, re.S,
+    ):
+        key, arg1, cls_inline, proto, sov, nov = m.groups()
+        wiring[key] = dict(
+            proto=proto,
+            sov=None if sov in (None, "undefined") else sov,
+            nov=nov,
+            cls=cls_inline or var2cls.get(arg1),
+        )
+    return wiring, cls2file
+
+
+def facade_methods(cls: str | None, cls2file: dict[str, str]) -> set[str]:
+    """Methods a facade implements directly — these bypass the proxy entirely."""
+    f = cls2file.get(cls or "")
+    if not f:
+        return set()
+    p = os.path.join(REPO_ROOT, ADAPTER, f"{f}.ts")
+    if not os.path.exists(p):
+        return set()
+    # Heuristic, not a parser: capture indented `(?:async) name(` declarations.
+    # Anchoring to line-start excludes keyword-prefixed call sites (`return foo(`,
+    # `await bar(`, `if (`) — enough for these facades, whose class bodies hold only
+    # declarations. A bare indented `verbConnect(x)` statement would still be captured;
+    # acceptable because no facade contains one, and a wrong bypass only risks a missed
+    # proxy-route check that the in-language connect-fallback.test.ts also guards.
+    return set(re.findall(r"^[ \t]+(?:async[ \t]+)?([a-zA-Z_]\w*)[ \t]*\(", open(p).read(), re.M))
+
+
+def renderer_calls() -> list[str]:
+    out = sh(
+        "grep -rhoE 'get[A-Za-z]+Service\\(\\)\\.[a-zA-Z_]+(Connect|_connect)' "
+        "clients/web/src clients/desktop/src"
+    )
+    return sorted(set(out.split()))
+
+
+def pascal(s: str) -> str:
+    return s[:1].upper() + s[1:]
+
+
+def main() -> int:
+    auth = authoritative_paths()
+    maps = override_maps()
+    g2k = getter_to_key()
+    wiring, cls2file = provider_wiring()
+    calls = renderer_calls()
+
+    # Fail closed: empty inputs mean the source tree moved or the script ran from
+    # the wrong place — NOT "all clean". A guard that checks nothing must never
+    # report OK. (renderer_calls() only sees single-line `getX().vConnect` calls;
+    # verbs reached via a stored variable or multi-line chain are a known blind
+    # spot — see the grep in renderer_calls().)
+    if not auth:
+        sys.exit("check-connect-routing: 0 authoritative proto paths found — api-client moved or wrong cwd?")
+    if not calls:
+        sys.exit("check-connect-routing: 0 renderer Connect calls found — source paths moved or wrong cwd?")
+
+    bugs: list[str] = []
+    unknown: list[str] = []
+    bypassed = 0
+    seen: set[tuple[str, str]] = set()
+
+    for call in calls:
+        mm = re.match(r"(get[A-Za-z]+Service)\(\)\.([a-zA-Z_]+?)(Connect|_connect)$", call)
+        if not mm:
+            continue
+        getter, stem, suf = mm.groups()
+        prop = stem + suf
+        if (getter, prop) in seen:
+            continue
+        seen.add((getter, prop))
+
+        key = g2k.get(getter)
+        if not key:
+            unknown.append(f"{call}  [getter not in service-getters.ts]")
+            continue
+        if key not in wiring:
+            unknown.append(f"{call}  [key '{key}' not wired via withConnectFallback]")
+            continue
+        w = wiring[key]
+        if prop in facade_methods(w["cls"], cls2file):
+            bypassed += 1
+            continue
+
+        if suf == "Connect":
+            camel = stem
+        else:
+            camel = re.sub(r"_([a-z0-9])", lambda x: x.group(1).upper(), stem)
+        method = maps.get(w["nov"], {}).get(camel, pascal(camel))
+        service = maps.get(w["sov"], {}).get(camel, w["proto"])
+        if f"/{service}/{method}".lower() not in auth:
+            bugs.append(f"{getter}().{prop}  ->  {service}/{method}   [NOT A REGISTERED PROTO PATH]")
+
+    print(
+        f"checked {len(seen)} renderer Connect calls "
+        f"({bypassed} handled directly by a facade, {len(seen) - bypassed} via proxy); "
+        f"{len(auth)} authoritative proto paths."
+    )
+    if bugs:
+        print(f"\nFAIL: {len(bugs)} call(s) derive a path the backend never registered (desktop-only 404):")
+        for b in bugs:
+            print("  ✗", b)
+    if unknown:
+        print(f"\nFAIL: {len(unknown)} call(s) hit an unrecognized facade:")
+        for u in unknown:
+            print("  ?", u)
+    if bugs or unknown:
+        print("\nFix: add the missing route to the override maps in "
+              f"{ADAPTER}/connect-fallback.ts (service via methodOverrides, name via methodNameOverrides).")
+        return 1
+    print("OK: every desktop Connect call routes to a registered proto path.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/electron-adapter/src/auth_connect.ts
+++ b/packages/electron-adapter/src/auth_connect.ts
@@ -1,4 +1,5 @@
 import { invoke } from "./invoke";
+import { coerceConnectResponse } from "./connect-response";
 import type { IAuthConnectService } from "@agentsmesh/service-interface";
 
 export class ElectronAuthConnectService implements IAuthConnectService {
@@ -6,69 +7,69 @@ export class ElectronAuthConnectService implements IAuthConnectService {
     const bytes = await invoke<number[] | Uint8Array>(
       "authConnectLoginConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async registerConnect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "authConnectRegisterConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async refreshTokenConnect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "authConnectRefreshTokenConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async verifyEmailConnect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "authConnectVerifyEmailConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async resendVerificationConnect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "authConnectResendVerificationConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async forgotPasswordConnect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "authConnectForgotPasswordConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async resetPasswordConnect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "authConnectResetPasswordConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async oauthRedirectConnect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "authConnectOauthRedirectConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async oauthCallbackConnect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "authConnectOauthCallbackConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async logoutConnect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "authConnectLogoutConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 }

--- a/packages/electron-adapter/src/connect-fallback.test.ts
+++ b/packages/electron-adapter/src/connect-fallback.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  withConnectFallback,
+  AUTOPILOT_METHOD_NAMES,
+  AGENT_USER_CONFIG_OVERRIDES,
+  EXTENSION_SERVICE_OVERRIDES,
+  EXTENSION_NAME_OVERRIDES,
+  USER_CREDENTIAL_METHOD_OVERRIDES,
+  USER_CREDENTIAL_NAME_OVERRIDES,
+  BILLING_SERVICE_OVERRIDES,
+  BILLING_NAME_OVERRIDES,
+} from "./connect-fallback";
+
+// Regression guard for the derived backend Connect path. The renderer reaches
+// an RPC as `getXxxService().<verb>Connect(bytes)`; withConnectFallback derives
+// (service, method). Most derive 1:1, but several need overrides — autopilot
+// (proto "Controller(s)" suffix the wasm verb drops), agent / extension /
+// userCredential (TS facade spanning multiple proto services), billing
+// (BillingPublicService split + "Subscription" suffix the wasm verb drops).
+//
+// Only facades that actually reach the proxy in production are asserted here.
+// invitation / promocode are deliberately absent: ElectronInvitationConnectService
+// and ElectronPromoCodeService implement every `*Connect` method directly (their
+// own dedicated IPC channels), so `Reflect.get` returns the real method and the
+// proxy is never consulted — asserting an override path for them would test a
+// derivation that never runs in production.
+describe("connect fallback routing", () => {
+  let calls: Array<{ service: string; method: string }>;
+
+  beforeEach(() => {
+    calls = [];
+    (globalThis as { window?: unknown }).window = {
+      electronAPI: {
+        invoke: async (channel: string, ...args: unknown[]) => {
+          if (channel === "connectCall") {
+            calls.push({ service: args[0] as string, method: args[1] as string });
+          }
+          return [];
+        },
+      },
+    };
+  });
+
+  const autopilot = () =>
+    withConnectFallback({}, "proto.autopilot.v1.AutopilotControllerService", undefined, AUTOPILOT_METHOD_NAMES);
+  const agent = () =>
+    withConnectFallback({}, "proto.agent.v1.AgentService", AGENT_USER_CONFIG_OVERRIDES);
+  const extension = () =>
+    withConnectFallback({}, "proto.extension.v1.SkillRegistryService", EXTENSION_SERVICE_OVERRIDES, EXTENSION_NAME_OVERRIDES);
+  const userCredential = () =>
+    withConnectFallback({}, "proto.user_credential.v1.UserRepositoryProviderService", USER_CREDENTIAL_METHOD_OVERRIDES, USER_CREDENTIAL_NAME_OVERRIDES);
+  const billing = () =>
+    withConnectFallback({}, "proto.billing.v1.BillingService", BILLING_SERVICE_OVERRIDES, BILLING_NAME_OVERRIDES);
+
+  const cases: Array<[() => object, string, string, string]> = [
+    // autopilot — name override (keeps/restores "Controller(s)")
+    [autopilot, "listAutopilotsConnect", "proto.autopilot.v1.AutopilotControllerService", "ListAutopilotControllers"],
+    [autopilot, "getAutopilotConnect", "proto.autopilot.v1.AutopilotControllerService", "GetAutopilotController"],
+    [autopilot, "pauseAutopilotConnect", "proto.autopilot.v1.AutopilotControllerService", "PauseAutopilotController"],
+    [autopilot, "getIterationsConnect", "proto.autopilot.v1.AutopilotControllerService", "GetIterations"],
+    // agent — sibling UserAgentConfigService; catalog stays on AgentService
+    [agent, "getUserAgentConfigConnect", "proto.agent.v1.UserAgentConfigService", "GetUserAgentConfig"],
+    [agent, "setUserAgentConfigConnect", "proto.agent.v1.UserAgentConfigService", "SetUserAgentConfig"],
+    [agent, "listAgentsConnect", "proto.agent.v1.AgentService", "ListAgents"],
+    // extension — four sub-services + GitHub casing
+    [extension, "createSkillRegistryConnect", "proto.extension.v1.SkillRegistryService", "CreateSkillRegistry"],
+    [extension, "listMarketSkillsConnect", "proto.extension.v1.MarketService", "ListMarketSkills"],
+    [extension, "installMcpFromMarketConnect", "proto.extension.v1.RepoMcpService", "InstallMcpFromMarket"],
+    [extension, "listRepoSkillsConnect", "proto.extension.v1.RepoSkillService", "ListRepoSkills"],
+    [extension, "installSkillFromGithubConnect", "proto.extension.v1.RepoSkillService", "InstallSkillFromGitHub"],
+    // user_credential — three sibling services; git verb matches, agent verb
+    // ALSO drops "Profile" (service + name), repository-provider is the default
+    [userCredential, "listGitCredentialsConnect", "proto.user_credential.v1.UserGitCredentialService", "ListGitCredentials"],
+    [userCredential, "createAgentCredentialConnect", "proto.user_credential.v1.UserAgentCredentialService", "CreateAgentCredentialProfile"],
+    [userCredential, "listAgentCredentialsForAgentConnect", "proto.user_credential.v1.UserAgentCredentialService", "ListAgentCredentialProfilesForAgent"],
+    [userCredential, "createRepositoryProviderConnect", "proto.user_credential.v1.UserRepositoryProviderService", "CreateRepositoryProvider"],
+    // billing — public RPCs live on the sibling BillingPublicService; four
+    // subscription verbs drop the proto's "Subscription"/"BillingCycle" suffix
+    [billing, "reactivate_connect", "proto.billing.v1.BillingService", "ReactivateSubscription"],
+    [billing, "request_cancel_connect", "proto.billing.v1.BillingService", "RequestCancelSubscription"],
+    [billing, "upgrade_connect", "proto.billing.v1.BillingService", "UpgradeSubscription"],
+    [billing, "change_cycle_connect", "proto.billing.v1.BillingService", "ChangeBillingCycle"],
+    [billing, "get_public_pricing_connect", "proto.billing.v1.BillingPublicService", "GetPublicPricing"],
+    [billing, "get_public_deployment_info_connect", "proto.billing.v1.BillingPublicService", "GetPublicDeploymentInfo"],
+  ];
+
+  for (const [facade, verb, service, method] of cases) {
+    it(`${verb} → ${service.split(".").pop()}/${method}`, async () => {
+      await (facade() as Record<string, (b: Uint8Array) => Promise<unknown>>)[verb](new Uint8Array());
+      expect(calls).toEqual([{ service, method }]);
+    });
+  }
+
+  it("default service derives 1:1 for both camel + snake surfaces", async () => {
+    const pod = withConnectFallback({}, "proto.pod.v1.PodService") as Record<string, (b: Uint8Array) => Promise<unknown>>;
+    await pod.listPodsConnect(new Uint8Array());
+    await pod.list_pods_connect(new Uint8Array());
+    expect(calls).toEqual([
+      { service: "proto.pod.v1.PodService", method: "ListPods" },
+      { service: "proto.pod.v1.PodService", method: "ListPods" },
+    ]);
+  });
+
+  it("resolves the coerced Uint8Array from the IPC response", async () => {
+    (globalThis as { window?: unknown }).window = {
+      electronAPI: { invoke: async () => [1, 2, 3] },
+    };
+    const pod = withConnectFallback({}, "proto.pod.v1.PodService") as Record<string, (b: Uint8Array) => Promise<Uint8Array>>;
+    const out = await pod.listPodsConnect(new Uint8Array());
+    expect(out).toBeInstanceOf(Uint8Array);
+    expect(Array.from(out)).toEqual([1, 2, 3]);
+  });
+
+  it("fails closed at access time on a malformed derivation", () => {
+    const svc = withConnectFallback({}, "proto.pod.v1.PodService") as Record<string, unknown>;
+    expect(() => svc.Connect).toThrow(/cannot derive/);
+    expect(calls).toEqual([]);
+  });
+
+  it("fails closed when the IPC response is not binary", async () => {
+    (globalThis as { window?: unknown }).window = {
+      electronAPI: { invoke: async () => ({ unexpected: true }) },
+    };
+    const svc = withConnectFallback({}, "proto.pod.v1.PodService") as Record<string, (b: Uint8Array) => Promise<unknown>>;
+    await expect(svc.listPodsConnect(new Uint8Array())).rejects.toThrow(/not binary/);
+  });
+});

--- a/packages/electron-adapter/src/connect-fallback.ts
+++ b/packages/electron-adapter/src/connect-fallback.ts
@@ -1,0 +1,154 @@
+import { invoke } from "./invoke";
+import { coerceConnectResponse } from "./connect-response";
+
+// Connect-RPC routing config + fallback proxy for the desktop renderer.
+// Kept separate from provider.ts (which imports every ElectronXxxService,
+// each pulling @agentsmesh/proto subpaths) so this — the routing brain — is
+// importable in isolation for unit tests.
+
+// user_credential proto bundles three backend services (git credential, agent
+// credential, repository provider) under a single wasm-side facade. The default
+// protoPath is UserRepositoryProviderService; route the other two here.
+export const USER_CREDENTIAL_METHOD_OVERRIDES: Record<string, string> = {
+  // git credential — renderer verb matches the proto RPC; only the service differs
+  listGitCredentials: "proto.user_credential.v1.UserGitCredentialService",
+  getGitCredential: "proto.user_credential.v1.UserGitCredentialService",
+  createGitCredential: "proto.user_credential.v1.UserGitCredentialService",
+  updateGitCredential: "proto.user_credential.v1.UserGitCredentialService",
+  deleteGitCredential: "proto.user_credential.v1.UserGitCredentialService",
+  getDefaultGitCredential: "proto.user_credential.v1.UserGitCredentialService",
+  setDefaultGitCredential: "proto.user_credential.v1.UserGitCredentialService",
+  clearDefaultGitCredential: "proto.user_credential.v1.UserGitCredentialService",
+  // agent credential — renderer verb drops the proto's "Profile" suffix, so it
+  // needs BOTH a service route (here) and a name remap (USER_CREDENTIAL_NAME_*).
+  listAgentCredentials: "proto.user_credential.v1.UserAgentCredentialService",
+  listAgentCredentialsForAgent: "proto.user_credential.v1.UserAgentCredentialService",
+  getAgentCredential: "proto.user_credential.v1.UserAgentCredentialService",
+  createAgentCredential: "proto.user_credential.v1.UserAgentCredentialService",
+  updateAgentCredential: "proto.user_credential.v1.UserAgentCredentialService",
+  deleteAgentCredential: "proto.user_credential.v1.UserAgentCredentialService",
+  setDefaultAgentCredential: "proto.user_credential.v1.UserAgentCredentialService",
+};
+// agent-credential verbs drop the proto's "Profile" suffix.
+export const USER_CREDENTIAL_NAME_OVERRIDES: Record<string, string> = {
+  listAgentCredentials: "ListAgentCredentialProfiles",
+  listAgentCredentialsForAgent: "ListAgentCredentialProfilesForAgent",
+  getAgentCredential: "GetAgentCredentialProfile",
+  createAgentCredential: "CreateAgentCredentialProfile",
+  updateAgentCredential: "UpdateAgentCredentialProfile",
+  deleteAgentCredential: "DeleteAgentCredentialProfile",
+  setDefaultAgentCredential: "SetDefaultAgentCredentialProfile",
+};
+
+// billing splits into BillingService (default) and BillingPublicService
+// (pre-auth pricing / deployment info). Four subscription verbs also drop the
+// proto's "Subscription" / "BillingCycle" suffix on the wasm side.
+export const BILLING_SERVICE_OVERRIDES: Record<string, string> = {
+  getPublicPricing: "proto.billing.v1.BillingPublicService",
+  getPublicDeploymentInfo: "proto.billing.v1.BillingPublicService",
+};
+export const BILLING_NAME_OVERRIDES: Record<string, string> = {
+  reactivate: "ReactivateSubscription",
+  requestCancel: "RequestCancelSubscription",
+  upgrade: "UpgradeSubscription",
+  changeCycle: "ChangeBillingCycle",
+};
+
+// autopilot's proto methods carry a "Controller(s)" suffix the wasm verbs drop
+// (listAutopilotsConnect → must POST ListAutopilotControllers). Remap each.
+// (getIterations already matches its proto name, so it's intentionally absent.)
+export const AUTOPILOT_METHOD_NAMES: Record<string, string> = {
+  listAutopilots: "ListAutopilotControllers",
+  getAutopilot: "GetAutopilotController",
+  createAutopilot: "CreateAutopilotController",
+  pauseAutopilot: "PauseAutopilotController",
+  resumeAutopilot: "ResumeAutopilotController",
+  stopAutopilot: "StopAutopilotController",
+  takeoverAutopilot: "TakeoverAutopilotController",
+  handbackAutopilot: "HandbackAutopilotController",
+  approveAutopilot: "ApproveAutopilotController",
+};
+
+// agent bundles AgentService (catalog) + UserAgentConfigService (user config).
+// Route the four user-config verbs to the sibling service.
+export const AGENT_USER_CONFIG_OVERRIDES: Record<string, string> = {
+  listUserAgentConfigs: "proto.agent.v1.UserAgentConfigService",
+  getUserAgentConfig: "proto.agent.v1.UserAgentConfigService",
+  setUserAgentConfig: "proto.agent.v1.UserAgentConfigService",
+  deleteUserAgentConfig: "proto.agent.v1.UserAgentConfigService",
+};
+
+// extension splits into SkillRegistryService (default), RepoMcpService /
+// RepoSkillService (per-repo install/manage), MarketService (catalog browse).
+// presignSkillUpload / installSkillFromUploadedFile are deliberately absent:
+// ElectronExtensionService implements those *Connect methods directly (dedicated
+// IPC channels), so the proxy never sees them.
+export const EXTENSION_SERVICE_OVERRIDES: Record<string, string> = {
+  listMarketMcpServers: "proto.extension.v1.MarketService",
+  listMarketSkills: "proto.extension.v1.MarketService",
+  installCustomMcpServer: "proto.extension.v1.RepoMcpService",
+  installMcpFromMarket: "proto.extension.v1.RepoMcpService",
+  listRepoMcpServers: "proto.extension.v1.RepoMcpService",
+  uninstallMcpServer: "proto.extension.v1.RepoMcpService",
+  updateMcpServer: "proto.extension.v1.RepoMcpService",
+  installSkillFromGithub: "proto.extension.v1.RepoSkillService",
+  installSkillFromMarket: "proto.extension.v1.RepoSkillService",
+  listRepoSkills: "proto.extension.v1.RepoSkillService",
+  uninstallSkill: "proto.extension.v1.RepoSkillService",
+  updateSkill: "proto.extension.v1.RepoSkillService",
+};
+// RepoSkillService spells the RPC "GitHub"; the wasm verb shortened it to
+// "Github", which the default first-letter-cap derivation can't recover.
+export const EXTENSION_NAME_OVERRIDES: Record<string, string> = {
+  installSkillFromGithub: "InstallSkillFromGitHub",
+};
+
+// Web's wasm services expose `<verb>Connect(Uint8Array) -> Uint8Array` methods.
+// Most ElectronXxxService classes only carry the legacy JSON surface, so a
+// `*Connect` lookup misses. This proxy forwards any unimplemented `*Connect` /
+// `*_connect` access onto the generic `connectCall` IPC handler, deriving the
+// proto (service, method) from the camelCased verb.
+//
+// `methodOverrides` routes a verb to a sibling backend service (a TS facade
+// spanning multiple proto services). `methodNameOverrides` remaps the derived
+// method name (wasm verb diverging from the proto RPC name).
+export function withConnectFallback<T extends object>(
+  service: T,
+  protoPath: string,
+  methodOverrides?: Record<string, string>,
+  methodNameOverrides?: Record<string, string>,
+): T {
+  return new Proxy(service, {
+    get(target, prop) {
+      const value = Reflect.get(target, prop);
+      if (value !== undefined) return value;
+      if (typeof prop !== "string") return undefined;
+
+      let camel: string;
+      if (prop.endsWith("Connect")) {
+        camel = prop.slice(0, -"Connect".length);
+      } else if (prop.endsWith("_connect")) {
+        const snake = prop.slice(0, -"_connect".length);
+        camel = snake.replace(/_([a-z0-9])/g, (_, c) => c.toUpperCase());
+      } else {
+        return undefined;
+      }
+      const protoMethod = methodNameOverrides?.[camel]
+        ?? camel.charAt(0).toUpperCase() + camel.slice(1);
+      // Fail closed at access time: an empty stem ("Connect"/"_connect") or a
+      // verb the snake→camel pass can't normalize (leftover "_") can't name a
+      // real RPC. Throwing here (not at call time) keeps `in`/`typeof` honest
+      // and runs the check once per property access, not per call.
+      if (!/^[A-Z][A-Za-z0-9]*$/.test(protoMethod)) {
+        throw new Error(`connect-fallback: cannot derive a proto method from "${prop}"`);
+      }
+      const targetService = methodOverrides?.[camel] ?? protoPath;
+      return async (request: Uint8Array): Promise<Uint8Array> =>
+        coerceConnectResponse(
+          await invoke<number[] | Uint8Array>(
+            "connectCall", targetService, protoMethod, Array.from(request),
+          ),
+        );
+    },
+  });
+}

--- a/packages/electron-adapter/src/connect-response.ts
+++ b/packages/electron-adapter/src/connect-response.ts
@@ -1,0 +1,9 @@
+// Normalize a `connectCall` IPC response to bytes. The main process returns a
+// number[] (`Array.from(bytes)`); in-process fakes may hand back a Uint8Array.
+// Anything else (null / undefined / plain object) is a malformed payload — fail
+// closed so it surfaces here instead of decoding to a corrupt all-defaults proto.
+export function coerceConnectResponse(resp: number[] | Uint8Array): Uint8Array {
+  if (resp instanceof Uint8Array) return resp;
+  if (Array.isArray(resp)) return new Uint8Array(resp);
+  throw new Error("connect-fallback: IPC response was not binary");
+}

--- a/packages/electron-adapter/src/grant.ts
+++ b/packages/electron-adapter/src/grant.ts
@@ -1,0 +1,6 @@
+// grant has no legacy JSON surface and no cached state — all three verbs
+// (createGrant / deleteGrant / listGrants) go through the Connect fallback in
+// provider.ts. An empty proxy target is all that's needed; the renderer was
+// previously getting a no-op stub because the desktop provider never wired
+// grantService at all.
+export class ElectronGrantService {}

--- a/packages/electron-adapter/src/index.ts
+++ b/packages/electron-adapter/src/index.ts
@@ -19,6 +19,7 @@ export { ElectronEnvBundleService } from './env_bundle';
 export { ElectronAgentService } from './agent';
 export { ElectronSSOService } from './sso';
 export { ElectronFileService } from './file';
+export { ElectronGrantService } from './grant';
 export { ElectronSupportTicketService } from './support_ticket';
 export { ElectronTicketRelationsService } from './ticket_relations';
 export { ElectronTokenUsageService } from './token_usage';

--- a/packages/electron-adapter/src/invitation.ts
+++ b/packages/electron-adapter/src/invitation.ts
@@ -1,4 +1,5 @@
 import { invoke } from "./invoke";
+import { coerceConnectResponse } from "./connect-response";
 import type { IInvitationConnectService } from "@agentsmesh/service-interface";
 
 export class ElectronInvitationConnectService implements IInvitationConnectService {
@@ -6,48 +7,48 @@ export class ElectronInvitationConnectService implements IInvitationConnectServi
     const bytes = await invoke<number[] | Uint8Array>(
       "invitationListInvitationsConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async createInvitationConnect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "invitationCreateInvitationConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async revokeInvitationConnect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "invitationRevokeInvitationConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async resendInvitationConnect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "invitationResendInvitationConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async acceptInvitationConnect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "invitationAcceptInvitationConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async listPendingInvitationsConnect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "invitationListPendingInvitationsConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async getInvitationByTokenConnect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "invitationGetInvitationByTokenConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 }

--- a/packages/electron-adapter/src/promocode.ts
+++ b/packages/electron-adapter/src/promocode.ts
@@ -1,4 +1,5 @@
 import { invoke } from "./invoke";
+import { coerceConnectResponse } from "./connect-response";
 import type { IPromoCodeService } from "@agentsmesh/service-interface";
 
 export class ElectronPromoCodeService implements IPromoCodeService {
@@ -6,20 +7,20 @@ export class ElectronPromoCodeService implements IPromoCodeService {
     const bytes = await invoke<number[] | Uint8Array>(
       "promocodeValidatePromoCodeConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async redeemPromoCodeConnect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "promocodeRedeemPromoCodeConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async getRedemptionHistoryConnect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "promocodeGetRedemptionHistoryConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 }

--- a/packages/electron-adapter/src/provider.ts
+++ b/packages/electron-adapter/src/provider.ts
@@ -19,6 +19,7 @@ import { ElectronEnvBundleService } from './env_bundle';
 import { ElectronAgentService } from './agent';
 import { ElectronSSOService } from './sso';
 import { ElectronFileService } from './file';
+import { ElectronGrantService } from './grant';
 import { ElectronSupportTicketService } from './support_ticket';
 import { ElectronTicketRelationsService } from './ticket_relations';
 import { ElectronTokenUsageService } from './token_usage';
@@ -28,7 +29,17 @@ import { ElectronAuthConnectService } from './auth_connect';
 import { ElectronBlockstoreService } from './blockstore';
 import { ElectronLocalRunnerService } from './local_runner';
 import { ElectronEventsManager } from './realtime';
-import { invoke } from './invoke';
+import {
+  withConnectFallback,
+  USER_CREDENTIAL_METHOD_OVERRIDES,
+  USER_CREDENTIAL_NAME_OVERRIDES,
+  BILLING_SERVICE_OVERRIDES,
+  BILLING_NAME_OVERRIDES,
+  AUTOPILOT_METHOD_NAMES,
+  AGENT_USER_CONFIG_OVERRIDES,
+  EXTENSION_SERVICE_OVERRIDES,
+  EXTENSION_NAME_OVERRIDES,
+} from "./connect-fallback";
 import {
   ElectronAcpManager, ElectronRelayManager, ElectronTicketState,
 } from './state_adapters';
@@ -55,28 +66,6 @@ class ElectronApiClientProxy {
     return new ElectronEventsManager();
   }
 }
-
-// user_credential proto bundles three backend services (git credential, agent
-// credential, repository provider) under a single wasm-side facade. Map each
-// method to the Connect service that actually owns it so calls land in the
-// right backend handler.
-const USER_CREDENTIAL_METHOD_OVERRIDES: Record<string, string> = {
-  listGitCredentials: "proto.user_credential.v1.UserGitCredentialService",
-  getGitCredential: "proto.user_credential.v1.UserGitCredentialService",
-  createGitCredential: "proto.user_credential.v1.UserGitCredentialService",
-  updateGitCredential: "proto.user_credential.v1.UserGitCredentialService",
-  deleteGitCredential: "proto.user_credential.v1.UserGitCredentialService",
-  getDefaultGitCredential: "proto.user_credential.v1.UserGitCredentialService",
-  setDefaultGitCredential: "proto.user_credential.v1.UserGitCredentialService",
-  clearDefaultGitCredential: "proto.user_credential.v1.UserGitCredentialService",
-  listAgentCredentialProfiles: "proto.user_credential.v1.UserAgentCredentialService",
-  listAgentCredentialProfilesForAgent: "proto.user_credential.v1.UserAgentCredentialService",
-  getAgentCredentialProfile: "proto.user_credential.v1.UserAgentCredentialService",
-  createAgentCredentialProfile: "proto.user_credential.v1.UserAgentCredentialService",
-  updateAgentCredentialProfile: "proto.user_credential.v1.UserAgentCredentialService",
-  deleteAgentCredentialProfile: "proto.user_credential.v1.UserAgentCredentialService",
-  setDefaultAgentCredentialProfile: "proto.user_credential.v1.UserAgentCredentialService",
-};
 
 export function createElectronServiceProvider(baseUrl = '') {
   // Services carry the full state (each IXxxService is a superset of IXxxState).
@@ -105,10 +94,10 @@ export function createElectronServiceProvider(baseUrl = '') {
     ticketService: withConnectFallback(ticketService, "proto.ticket.v1.TicketService"),
     channelService: withConnectFallback(channelService, "proto.channel.v1.ChannelService"),
     loopService: withConnectFallback(loopService, "proto.loop.v1.LoopService"),
-    autopilotService: withConnectFallback(autopilotService, "proto.autopilot.v1.AutopilotControllerService"),
+    autopilotService: withConnectFallback(autopilotService, "proto.autopilot.v1.AutopilotControllerService", undefined, AUTOPILOT_METHOD_NAMES),
     meshService: withConnectFallback(meshService, "proto.mesh.v1.MeshService"),
-    billingService: withConnectFallback(new ElectronBillingService(), "proto.billing.v1.BillingService"),
-    extensionService: withConnectFallback(new ElectronExtensionService(), "proto.extension.v1.SkillRegistryService"),
+    billingService: withConnectFallback(new ElectronBillingService(), "proto.billing.v1.BillingService", BILLING_SERVICE_OVERRIDES, BILLING_NAME_OVERRIDES),
+    extensionService: withConnectFallback(new ElectronExtensionService(), "proto.extension.v1.SkillRegistryService", EXTENSION_SERVICE_OVERRIDES, EXTENSION_NAME_OVERRIDES),
     repositoryService: withConnectFallback(repositoryService, "proto.repository.v1.RepositoryService"),
     invitationService: withConnectFallback(new ElectronInvitationConnectService(), "proto.invitation.v1.InvitationService"),
     apiKeyService: withConnectFallback(new ElectronApiKeyService(), "proto.apikey.v1.ApiKeyService"),
@@ -120,11 +109,13 @@ export function createElectronServiceProvider(baseUrl = '') {
       new ElectronUserCredentialService(),
       "proto.user_credential.v1.UserRepositoryProviderService",
       USER_CREDENTIAL_METHOD_OVERRIDES,
+      USER_CREDENTIAL_NAME_OVERRIDES,
     ),
     envBundleService: withConnectFallback(new ElectronEnvBundleService(), "proto.env_bundle.v1.EnvBundleService"),
-    agentService: withConnectFallback(new ElectronAgentService(), "proto.agent.v1.AgentService"),
+    agentService: withConnectFallback(new ElectronAgentService(), "proto.agent.v1.AgentService", AGENT_USER_CONFIG_OVERRIDES),
     ssoService: withConnectFallback(new ElectronSSOService(), "proto.sso.v1.SSOService"),
     fileService: withConnectFallback(new ElectronFileService(), "proto.file.v1.FileService"),
+    grantService: withConnectFallback(new ElectronGrantService(), "proto.grant.v1.GrantService"),
     supportTicketService: withConnectFallback(new ElectronSupportTicketService(), "proto.support_ticket.v1.SupportTicketService"),
     ticketRelationsService: withConnectFallback(new ElectronTicketRelationsService(), "proto.ticket_relations.v1.TicketRelationsService"),
     tokenUsageService: withConnectFallback(new ElectronTokenUsageService(), "proto.token_usage.v1.TokenUsageService"),
@@ -146,53 +137,3 @@ export function createElectronServiceProvider(baseUrl = '') {
   };
 }
 
-// Web's wasm-side services expose `<verb>Connect(Uint8Array) -> Uint8Array`
-// methods generated from the proto schema. Most ElectronXxxService classes
-// still only carry the legacy JSON-shaped surface, so renderer code that
-// reaches for the proto wire (e.g. `lib/api/channelConnect.ts`) hits
-// `<method> is not a function`. This wrapper auto-forwards any
-// `*Connect` lookup that the service doesn't implement onto the generic
-// `connectCall` IPC handler in main/index.ts, deriving the proto
-// method name from the camelCased TS name.
-//
-// `methodOverrides` lets a single TS-facing service span multiple backend
-// Connect services (e.g. user_credential bundles UserGitCredentialService,
-// UserAgentCredentialService, and UserRepositoryProviderService — wasm
-// dispatches per method but the TS facade is one object).
-function withConnectFallback<T extends object>(
-  service: T,
-  protoPath: string,
-  methodOverrides?: Record<string, string>,
-): T {
-  return new Proxy(service, {
-    get(target, prop) {
-      const value = Reflect.get(target, prop);
-      if (value !== undefined) return value;
-      if (typeof prop !== "string") return undefined;
-
-      // Two naming styles for the binary-Connect surface — both originate
-      // from the same wasm-bindgen impl. Webpack ESM consumers see
-      // camelCase (`listAgentsConnect`); the Connect-RPC adapters in
-      // clients/web/src/lib/api/*Connect.ts use snake_case
-      // (`list_agents_connect`) since that's what the autogenerated
-      // wasm.d.ts emits. Route both shapes through the same proxy.
-      let camel: string;
-      if (prop.endsWith("Connect")) {
-        camel = prop.slice(0, -"Connect".length);
-      } else if (prop.endsWith("_connect")) {
-        const snake = prop.slice(0, -"_connect".length);
-        camel = snake.replace(/_([a-z0-9])/g, (_, c) => c.toUpperCase());
-      } else {
-        return undefined;
-      }
-      const protoMethod = camel.charAt(0).toUpperCase() + camel.slice(1);
-      const targetService = methodOverrides?.[camel] ?? protoPath;
-      return async (request: Uint8Array): Promise<Uint8Array> => {
-        const resp = await invoke<number[] | Uint8Array>(
-          "connectCall", targetService, protoMethod, Array.from(request),
-        );
-        return resp instanceof Uint8Array ? resp : new Uint8Array(resp);
-      };
-    },
-  });
-}

--- a/packages/electron-adapter/src/repository.ts
+++ b/packages/electron-adapter/src/repository.ts
@@ -1,4 +1,5 @@
 import { invoke } from "./invoke";
+import { coerceConnectResponse } from "./connect-response";
 import type { IRepositoryService, IRepoState } from "@agentsmesh/service-interface";
 import { fromBinary } from "@bufbuild/protobuf";
 import {
@@ -25,7 +26,7 @@ async function connectCall(method: string, request: Uint8Array): Promise<Uint8Ar
     method,
     Array.from(request),
   );
-  return resp instanceof Uint8Array ? resp : new Uint8Array(resp);
+  return coerceConnectResponse(resp);
 }
 
 function repositoryToCache(r: ProtoRepository): Record<string, unknown> {

--- a/packages/electron-adapter/src/runner.ts
+++ b/packages/electron-adapter/src/runner.ts
@@ -1,4 +1,5 @@
 import { invoke } from "./invoke";
+import { coerceConnectResponse } from "./connect-response";
 import type { IRunnerService } from "@agentsmesh/service-interface";
 import { fromBinary } from "@bufbuild/protobuf";
 import {
@@ -159,7 +160,7 @@ export class ElectronRunnerService implements IRunnerService {
       "runnerAuthorizeRunner",
       Array.from(reqBytes),
     );
-    return result instanceof Uint8Array ? result : new Uint8Array(result);
+    return coerceConnectResponse(result);
   }
 
   async get_auth_status(reqBytes: Uint8Array): Promise<Uint8Array> {
@@ -167,7 +168,7 @@ export class ElectronRunnerService implements IRunnerService {
       "runnerGetAuthStatus",
       Array.from(reqBytes),
     );
-    return result instanceof Uint8Array ? result : new Uint8Array(result);
+    return coerceConnectResponse(result);
   }
 
   async list_runner_logs(id: bigint): Promise<string> {

--- a/packages/electron-adapter/src/sso.ts
+++ b/packages/electron-adapter/src/sso.ts
@@ -1,4 +1,5 @@
 import { invoke } from "./invoke";
+import { coerceConnectResponse } from "./connect-response";
 import type { ISSOService } from "@agentsmesh/service-interface";
 
 export class ElectronSSOService implements ISSOService {
@@ -6,13 +7,13 @@ export class ElectronSSOService implements ISSOService {
     const bytes = await invoke<number[] | Uint8Array>(
       "ssoDiscoverConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async ldapAuthConnect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "ssoLdapAuthConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 }

--- a/packages/electron-adapter/src/support_ticket.ts
+++ b/packages/electron-adapter/src/support_ticket.ts
@@ -1,4 +1,5 @@
 import { invoke } from "./invoke";
+import { coerceConnectResponse } from "./connect-response";
 import type { ISupportTicketService } from "@agentsmesh/service-interface";
 
 export class ElectronSupportTicketService implements ISupportTicketService {
@@ -14,20 +15,20 @@ export class ElectronSupportTicketService implements ISupportTicketService {
     const bytes = await invoke<number[] | Uint8Array>(
       "supportTicketListSupportTicketsConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async getSupportTicketConnect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "supportTicketGetSupportTicketConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async getAttachmentUrlConnect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "supportTicketGetAttachmentUrlConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 }

--- a/packages/electron-adapter/src/ticket.ts
+++ b/packages/electron-adapter/src/ticket.ts
@@ -1,4 +1,5 @@
 import { invoke } from "./invoke";
+import { coerceConnectResponse } from "./connect-response";
 import type { ITicketService } from "@agentsmesh/service-interface";
 
 export class ElectronTicketService implements ITicketService {
@@ -25,86 +26,86 @@ export class ElectronTicketService implements ITicketService {
 
   async list_tickets_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>("ticketListTicketsConnect", Array.from(request));
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async get_ticket_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>("ticketGetTicketConnect", Array.from(request));
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async create_ticket_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>("ticketCreateTicketConnect", Array.from(request));
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async update_ticket_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>("ticketUpdateTicketConnect", Array.from(request));
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async delete_ticket_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>("ticketDeleteTicketConnect", Array.from(request));
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async update_ticket_status_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>("ticketUpdateTicketStatusConnect", Array.from(request));
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async get_active_tickets_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>("ticketGetActiveTicketsConnect", Array.from(request));
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async get_board_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>("ticketGetBoardConnect", Array.from(request));
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async get_sub_tickets_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>("ticketGetSubTicketsConnect", Array.from(request));
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async add_assignee_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>("ticketAddAssigneeConnect", Array.from(request));
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async remove_assignee_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>("ticketRemoveAssigneeConnect", Array.from(request));
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async list_labels_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>("ticketListLabelsConnect", Array.from(request));
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async create_label_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>("ticketCreateLabelConnect", Array.from(request));
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async update_label_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>("ticketUpdateLabelConnect", Array.from(request));
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async delete_label_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>("ticketDeleteLabelConnect", Array.from(request));
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async add_label_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>("ticketAddLabelConnect", Array.from(request));
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async remove_label_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>("ticketRemoveLabelConnect", Array.from(request));
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 }

--- a/packages/electron-adapter/src/ticket_relations.ts
+++ b/packages/electron-adapter/src/ticket_relations.ts
@@ -1,4 +1,5 @@
 import { invoke } from "./invoke";
+import { coerceConnectResponse } from "./connect-response";
 import type { ITicketRelationsService } from "@agentsmesh/service-interface";
 
 // Forwards the Connect-RPC Uint8Array round-trip to the node-bridge's
@@ -10,76 +11,76 @@ export class ElectronTicketRelationsService implements ITicketRelationsService {
     const bytes = await invoke<number[] | Uint8Array>(
       "ticketRelationsListRelationsConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async create_relation_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "ticketRelationsCreateRelationConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async delete_relation_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "ticketRelationsDeleteRelationConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async list_commits_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "ticketRelationsListCommitsConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async link_commit_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "ticketRelationsLinkCommitConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async unlink_commit_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "ticketRelationsUnlinkCommitConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async list_merge_requests_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "ticketRelationsListMergeRequestsConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async list_comments_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "ticketRelationsListCommentsConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async create_comment_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "ticketRelationsCreateCommentConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async update_comment_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "ticketRelationsUpdateCommentConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async delete_comment_connect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "ticketRelationsDeleteCommentConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 }

--- a/packages/electron-adapter/src/user.ts
+++ b/packages/electron-adapter/src/user.ts
@@ -1,4 +1,5 @@
 import { invoke } from "./invoke";
+import { coerceConnectResponse } from "./connect-response";
 import type { IUserApiService } from "@agentsmesh/service-interface";
 
 export class ElectronUserService implements IUserApiService {
@@ -6,41 +7,41 @@ export class ElectronUserService implements IUserApiService {
     const bytes = await invoke<number[] | Uint8Array>(
       "userGetMeConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async updateMeConnect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "userUpdateMeConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async changePasswordConnect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "userChangePasswordConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async listIdentitiesConnect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "userListIdentitiesConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async deleteIdentityConnect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "userDeleteIdentityConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 
   async searchUsersConnect(request: Uint8Array): Promise<Uint8Array> {
     const bytes = await invoke<number[] | Uint8Array>(
       "userSearchUsersConnect", Array.from(request),
     );
-    return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return coerceConnectResponse(bytes);
   }
 }

--- a/packages/electron-adapter/vitest.config.ts
+++ b/packages/electron-adapter/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+// Pure-logic units: node env, no jsdom/wasm. Verifies the electron service
+// provider derives the correct backend Connect (service, method) path for
+// every facade — guarding the multi-service routing + name-override config.
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## What

Desktop renderer has no wasm, so `ElectronXxxService` Connect calls fall through `withConnectFallback`, which derives the backend `(service, method)` by string-munging the verb. Verbs whose wasm name diverges from the proto RPC (suffix / sibling-service) **404'd on desktop only** — web routes via the wasm api-client and is unaffected.

Autopilot was the reported case (`ListAutopilots` vs `ListAutopilotControllers`); a review surfaced **6 more on billing** (`reactivate`/`requestCancel`/`upgrade`/`changeCycle` dropped the `Subscription`/`BillingCycle` suffix; public pricing + deployment info live on `BillingPublicService`).

## Changes

- **billing**: add `BILLING_SERVICE_OVERRIDES` + `BILLING_NAME_OVERRIDES`
- **remove dead maps** (promocode + invitation fully, 2 extension entries): those facades implement `*Connect` directly via dedicated IPC channels and bypass the proxy, so the override maps never fired (and their tests asserted dead paths)
- **`coerceConnectResponse()`**: extracted; proxy + 10 facades share it (was 62 copies), and it fails closed on a non-binary IPC response instead of building a junk buffer
- **fail-closed method-name check** hoisted into the proxy get-trap (runs once per access, keeps `in`/`typeof` honest)
- **`scripts/check-connect-routing.py`**: CI guard that re-derives every renderer Connect call and asserts it routes to a registered proto path; fails closed on empty input
- **CI wiring**: electron-adapter type-check + unit + routing guard added to `bazel.yml` (`packages/...` was not exercised in CI before)

## Test plan

- `bazel test //packages/electron-adapter:electron_adapter_typecheck_test` — PASS (verified it catches injected type errors)
- `bazel test //packages/electron-adapter:unit` — 26 tests PASS (billing routes + fail-closed + positive return-value)
- `python3 packages/electron-adapter/scripts/check-connect-routing.py` — OK (271 calls → registered paths; verified it catches a removed override and fails closed on empty input)
- `bazel run //:buildifier_check` — PASS

## Notes

- Web is unaffected throughout. **Requires a new desktop release** to reach users.
- Reviewed across 4 `/code-review` rounds; core routing has 0 active defects, severity converged HIGH→low.