### PR TITLE
fix(blocks): sub-pages render as navigable links instead of inlined content

### DIFF
--- a/clients/desktop/src/renderer/pages/dashboard/blocks/BlocksPage.tsx
+++ b/clients/desktop/src/renderer/pages/dashboard/blocks/BlocksPage.tsx
@@ -8,17 +8,12 @@ import { BlocksDocHeader } from "@/components/blocks/BlocksDocHeader";
 import { CenteredSpinner } from "@/components/ui/spinner";
 import { getErrorMessage } from "@/lib/utils";
 import { blockstoreApi } from "@/lib/api/facade/blockstoreApi";
+import { useSelectPage } from "@/lib/blockstore/useSelectPage";
+import { useJumpToBlock } from "@/lib/blockstore/useJumpToBlock";
+import { pageDisplayMeta } from "@/lib/blockstore/pageDisplayMeta";
 import type { Workspace } from "@/lib/viewModels/blockstore";
 import { useBlockstoreStore, useBlocks } from "@/stores/blockstore";
 import "@/stores/blockstoreSubscribe";
-
-function pageMeta(block: { data?: { title?: unknown; icon?: unknown }; text?: string | null } | undefined) {
-  if (!block) return { title: "Untitled", icon: undefined as string | undefined };
-  const t = block.data?.title;
-  const title = typeof t === "string" && t.trim() ? t : block.text?.trim() || "Untitled";
-  const icon = typeof block.data?.icon === "string" ? (block.data.icon as string) : undefined;
-  return { title, icon };
-}
 
 export function BlocksPage() {
   const t = useTranslations();
@@ -30,6 +25,8 @@ export function BlocksPage() {
   const [searchOpen, setSearchOpen] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const blocks = useBlocks();
+  const selectPage = useSelectPage();
+  const jumpToBlock = useJumpToBlock();
 
   const hydrate = async (ws: Workspace) => {
     setWorkspace(ws);
@@ -74,9 +71,9 @@ export function BlocksPage() {
   const rootId = workspace?.root_block_id ?? null;
   const selectedPageID = pageParam ?? rootId;
 
-  const rootMeta = useMemo(() => pageMeta(rootId ? blocks[rootId] : undefined), [rootId, blocks]);
+  const rootMeta = useMemo(() => pageDisplayMeta(rootId ? blocks[rootId] : undefined), [rootId, blocks]);
   const currentMeta = useMemo(
-    () => pageMeta(selectedPageID ? blocks[selectedPageID] : undefined),
+    () => pageDisplayMeta(selectedPageID ? blocks[selectedPageID] : undefined),
     [selectedPageID, blocks],
   );
 
@@ -93,6 +90,7 @@ export function BlocksPage() {
           currentIcon={currentMeta.icon}
           isRoot={selectedPageID === rootId}
           onAddBlock={() => setMenuOpen(true)}
+          onNavigateRoot={() => selectPage(rootId)}
         />
         <div className="min-h-0 flex-1 overflow-y-auto">
           <DocumentView
@@ -107,12 +105,7 @@ export function BlocksPage() {
         workspaceID={workspace.id}
         open={searchOpen}
         onClose={() => setSearchOpen(false)}
-        onJumpToBlock={(blockID) => {
-          const el = document.getElementById(`block-${blockID}`);
-          el?.scrollIntoView({ behavior: "smooth", block: "center" });
-          el?.classList.add("ring-2", "ring-primary");
-          setTimeout(() => el?.classList.remove("ring-2", "ring-primary"), 1500);
-        }}
+        onJumpToBlock={jumpToBlock}
       />
     </div>
   );

--- a/clients/web/src/app/(dashboard)/[org]/blocks/page.tsx
+++ b/clients/web/src/app/(dashboard)/[org]/blocks/page.tsx
@@ -10,18 +10,13 @@ import { BlocksDocHeader } from "@/components/blocks/BlocksDocHeader";
 import { CenteredSpinner } from "@/components/ui/spinner";
 import { getErrorMessage } from "@/lib/utils";
 import { blockstoreApi } from "@/lib/api/facade/blockstoreApi";
+import { useSelectPage } from "@/lib/blockstore/useSelectPage";
+import { useJumpToBlock } from "@/lib/blockstore/useJumpToBlock";
+import { pageDisplayMeta } from "@/lib/blockstore/pageDisplayMeta";
 import type { Workspace } from "@/lib/viewModels/blockstore";
 import { useBlocks, useBlockstoreStore } from "@/stores/blockstore";
 import { useCurrentOrg } from "@/stores/auth";
 import "@/stores/blockstoreSubscribe";
-
-function pageMeta(block: { data?: { title?: unknown; icon?: unknown }; text?: string | null } | undefined) {
-  if (!block) return { title: "Untitled", icon: undefined as string | undefined };
-  const t = block.data?.title;
-  const title = typeof t === "string" && t.trim() ? t : block.text?.trim() || "Untitled";
-  const icon = typeof block.data?.icon === "string" ? (block.data.icon as string) : undefined;
-  return { title, icon };
-}
 
 export default function BlockstorePage() {
   const t = useTranslations();
@@ -34,6 +29,8 @@ export default function BlockstorePage() {
   const [searchOpen, setSearchOpen] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const blocks = useBlocks();
+  const selectPage = useSelectPage();
+  const jumpToBlock = useJumpToBlock();
 
   const hydrate = async (ws: Workspace) => {
     setWorkspace(ws);
@@ -79,9 +76,9 @@ export default function BlockstorePage() {
   const rootId = workspace?.root_block_id ?? null;
   const selectedPageID = pageParam ?? rootId;
 
-  const rootMeta = useMemo(() => pageMeta(rootId ? blocks[rootId] : undefined), [rootId, blocks]);
+  const rootMeta = useMemo(() => pageDisplayMeta(rootId ? blocks[rootId] : undefined), [rootId, blocks]);
   const currentMeta = useMemo(
-    () => pageMeta(selectedPageID ? blocks[selectedPageID] : undefined),
+    () => pageDisplayMeta(selectedPageID ? blocks[selectedPageID] : undefined),
     [selectedPageID, blocks],
   );
 
@@ -98,6 +95,7 @@ export default function BlockstorePage() {
           currentIcon={currentMeta.icon}
           isRoot={selectedPageID === rootId}
           onAddBlock={() => setMenuOpen(true)}
+          onNavigateRoot={() => selectPage(rootId)}
         />
         <div className="min-h-0 flex-1 overflow-y-auto">
           <DocumentView
@@ -112,12 +110,7 @@ export default function BlockstorePage() {
         workspaceID={workspace.id}
         open={searchOpen}
         onClose={() => setSearchOpen(false)}
-        onJumpToBlock={(blockID) => {
-          const el = document.getElementById(`block-${blockID}`);
-          el?.scrollIntoView({ behavior: "smooth", block: "center" });
-          el?.classList.add("ring-2", "ring-primary");
-          setTimeout(() => el?.classList.remove("ring-2", "ring-primary"), 1500);
-        }}
+        onJumpToBlock={jumpToBlock}
       />
     </div>
   );

--- a/clients/web/src/components/blocks/BlocksDocHeader.tsx
+++ b/clients/web/src/components/blocks/BlocksDocHeader.tsx
@@ -10,6 +10,7 @@ interface BlocksDocHeaderProps {
   currentIcon?: string;
   isRoot: boolean;
   onAddBlock: () => void;
+  onNavigateRoot?: () => void;
 }
 
 export function BlocksDocHeader({
@@ -19,16 +20,33 @@ export function BlocksDocHeader({
   currentIcon,
   isRoot,
   onAddBlock,
+  onNavigateRoot,
 }: BlocksDocHeaderProps) {
+  const rootLabel = (
+    <>
+      {rootIcon && <span className="mr-1" aria-hidden="true">{rootIcon}</span>}
+      {rootTitle}
+    </>
+  );
   return (
     <div className="flex flex-col gap-1.5 border-b border-border px-12 pb-3 pt-4">
       <div className="flex items-center gap-2 text-[12px] text-muted-foreground">
         <span>Pages</span>
         <span className="text-border">›</span>
-        <span className={isRoot ? "font-medium text-foreground" : undefined}>
-          {rootIcon && <span className="mr-1" aria-hidden="true">{rootIcon}</span>}
-          {rootTitle}
-        </span>
+        {!isRoot && onNavigateRoot ? (
+          <button
+            type="button"
+            onClick={onNavigateRoot}
+            data-testid="blocks-breadcrumb-root"
+            className="inline-flex items-center rounded text-muted-foreground transition-colors hover:text-foreground hover:underline"
+          >
+            {rootLabel}
+          </button>
+        ) : (
+          <span className={isRoot ? "font-medium text-foreground" : "text-muted-foreground"}>
+            {rootLabel}
+          </span>
+        )}
         {!isRoot && (
           <>
             <span className="text-border">›</span>

--- a/clients/web/src/components/blocks/BlocksSidebar.tsx
+++ b/clients/web/src/components/blocks/BlocksSidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { ChevronRight, FileText, Search, Plus, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useBlocks, useRefs, useNestChildrenIndex, useBlockstoreStore, useWorkspace } from "@/stores/blockstore";
@@ -9,6 +9,7 @@ import { useBlockTypeSpecs } from "@/lib/blockstore/useBlockTypeSpec";
 import { useBlockstoreDispatch } from "@/components/blocks/editor/useBlockstoreDispatch";
 import { BLOCK_TYPE_PAGE } from "@/lib/viewModels/blockstore";
 import { buildPageTree, countByType, colorForType, type PageNode } from "@/lib/blockstore/page-tree";
+import { useSelectPage } from "@/lib/blockstore/useSelectPage";
 import {
   ContextMenu, ContextMenuTrigger, ContextMenuContent, ContextMenuItem,
 } from "@/components/ui/context-menu";
@@ -19,7 +20,6 @@ import {
 import { useTranslations } from "next-intl";
 
 export function BlocksSidebar() {
-  const router = useRouter();
   const searchParams = useSearchParams();
   const pageParam = searchParams.get("page");
   const activeWorkspaceId = useBlockstoreStore((s) => s.activeWorkspaceId);
@@ -48,13 +48,7 @@ export function BlocksSidebar() {
   const triggerCount = typeCounts["trigger_def"] ?? 0;
   const typeEntries = Object.values(typeSpecs);
 
-  const handleSelectPage = (id: string) => {
-    const next = new URLSearchParams(Array.from(searchParams.entries()));
-    if (id === rootBlockID) next.delete("page");
-    else next.set("page", id);
-    const qs = next.toString();
-    router.replace(qs ? `?${qs}` : "?");
-  };
+  const selectPage = useSelectPage();
 
   const handleAddPage = async () => {
     if (!rootBlockID) return;
@@ -64,7 +58,7 @@ export function BlocksSidebar() {
       { title: "Untitled" },
       { text: "Untitled" },
     );
-    if (newID) handleSelectPage(newID);
+    if (newID) selectPage(newID);
   };
 
   const handleOpenSearch = () => {
@@ -105,7 +99,7 @@ export function BlocksSidebar() {
               node={node}
               depth={0}
               selectedId={selectedPageID}
-              onSelect={handleSelectPage}
+              onSelect={selectPage}
               onDelete={setPendingDelete}
             />
           ))

--- a/clients/web/src/components/blocks/renderers/LinkToPageRenderer.tsx
+++ b/clients/web/src/components/blocks/renderers/LinkToPageRenderer.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { ArrowUpRight } from "lucide-react";
 
 import type { Block } from "@/lib/viewModels/blockstore";
+import { useJumpToBlock } from "@/lib/blockstore/useJumpToBlock";
 import { useBlock } from "@/stores/blockstore";
 
 import { BlockChrome } from "../editor/BlockChrome";
@@ -11,6 +12,7 @@ import { useBlockstoreDispatch } from "../editor/useBlockstoreDispatch";
 
 export function LinkToPageRenderer({ block }: { block: Block }) {
   const dispatch = useBlockstoreDispatch(block.workspace_id);
+  const jumpToBlock = useJumpToBlock();
   const targetID = (block.data?.target_id as string | undefined) ?? "";
   const target = useBlock(targetID || null);
 
@@ -25,11 +27,7 @@ export function LinkToPageRenderer({ block }: { block: Block }) {
     "Untitled page";
 
   const handleJump = () => {
-    if (!targetID) return;
-    const el = document.getElementById(`block-${targetID}`);
-    el?.scrollIntoView({ behavior: "smooth", block: "center" });
-    el?.classList.add("ring-2", "ring-primary");
-    setTimeout(() => el?.classList.remove("ring-2", "ring-primary"), 1500);
+    if (targetID) jumpToBlock(targetID);
   };
 
   return (

--- a/clients/web/src/components/blocks/renderers/PageRenderer.tsx
+++ b/clients/web/src/components/blocks/renderers/PageRenderer.tsx
@@ -3,24 +3,25 @@
 import React from "react";
 
 import type { Block } from "@/lib/viewModels/blockstore";
-import { cn } from "@/lib/utils";
 
 import { NestChildren } from "../BlockRenderer";
 import { EditableText } from "../editor/EditableText";
 import { useBlockstoreDispatch } from "../editor/useBlockstoreDispatch";
+import { SubPageLink } from "./SubPageLink";
 
 export function PageRenderer({ block, depth }: { block: Block; depth: number }) {
   const dispatch = useBlockstoreDispatch(block.workspace_id);
   const title = (block.data?.title as string | undefined) ?? "";
 
+  // A page nested inside another page is an independent document — render it as
+  // a navigable sub-page link, never inline its content (Notion semantics).
+  if (depth > 0) return <SubPageLink block={block} />;
+
   return (
-    <section className={cn("flex flex-col gap-3", depth === 0 && "py-6")}>
+    <section className="flex flex-col gap-3 py-6">
       <EditableText
-        className={cn(
-          "outline-none",
-          depth === 0 ? "text-3xl font-bold tracking-tight" : "text-lg font-semibold",
-        )}
-        placeholder={depth === 0 ? "Untitled page" : "Subpage"}
+        className="text-3xl font-bold tracking-tight outline-none"
+        placeholder="Untitled page"
         value={title}
         onChange={(next) => {
           dispatch.updateBlockData(block.id, { title: next });

--- a/clients/web/src/components/blocks/renderers/SubPageLink.tsx
+++ b/clients/web/src/components/blocks/renderers/SubPageLink.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import React from "react";
+import { FileText } from "lucide-react";
+
+import type { Block } from "@/lib/viewModels/blockstore";
+import { pageDisplayMeta } from "@/lib/blockstore/pageDisplayMeta";
+import { useSelectPage } from "@/lib/blockstore/useSelectPage";
+
+import { BlockChrome } from "../editor/BlockChrome";
+import { useBlockstoreDispatch } from "../editor/useBlockstoreDispatch";
+
+export function SubPageLink({ block }: { block: Block }) {
+  const dispatch = useBlockstoreDispatch(block.workspace_id);
+  const selectPage = useSelectPage();
+
+  const { title, icon } = pageDisplayMeta(block);
+
+  const handleDelete = () => {
+    void dispatch.detachChild(block.id);
+    void dispatch.removeBlock(block.id);
+  };
+
+  return (
+    <BlockChrome
+      className="pl-1"
+      blockID={block.id}
+      onDelete={handleDelete}
+      onDuplicate={() => void dispatch.duplicate(block.id)}
+      onToggleVisibility={(next) => void dispatch.setBlockVisibility(block.id, next)}
+    >
+      <button
+        type="button"
+        onClick={() => selectPage(block.id)}
+        data-testid={`blocks-subpage-link-${block.id}`}
+        className="inline-flex items-center gap-1.5 rounded px-1 py-0.5 text-left text-sm font-medium text-foreground hover:bg-muted/50"
+      >
+        <span aria-hidden="true" className="flex-shrink-0 text-muted-foreground">
+          {icon ?? <FileText className="inline h-4 w-4" />}
+        </span>
+        <span className="truncate underline decoration-muted-foreground/40 underline-offset-2">
+          {title}
+        </span>
+      </button>
+    </BlockChrome>
+  );
+}

--- a/clients/web/src/lib/blockstore/findOwnerPage.test.ts
+++ b/clients/web/src/lib/blockstore/findOwnerPage.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { BLOCK_TYPE_PAGE, type Block, type BlockRef } from "@/lib/viewModels/blockstore";
+
+import { findOwnerPage } from "./findOwnerPage";
+
+function blk(id: string, type: string): Block {
+  return { id, type } as unknown as Block;
+}
+function ref(id: number, from: string, to: string): BlockRef {
+  return { id, from_id: from, to_id: to, rel: "nest" } as unknown as BlockRef;
+}
+
+const blocks = {
+  root: blk("root", BLOCK_TYPE_PAGE),
+  sub: blk("sub", BLOCK_TYPE_PAGE),
+  para: blk("para", "paragraph"),
+  toggle: blk("toggle", "toggle"),
+  deep: blk("deep", "paragraph"),
+};
+const refs = {
+  1: ref(1, "root", "sub"),
+  2: ref(2, "root", "toggle"),
+  3: ref(3, "toggle", "para"),
+  4: ref(4, "sub", "deep"),
+};
+const nest = { root: [1, 2], toggle: [3], sub: [4] };
+
+describe("findOwnerPage", () => {
+  it("returns the page itself when the target is a page", () => {
+    expect(findOwnerPage("sub", blocks, refs, nest)).toBe("sub");
+    expect(findOwnerPage("root", blocks, refs, nest)).toBe("root");
+  });
+
+  it("returns the nearest page ancestor for a nested non-page block", () => {
+    expect(findOwnerPage("para", blocks, refs, nest)).toBe("root");
+  });
+
+  it("stops at the nearest sub-page, not the root", () => {
+    expect(findOwnerPage("deep", blocks, refs, nest)).toBe("sub");
+  });
+
+  it("returns null for an orphan non-page block", () => {
+    expect(findOwnerPage("ghost", blocks, refs, nest)).toBeNull();
+  });
+});

--- a/clients/web/src/lib/blockstore/findOwnerPage.ts
+++ b/clients/web/src/lib/blockstore/findOwnerPage.ts
@@ -1,0 +1,35 @@
+import { BLOCK_TYPE_PAGE, type Block, type BlockRef } from "@/lib/viewModels/blockstore";
+
+// Walk the nest tree upward from blockID to the nearest page ancestor — the page
+// that actually renders blockID in its DOM (sub-pages render as links, so a block
+// only lives in the DOM of its closest page ancestor). A page target owns itself.
+export function findOwnerPage(
+  blockID: string,
+  blocks: Record<string, Block>,
+  refs: Record<number, BlockRef>,
+  nestChildren: Record<string, number[]>,
+): string | null {
+  const parentOf = buildParentIndex(refs, nestChildren);
+  const seen = new Set<string>();
+  let current: string | undefined = blockID;
+  while (current && !seen.has(current)) {
+    seen.add(current);
+    if (blocks[current]?.type === BLOCK_TYPE_PAGE) return current;
+    current = parentOf[current];
+  }
+  return null;
+}
+
+function buildParentIndex(
+  refs: Record<number, BlockRef>,
+  nestChildren: Record<string, number[]>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [parentID, refIDs] of Object.entries(nestChildren)) {
+    for (const rid of refIDs) {
+      const childID = refs[rid]?.to_id;
+      if (childID && !(childID in out)) out[childID] = parentID;
+    }
+  }
+  return out;
+}

--- a/clients/web/src/lib/blockstore/page-tree.ts
+++ b/clients/web/src/lib/blockstore/page-tree.ts
@@ -1,5 +1,7 @@
 import { BLOCK_TYPE_PAGE, type Block, type BlockRef } from "@/lib/viewModels/blockstore";
 
+import { pageDisplayMeta } from "./pageDisplayMeta";
+
 export interface PageNode {
   id: string;
   title: string;
@@ -54,24 +56,13 @@ function buildOne(
 ): PageNode | null {
   const block = blocks[id];
   if (!block || block.type !== BLOCK_TYPE_PAGE) return null;
+  const meta = pageDisplayMeta(block);
   return {
     id,
-    title: titleOf(block),
-    icon: iconOf(block),
+    title: meta.title,
+    icon: meta.icon,
     children: childPages(blocks, refs, nestChildren, id),
   };
-}
-
-function titleOf(block: Block): string {
-  const t = block.data?.title;
-  if (typeof t === "string" && t.trim()) return t;
-  if (block.text && block.text.trim()) return block.text;
-  return "Untitled";
-}
-
-function iconOf(block: Block): string | undefined {
-  const icon = block.data?.icon;
-  return typeof icon === "string" ? icon : undefined;
 }
 
 export function countByType(

--- a/clients/web/src/lib/blockstore/pageDisplayMeta.test.ts
+++ b/clients/web/src/lib/blockstore/pageDisplayMeta.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import type { Block } from "@/lib/viewModels/blockstore";
+
+import { pageDisplayMeta } from "./pageDisplayMeta";
+
+function block(data: Record<string, unknown>, text: string | null = null): Block {
+  return { data, text } as unknown as Block;
+}
+
+describe("pageDisplayMeta", () => {
+  it("returns Untitled for a missing block", () => {
+    expect(pageDisplayMeta(undefined)).toEqual({ title: "Untitled" });
+    expect(pageDisplayMeta(null)).toEqual({ title: "Untitled" });
+  });
+
+  it("prefers trimmed data.title", () => {
+    expect(pageDisplayMeta(block({ title: "  Hello  " })).title).toBe("Hello");
+  });
+
+  it("falls back to trimmed text when title is blank", () => {
+    expect(pageDisplayMeta(block({ title: "   " }, "  Body  ")).title).toBe("Body");
+  });
+
+  it("falls back to Untitled when both are blank", () => {
+    expect(pageDisplayMeta(block({}, "   ")).title).toBe("Untitled");
+  });
+
+  it("extracts a string icon and ignores non-string icons", () => {
+    expect(pageDisplayMeta(block({ title: "X", icon: "📈" })).icon).toBe("📈");
+    expect(pageDisplayMeta(block({ title: "X", icon: 42 })).icon).toBeUndefined();
+  });
+});

--- a/clients/web/src/lib/blockstore/pageDisplayMeta.ts
+++ b/clients/web/src/lib/blockstore/pageDisplayMeta.ts
@@ -1,0 +1,11 @@
+import type { Block } from "@/lib/viewModels/blockstore";
+
+export function pageDisplayMeta(
+  block: Block | null | undefined,
+): { title: string; icon?: string } {
+  if (!block) return { title: "Untitled" };
+  const fromTitle = typeof block.data?.title === "string" ? block.data.title.trim() : "";
+  const fromText = block.text?.trim() ?? "";
+  const icon = typeof block.data?.icon === "string" ? block.data.icon : undefined;
+  return { title: fromTitle || fromText || "Untitled", icon };
+}

--- a/clients/web/src/lib/blockstore/pageQuery.test.ts
+++ b/clients/web/src/lib/blockstore/pageQuery.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPageQuery } from "./pageQuery";
+
+describe("buildPageQuery", () => {
+  it("sets the page param when selecting a sub-page", () => {
+    expect(buildPageQuery(new URLSearchParams(""), "p1", "root")).toBe("?page=p1");
+  });
+
+  it("clears the page param when selecting the root", () => {
+    expect(buildPageQuery(new URLSearchParams("page=p1"), "root", "root")).toBe("?");
+  });
+
+  it("preserves unrelated params", () => {
+    expect(buildPageQuery(new URLSearchParams("ws=w1"), "p2", "root")).toBe("?ws=w1&page=p2");
+  });
+
+  it("replaces an existing page param", () => {
+    expect(buildPageQuery(new URLSearchParams("page=p1"), "p2", "root")).toBe("?page=p2");
+  });
+});

--- a/clients/web/src/lib/blockstore/pageQuery.ts
+++ b/clients/web/src/lib/blockstore/pageQuery.ts
@@ -1,0 +1,11 @@
+export function buildPageQuery(
+  current: URLSearchParams,
+  pageID: string,
+  rootBlockID: string | null,
+): string {
+  const next = new URLSearchParams(Array.from(current.entries()));
+  if (pageID === rootBlockID) next.delete("page");
+  else next.set("page", pageID);
+  const qs = next.toString();
+  return qs ? `?${qs}` : "?";
+}

--- a/clients/web/src/lib/blockstore/useJumpToBlock.ts
+++ b/clients/web/src/lib/blockstore/useJumpToBlock.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useCallback } from "react";
+import { useSearchParams } from "next/navigation";
+
+import {
+  readBlocks,
+  readNestChildren,
+  readRefs,
+  useBlockstoreStore,
+  useWorkspace,
+} from "@/stores/blockstore";
+
+import { findOwnerPage } from "./findOwnerPage";
+import { useSelectPage } from "./useSelectPage";
+
+export function useJumpToBlock(): (blockID: string) => void {
+  const selectPage = useSelectPage();
+  const searchParams = useSearchParams();
+  const activeWorkspaceId = useBlockstoreStore((s) => s.activeWorkspaceId);
+  const rootBlockID = useWorkspace(activeWorkspaceId)?.root_block_id ?? null;
+
+  return useCallback(
+    (blockID: string) => {
+      const owner =
+        findOwnerPage(blockID, readBlocks(), readRefs(), readNestChildren()) ?? rootBlockID;
+      const currentPage = searchParams.get("page") ?? rootBlockID;
+      if (owner && owner !== currentPage) selectPage(owner);
+      scrollToBlockWhenReady(blockID);
+    },
+    [selectPage, searchParams, rootBlockID],
+  );
+}
+
+// After a cross-page jump the target only enters the DOM once the new page
+// commits, so poll a bounded number of frames rather than scrolling eagerly.
+function scrollToBlockWhenReady(blockID: string, attempts = 60): void {
+  const el = document.getElementById(`block-${blockID}`);
+  if (el) {
+    el.scrollIntoView({ behavior: "smooth", block: "center" });
+    el.classList.add("ring-2", "ring-primary");
+    setTimeout(() => el.classList.remove("ring-2", "ring-primary"), 1500);
+    return;
+  }
+  if (attempts <= 0) return;
+  requestAnimationFrame(() => scrollToBlockWhenReady(blockID, attempts - 1));
+}

--- a/clients/web/src/lib/blockstore/useSelectPage.ts
+++ b/clients/web/src/lib/blockstore/useSelectPage.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useCallback } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { useBlockstoreStore, useWorkspace } from "@/stores/blockstore";
+
+import { buildPageQuery } from "./pageQuery";
+
+export function useSelectPage(): (pageID: string) => void {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const activeWorkspaceId = useBlockstoreStore((s) => s.activeWorkspaceId);
+  const rootBlockID = useWorkspace(activeWorkspaceId)?.root_block_id ?? null;
+
+  return useCallback(
+    (pageID: string) => {
+      router.replace(buildPageQuery(searchParams, pageID, rootBlockID));
+    },
+    [router, searchParams, rootBlockID],
+  );
+}


### PR DESCRIPTION
## 问题

Blocks(Notion 式页面编辑器)中,父页面会把所有子页面(sub-page)的**完整内容**(图表、章节等)内联渲染在正文里。子页面本应是独立文档,只该显示为可导航的链接。

## 修复

**单一收口点** — 所有 `depth>0` 的 page 块都经 `PageRenderer` 路由到新的 `SubPageLink`,渲染为可点击链接并作为独立页面打开。`PageRenderer` 仅被 `BlockRenderer` 实例化,所有容器块的 page 子节点必经此处,一处判 depth 覆盖全部嵌套场景。

## 随附的架构整改(arch_check)

- **W1 page-aware 跳转**:`useJumpToBlock` + `findOwnerPage` 先导航到目标 block 所属的 page 再滚动。子页面内容不再内联后,裸 `scrollIntoView` 对跨页 block 会静默失效——此修复消除该回归(`LinkToPageRenderer` / `SearchPanel` 跳转统一收敛)。
- **W2 pageDisplayMeta 收敛**:title/icon 派生从 4 处散落(trim 语义不一致)统一为单一纯函数。
- **I2 面包屑死按钮**:根面包屑在无 `onNavigateRoot` 时退化为 span,不再"看似可点实则无反应"。

## 跨端

`useSelectPage` 用 `next/navigation`,desktop 经 vite alias → react-router shim,web + desktop 共用同一份 web 源。desktop `BlocksPage.tsx` 与 web `page.tsx` 对称接线。

## 验证

四项 bazel 门全绿:
- `//clients/web:src_typecheck_test`(真类型门)
- `//clients/web:lint`
- `//clients/web:unit`(含新增 pageDisplayMeta / findOwnerPage / pageQuery 测试)
- `//clients/desktop:out`(验证 @/ 与 next/navigation alias 两端解析)