### PR TITLE
fix(realtime): empty-status agent event no longer drops running pod from sidebar

### DIFF
--- a/clients/core/crates/state/src/event_dispatch.rs
+++ b/clients/core/crates/state/src/event_dispatch.rs
@@ -107,10 +107,9 @@ pub fn dispatch(state: &mut AppState, event: &RealtimeEvent) {
         }
         EventType::PodAgentStatusChanged => {
             if let Some(key) = event.data.get("pod_key").and_then(|v| v.as_str()) {
-                let status = event.data.get("status").and_then(|v| v.as_str()).unwrap_or("");
                 let agent = event.data.get("agent_status").and_then(|v| v.as_str());
-                state.pods.update_pod_status(key, status, agent, None, None, Some(event.timestamp));
-                state.mesh.update_node_status(key, status, agent);
+                if let Some(a) = agent { state.pods.update_agent_status(key, a); }
+                state.mesh.update_node_status(key, "", agent);
             }
         }
         EventType::PodTerminated => {
@@ -186,9 +185,7 @@ pub fn dispatch(state: &mut AppState, event: &RealtimeEvent) {
             // status in place so the board/badge updates immediately.
             if let Some(slug) = jstr(&event.data, "slug") {
                 if let Some(status) = jstr(&event.data, "status") {
-                    if !status.is_empty() {
-                        state.tickets.update_ticket_status(slug, status);
-                    }
+                    state.tickets.update_ticket_status(slug, status);
                 }
                 state.pending_refetch_ticket_slugs.push(slug.to_string());
             }
@@ -213,9 +210,7 @@ pub fn dispatch(state: &mut AppState, event: &RealtimeEvent) {
             // — not a full Runner. Apply the status transition in place.
             if let Some(id) = ji64(&event.data, "runner_id") {
                 let status = jstr(&event.data, "status").unwrap_or("");
-                if !status.is_empty() {
-                    state.runners.update_runner_status(id, status);
-                }
+                state.runners.update_runner_status(id, status);
             }
         }
         EventType::LoopRunStarted => {
@@ -563,6 +558,40 @@ mod tests {
         // terminated flips the mesh node status too.
         dispatch(&mut s, &make_event(EventType::PodTerminated, json!({"pod_key":"p1"})));
         assert_eq!(s.mesh.get_node_by_key("p1").unwrap().status, "terminated");
+    }
+
+    #[test]
+    fn pod_agent_status_changed_keeps_pod_status() {
+        let mut s = AppState::new();
+        s.pods.upsert_pod(Pod {
+            pod_key: "p1".into(), status: "running".into(),
+            agent_slug: "claude".into(), agent_status: "idle".into(), ..Default::default()
+        }, Some(1));
+        dispatch(&mut s, &make_event(EventType::PodAgentStatusChanged, json!({"pod_key":"p1","agent_status":"executing"})));
+        let p = s.pods.get_pod("p1").unwrap();
+        assert_eq!(p.status, "running", "agent-only event must not blank status");
+        assert_eq!(p.agent_status, "executing");
+    }
+
+    #[test]
+    fn agent_status_event_does_not_poison_status_watermark() {
+        let mut s = AppState::new();
+        s.pods.upsert_pod(Pod {
+            pod_key: "p1".into(), status: "running".into(),
+            agent_slug: "claude".into(), ..Default::default()
+        }, Some(100));
+        let agent_evt = RealtimeEvent {
+            timestamp: 200,
+            ..make_event(EventType::PodAgentStatusChanged, json!({"pod_key":"p1","agent_status":"executing"}))
+        };
+        dispatch(&mut s, &agent_evt);
+        let term_evt = RealtimeEvent {
+            timestamp: 150,
+            ..make_event(EventType::PodTerminated, json!({"pod_key":"p1"}))
+        };
+        dispatch(&mut s, &term_evt);
+        assert_eq!(s.pods.get_pod("p1").unwrap().status, "terminated",
+            "agent heartbeat must not advance the status watermark and drop a later terminated event");
     }
 
     #[test]

--- a/clients/core/crates/state/src/pod_state.rs
+++ b/clients/core/crates/state/src/pod_state.rs
@@ -94,10 +94,12 @@ impl PodState {
         let error_code_owned = error_code.map(String::from);
         let error_message_owned = error_message.map(String::from);
         let updater = |pod: &mut Pod| {
-            pod.status = status_owned.clone();
+            if !status_owned.is_empty() {
+                pod.status = status_owned.clone();
+                pod.error_code = error_code_owned.clone();
+                pod.error_message = error_message_owned.clone();
+            }
             if let Some(ref as_) = agent_status_owned { pod.agent_status = as_.clone(); }
-            pod.error_code = error_code_owned.clone();
-            pod.error_message = error_message_owned.clone();
         };
         if let Some(p) = self.pods.iter_mut().find(|p| p.pod_key == pod_key) {
             updater(p);

--- a/clients/core/crates/state/src/pod_state_tests.rs
+++ b/clients/core/crates/state/src/pod_state_tests.rs
@@ -99,6 +99,31 @@ fn update_pod_status_with_timestamp_guard() {
 }
 
 #[test]
+fn update_pod_status_empty_status_keeps_old() {
+    let mut s = PodState::new();
+    let mut pod = make_pod("p1", "running");
+    pod.agent_status = "idle".into();
+    s.upsert_pod(pod, None);
+    s.update_pod_status("p1", "", Some("executing"), None, None, None);
+    let p = s.get_pod("p1").unwrap();
+    assert_eq!(p.status, "running");
+    assert_eq!(p.agent_status, "executing");
+}
+
+#[test]
+fn update_pod_status_empty_status_preserves_error_fields() {
+    let mut s = PodState::new();
+    let mut pod = make_pod("p1", "running");
+    pod.error_code = Some("E001".into());
+    pod.error_message = Some("boom".into());
+    s.upsert_pod(pod, None);
+    s.update_pod_status("p1", "", Some("executing"), None, None, None);
+    let p = s.get_pod("p1").unwrap();
+    assert_eq!(p.error_code.as_deref(), Some("E001"));
+    assert_eq!(p.error_message.as_deref(), Some("boom"));
+}
+
+#[test]
 fn update_pod_status_syncs_current_pod() {
     let mut s = PodState::new();
     let pod = make_pod("p1", "running");

--- a/clients/core/crates/state/src/runner_state.rs
+++ b/clients/core/crates/state/src/runner_state.rs
@@ -84,6 +84,7 @@ impl RunnerState {
     }
 
     pub fn update_runner_status(&mut self, id: i64, status: &str) {
+        if status.is_empty() { return; }
         tracing::info!(target: "runner", runner_id = id, status, "status changed");
         for r in &mut self.runners {
             if r.id == id {

--- a/clients/core/crates/state/src/runner_state_tests.rs
+++ b/clients/core/crates/state/src/runner_state_tests.rs
@@ -81,6 +81,17 @@ fn update_runner_status_removes_from_available() {
 }
 
 #[test]
+fn update_runner_status_empty_keeps_status_and_availability() {
+    let mut s = RunnerState::new();
+    let r = make_runner(1, "r1", "online", true, 4, 0);
+    s.set_runners(vec![r.clone()]);
+    s.set_available_runners(vec![r]);
+    s.update_runner_status(1, "");
+    assert_eq!(s.get_runner(1).unwrap().status, "online");
+    assert_eq!(s.available_runners().len(), 1, "empty status must not evict from available_runners");
+}
+
+#[test]
 fn can_accept_pods_true() {
     let r = make_runner(1, "r1", "online", true, 4, 2);
     assert!(RunnerState::can_accept_pods(&r));

--- a/clients/core/crates/state/src/ticket_state.rs
+++ b/clients/core/crates/state/src/ticket_state.rs
@@ -100,6 +100,7 @@ impl TicketState {
     }
 
     pub fn update_ticket_status(&mut self, slug: &str, status: &str) {
+        if status.is_empty() { return; }
         tracing::info!(target: "ticket", slug, status, "status changed");
         if let Some(t) = self.tickets.iter_mut().find(|t| t.slug == slug) {
             t.status = status.to_string();

--- a/clients/core/crates/state/src/ticket_state_tests.rs
+++ b/clients/core/crates/state/src/ticket_state_tests.rs
@@ -34,6 +34,18 @@ fn set_tickets() {
 }
 
 #[test]
+fn update_ticket_status_empty_keeps_status() {
+    let mut s = TicketState::new();
+    s.set_tickets(vec![tk("T-1", "a")]);
+    s.update_ticket_status("T-1", "");
+    assert_eq!(
+        s.get_tickets().iter().find(|t| t.slug == "T-1").unwrap().status,
+        ticket_status::TODO,
+        "empty status must not blank the ticket"
+    );
+}
+
+#[test]
 fn add_ticket() {
     let mut s = TicketState::new();
     s.add_ticket(tk("T-1", "a"));

--- a/clients/web/e2e-playwright/tests/pod/pod-agent-status-keeps-sidebar.spec.ts
+++ b/clients/web/e2e-playwright/tests/pod/pod-agent-status-keeps-sidebar.spec.ts
@@ -1,0 +1,61 @@
+// Regression: a pod:agent_status_changed event carries an empty pod status.
+// The Rust dispatch (event_dispatch.rs PodAgentStatusChanged) once funneled it
+// through update_pod_status, blanking pod.status → the running pod dropped out
+// of the "running,initializing" sidebar filter and vanished from the workspace
+// mid-run. This locks the full wire → wasm dispatch → sidebar render chain.
+import { test, expect } from "../../fixtures/index";
+import { TEST_ORG_SLUG } from "../../helpers/env";
+import { clearAuthRateLimit } from "../../helpers/redis";
+import { terminateAllPods } from "../../helpers/pod-cleanup";
+import { pollUntil } from "../../helpers/retry";
+import { setupAcpScenarioPage } from "../../helpers/acp-spec-setup";
+import { withEventSubscription } from "../../helpers/eventbus-stream";
+
+test.describe("Pod sidebar · agent_status_changed keeps the running pod", () => {
+  test.beforeEach(async () => { clearAuthRateLimit(); });
+  test.afterEach(async () => { await terminateAllPods(); });
+
+  test("an empty-status agent event must not drop the pod from the sidebar", async ({ page, api, monitor }) => {
+    const cc = await api.connect();
+    const token = api.getToken();
+    if (!token) throw new Error("api fixture missing token");
+
+    // Warm the workspace route — the first hit on a cold next_dev dev server
+    // compiles the route + 21MB wasm, exceeding setupAcpScenarioPage's 30s goto.
+    await page.goto(`/${TEST_ORG_SLUG}/workspace`, { waitUntil: "load", timeout: 120_000 });
+
+    const { pod, assertWasmHealthy } = await setupAcpScenarioPage(page, api, monitor, {
+      mode: "acp", scenario: "echo",
+    });
+
+    const podSelector = `[data-testid="pod-list-item"][data-pod-key="${pod.podKey}"]`;
+    await expect(page.locator(podSelector)).toBeVisible({ timeout: 15_000 });
+
+    // SendPodPrompt only drives the ACP executing→idle cycle once the agent
+    // handshake settles to running; gate on it so the trigger can't race init.
+    await pollUntil(
+      async () => ((await cc.pod.getPod({ orgSlug: TEST_ORG_SLUG, podKey: pod.podKey })) as { status: string }).status === "running",
+      { maxAttempts: 20, intervalMs: 1000, label: "pod-running" },
+    );
+    await page.waitForTimeout(1500); // wasm EventSubscriptionManager bootstrap
+
+    const { event } = await withEventSubscription<unknown, { pod_key?: string; status?: string; agent_status?: string }>(
+      {
+        token, orgSlug: TEST_ORG_SLUG, timeoutMs: 15_000,
+        predicate: (type, data) => type === "pod:agent_status_changed" && data.pod_key === pod.podKey,
+      },
+      async () => {
+        await cc.pod.sendPodPrompt({ orgSlug: TEST_ORG_SLUG, podKey: pod.podKey, prompt: "ping" });
+      },
+    );
+    expect(event.data.status ?? "").toBe("");
+    expect(typeof event.data.agent_status).toBe("string");
+
+    // The echoed reply proves the page consumed this pod's agent activity, so
+    // its wasm subscriber has dispatched the empty-status event by now.
+    await expect(page.getByText("echo: ping")).toBeVisible({ timeout: 15_000 });
+
+    await expect(page.locator(podSelector)).toHaveCount(1);
+    assertWasmHealthy();
+  });
+});

--- a/packages/electron-adapter/src/pod.ts
+++ b/packages/electron-adapter/src/pod.ts
@@ -168,10 +168,13 @@ export class ElectronPodService implements IPodService {
 
   apply_pod_status_event(reqBytes: Uint8Array): void {
     const req = fromBinary(ApplyPodStatusEventRequestSchema, reqBytes);
-    const patch: Record<string, unknown> = { status: req.status };
+    const patch: Record<string, unknown> = {};
+    if (req.status) {
+      patch.status = req.status;
+      if (req.errorCode !== undefined) patch.error_code = req.errorCode ?? undefined;
+      if (req.errorMessage !== undefined) patch.error_message = req.errorMessage ?? undefined;
+    }
     if (req.agentStatus !== undefined) patch.agent_status = req.agentStatus ?? undefined;
-    if (req.errorCode !== undefined) patch.error_code = req.errorCode ?? undefined;
-    if (req.errorMessage !== undefined) patch.error_message = req.errorMessage ?? undefined;
     this._podsCache = patchPodInCache(this._podsCache, req.podKey, patch);
   }
 


### PR DESCRIPTION
## Problem
Running pods intermittently vanished from the workspace sidebar, especially during status transitions. Root cause: `pod:agent_status_changed` events carry an empty pod status, and the shared Rust dispatch funneled them through `update_pod_status`, which unconditionally overwrote `pod.status=""` — dropping the running pod out of the `running,initializing` sidebar filter. It also advanced the per-pod timestamp watermark, which could drop a same-millisecond `terminated` event.

#437 added this empty-status guard to `mesh_state.update_node_status` but missed the sibling domains.

## Fix (systematic)
- Route `PodAgentStatusChanged` → the existing `update_agent_status` (agent-only; no status/error/watermark side effects)
- Guard `update_pod_status` against empty status (defense-in-depth)
- Add in-method empty-status guards to `runner_state`/`ticket_state`, retiring the scattered dispatch-arm `!status.is_empty()` checks
- Mirror the guard in the electron-adapter TS twin (`apply_pod_status_event`)

## Tests
- **Unit**: pod/runner/ticket empty-status guards + watermark-collision regression (`bazel test //clients/core/crates/state:state_test`, green)
- **UI e2e**: `pod-agent-status-keeps-sidebar.spec.ts` — verifies the running pod survives a real `pod:agent_status_changed` end-to-end; built + run against the full dev stack, passing.