### PR TITLE
fix(repository): register webhooks with the provider's expected project id

### DIFF
--- a/backend/internal/service/repository/webhook_project_id_test.go
+++ b/backend/internal/service/repository/webhook_project_id_test.go
@@ -1,0 +1,36 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/anthropics/agentsmesh/backend/internal/domain/gitprovider"
+)
+
+func TestWebhookProjectID(t *testing.T) {
+	tests := []struct {
+		name         string
+		providerType string
+		slug         string
+		externalID   string
+		want         string
+	}{
+		{"github uses owner/repo slug", "github", "owner/repo", "12345", "owner/repo"},
+		{"gitee uses owner/repo slug", "gitee", "owner/repo", "67890", "owner/repo"},
+		{"gitlab keeps numeric external id", "gitlab", "group/project", "777", "777"},
+		{"unknown provider defaults to slug", "generic", "owner/repo", "42", "owner/repo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &gitprovider.Repository{
+				ProviderType: tt.providerType,
+				Slug:         tt.slug,
+				ExternalID:   tt.externalID,
+			}
+
+			if got := webhookProjectID(repo); got != tt.want {
+				t.Errorf("webhookProjectID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/service/repository/webhook_registration.go
+++ b/backend/internal/service/repository/webhook_registration.go
@@ -21,7 +21,7 @@ func (s *WebhookService) RegisterWebhookForRepository(ctx context.Context, repo 
 		return s.saveManualSetupConfig(ctx, repo, result, webhookURL, webhookSecret, "Webhook requires manual setup: "+err.Error())
 	}
 
-	webhookID, err := provider.RegisterWebhook(ctx, repo.ExternalID, &git.WebhookConfig{
+	webhookID, err := provider.RegisterWebhook(ctx, webhookProjectID(repo), &git.WebhookConfig{
 		URL:    webhookURL,
 		Secret: webhookSecret,
 		Events: []string{"merge_request", "pipeline"},
@@ -108,7 +108,7 @@ func (s *WebhookService) DeleteWebhookForRepository(ctx context.Context, repo *g
 		return s.repo.Save(ctx, repo)
 	}
 
-	if err := provider.DeleteWebhook(ctx, repo.ExternalID, repo.WebhookConfig.ID); err != nil {
+	if err := provider.DeleteWebhook(ctx, webhookProjectID(repo), repo.WebhookConfig.ID); err != nil {
 		if s.logger != nil {
 			s.logger.Warn("Failed to delete webhook from provider",
 				"repo_id", repo.ID,
@@ -119,6 +119,13 @@ func (s *WebhookService) DeleteWebhookForRepository(ctx context.Context, repo *g
 
 	repo.WebhookConfig = nil
 	return s.repo.Save(ctx, repo)
+}
+
+func webhookProjectID(repo *gitprovider.Repository) string {
+	if repo.ProviderType == "gitlab" {
+		return repo.ExternalID
+	}
+	return repo.Slug
 }
 
 func (s *WebhookService) buildWebhookURL(orgSlug string, repo *gitprovider.Repository) string {


### PR DESCRIPTION
## Problem

GitHub and Gitee expose repository webhooks at `/repos/{owner}/{repo}/hooks`, which requires the `owner/repo` slug. `RegisterWebhookForRepository` passed `repo.ExternalID` (the numeric repository id), so on GitHub/Gitee the create-hook call hit `/repos/{numericId}/hooks` and the API returned **404 Not Found** ("resource not found"). Auto-registration silently fell back to "manual setup required" for every GitHub/Gitee repo.

Illustration of the two paths:

```
POST /repos/{numericId}/hooks    -> 404 Not Found
POST /repos/{owner}/{repo}/hooks -> 201 Created
```

## Fix

Resolve the project identifier per provider:
- GitHub / Gitee: use `repo.Slug` (`owner/repo`) - their REST hooks endpoints require it.
- GitLab: keep `repo.ExternalID` - GitLab uses `/projects/{id}/hooks` and its provider already `url.PathEscape`s the id.

Applied to both `RegisterWebhook` and `DeleteWebhook` via a small `webhookProjectID()` helper.

## Scope

One file, no API/signature changes. GitLab behaviour is unchanged (still numeric id); only GitHub/Gitee switch from the numeric id to the slug.
