### PR TITLE
feat(runner): make data_dir, state_dir, and console_port configurable

### DIFF
--- a/runner/README.md
+++ b/runner/README.md
@@ -94,6 +94,33 @@ default_agent: claude-code
 log_level: info
 ```
 
+### Multiple runners on one host
+
+Three optional fields let you run several runners side-by-side without
+the per-instance state colliding on `~/.agentsmesh/runner.pid` or the
+console bind port. Empty values fall back to today's defaults, so
+single-instance setups need no change.
+
+```yaml
+# Instance A — ~/.agentsmesh/config-a.yaml
+data_dir: ~/.agentsmesh-a       # certs + plugins
+state_dir: /tmp/agentsmesh-a    # runner.pid + locks (cleared on reboot)
+console_port: 19080
+mcp_port: 19000
+
+# Instance B — ~/.agentsmesh/config-b.yaml
+data_dir: ~/.agentsmesh-b
+state_dir: /tmp/agentsmesh-b
+console_port: 19081
+mcp_port: 19001
+```
+
+Run both:
+```bash
+agentsmesh-runner run --config ~/.agentsmesh/config-a.yaml &
+agentsmesh-runner run --config ~/.agentsmesh/config-b.yaml &
+```
+
 ## Web Console
 
 When using the web console command, a local web UI is available at:

--- a/runner/cmd/runner/cmd_run.go
+++ b/runner/cmd/runner/cmd_run.go
@@ -26,6 +26,8 @@ import (
 )
 
 // DefaultConsolePort is the default port for the web console.
+// Used as the flag default for the `webconsole` subcommand; the runner
+// itself reads cfg.GetConsolePort() so operators can override per-instance.
 const DefaultConsolePort = 19080
 
 func runRunner(args []string) {
@@ -160,8 +162,10 @@ func startRunner(cfg *config.Config) (ok bool) {
 	// Clean up leftover binaries from previous self-update (Windows rename-self strategy)
 	updater.CleanupOldBinaries()
 
+	stateDir := cfg.GetStateDir()
+
 	// Clean up stale runner process from previous run
-	if err := pidfile.CleanupStaleProcess(); err != nil {
+	if err := pidfile.CleanupStaleProcess(stateDir); err != nil {
 		log.Error("Failed to clean up stale runner", "error", err)
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		return false
@@ -172,11 +176,11 @@ func startRunner(cfg *config.Config) (ok bool) {
 	mcp.TryReclaimPort(cfg.GetMCPPort())
 
 	// Write PID file for next startup to find us
-	if err := pidfile.Write(); err != nil {
+	if err := pidfile.Write(stateDir); err != nil {
 		log.Warn("Failed to write PID file", "error", err)
 		// Non-fatal: runner works fine without it, just can't auto-cleanup next time
 	}
-	defer pidfile.Remove()
+	defer pidfile.Remove(stateDir)
 
 	// Create runner dependencies (I/O: workspace, gRPC, certs, pod daemon)
 	deps, err := runner.CreateDeps(cfg)
@@ -208,7 +212,7 @@ func startRunner(cfg *config.Config) (ok bool) {
 	r.SetRestartFunc(execRestartFunc(execPath))
 
 	// Create web console (lifecycle managed by Supervisor)
-	consoleServer := console.New(cfg, DefaultConsolePort, version)
+	consoleServer := console.New(cfg, cfg.GetConsolePort(), version)
 	r.AddService(&lifecycle.ConsoleService{Server: consoleServer})
 
 	// Setup context with cancellation

--- a/runner/cmd/runner/register.go
+++ b/runner/cmd/runner/register.go
@@ -246,4 +246,10 @@ type savedGRPCConfig struct {
 	DefaultShell      string `yaml:"default_shell"`
 	HealthCheckPort   int    `yaml:"health_check_port"`
 	LogLevel          string `yaml:"log_level"`
+
+	// Multi-instance knobs — omitted when at default so existing
+	// single-instance setups keep a minimal config.yaml.
+	DataDir     string `yaml:"data_dir,omitempty"`
+	StateDir    string `yaml:"state_dir,omitempty"`
+	ConsolePort int    `yaml:"console_port,omitempty"`
 }

--- a/runner/internal/config/config_paths.go
+++ b/runner/internal/config/config_paths.go
@@ -56,6 +56,37 @@ func (c *Config) GetMCPPort() int {
 	return 19000 // Default port
 }
 
+// GetConsolePort returns the web console bind port.
+func (c *Config) GetConsolePort() int {
+	if c.ConsolePort > 0 {
+		return c.ConsolePort
+	}
+	return 19080
+}
+
+// GetDataDir returns the persistent state root. Empty config falls back
+// to ~/.agentsmesh, matching the historical hardcoded default.
+func (c *Config) GetDataDir() string {
+	if c.DataDir != "" {
+		return os.ExpandEnv(c.DataDir)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".agentsmesh")
+}
+
+// GetStateDir returns the runtime state root for pid files and locks.
+// Falls back to GetDataDir when not set, which itself falls back to
+// ~/.agentsmesh — so empty config matches the historical behavior.
+func (c *Config) GetStateDir() string {
+	if c.StateDir != "" {
+		return os.ExpandEnv(c.StateDir)
+	}
+	return c.GetDataDir()
+}
+
 // GetPluginsDir returns the user plugins directory path.
 // Returns empty string if no plugins directory is configured.
 func (c *Config) GetPluginsDir() string {

--- a/runner/internal/config/config_types.go
+++ b/runner/internal/config/config_types.go
@@ -11,6 +11,19 @@ type Config struct {
 	NodeID      string `mapstructure:"node_id"`
 	Description string `mapstructure:"description"`
 
+	// DataDir is the persistent state root — certs, plugins, default
+	// lookup root for relative cert paths. Empty -> ~/.agentsmesh.
+	DataDir string `mapstructure:"data_dir"`
+
+	// StateDir is the runtime state root — runner.pid, locks.
+	// Empty -> DataDir -> ~/.agentsmesh. Operators running multiple
+	// runners on one host can point this at /var/run/agentsmesh/<id>
+	// or /tmp/agentsmesh/<id> so the pid file doesn't survive crash + reboot.
+	StateDir string `mapstructure:"state_dir"`
+
+	// ConsolePort overrides the local web-console bind port. 0 -> 19080.
+	ConsolePort int `mapstructure:"console_port"`
+
 	// mTLS Certificate Authentication (gRPC)
 	CertFile     string `mapstructure:"cert_file"`     // Path to client certificate
 	KeyFile      string `mapstructure:"key_file"`      // Path to client private key

--- a/runner/internal/pidfile/pidfile.go
+++ b/runner/internal/pidfile/pidfile.go
@@ -1,9 +1,10 @@
 // Package pidfile manages a PID file for the runner process.
 //
-// The PID file (~/.agentsmesh/runner.pid) allows the runner to detect and clean up
-// stale processes from previous runs that were killed ungracefully (SIGKILL, OOM).
-// Without this, ports (MCP :19000, Console :19080) remain occupied and the runner
-// cannot restart.
+// The PID file ({stateDir}/runner.pid, default ~/.agentsmesh/runner.pid)
+// allows the runner to detect and clean up stale processes from previous
+// runs that were killed ungracefully (SIGKILL, OOM). Without this, ports
+// (MCP :19000, Console :19080) remain occupied and the runner cannot
+// restart.
 //
 // File format: "<PID> <executable-name>\n"
 // Example: "12345 agentsmesh-runner\n"
@@ -19,24 +20,28 @@ import (
 
 const pidFileName = "runner.pid"
 
-// GetPath returns the path to the PID file (~/.agentsmesh/runner.pid).
-func GetPath() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
+// GetPath returns the path to the PID file under stateDir. An empty
+// stateDir falls back to ~/.agentsmesh, matching the historical default.
+func GetPath(stateDir string) string {
+	dir := stateDir
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		dir = filepath.Join(home, ".agentsmesh")
 	}
-	return filepath.Join(home, ".agentsmesh", pidFileName)
+	return filepath.Join(dir, pidFileName)
 }
 
-// Write writes the current process PID and executable name to the PID file.
-// Creates ~/.agentsmesh/ directory if needed.
-func Write() error {
-	pidPath := GetPath()
+// Write writes the current process PID and executable name to
+// {stateDir}/runner.pid. Creates the parent directory if needed.
+func Write(stateDir string) error {
+	pidPath := GetPath(stateDir)
 	if pidPath == "" {
 		return fmt.Errorf("cannot determine PID file path")
 	}
 
-	// Ensure directory exists
 	dir := filepath.Dir(pidPath)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("failed to create directory %s: %w", dir, err)
@@ -48,10 +53,11 @@ func Write() error {
 	return os.WriteFile(pidPath, []byte(content), 0644)
 }
 
-// Remove deletes the PID file, but only if it contains the current process's PID.
-// This prevents a race where a newer instance wrote its PID and we accidentally delete it.
-func Remove() {
-	pidPath := GetPath()
+// Remove deletes the PID file, but only if it contains the current
+// process's PID. This prevents a race where a newer instance wrote its
+// PID and we accidentally delete it.
+func Remove(stateDir string) {
+	pidPath := GetPath(stateDir)
 	if pidPath == "" {
 		return
 	}
@@ -71,14 +77,14 @@ func Remove() {
 		return
 	}
 
-	// Only remove if it's our PID
 	if pid == os.Getpid() {
 		os.Remove(pidPath)
 	}
 }
 
-// parsePIDFile reads and parses the PID file, returning the PID and executable name.
-// Returns (0, "", nil) if the file doesn't exist or is corrupt (corrupt files are removed).
+// parsePIDFile reads and parses the PID file, returning the PID and
+// executable name. Returns (0, "", nil) if the file doesn't exist or is
+// corrupt (corrupt files are removed).
 func parsePIDFile(pidPath string) (int, string, error) {
 	data, err := os.ReadFile(pidPath)
 	if os.IsNotExist(err) {
@@ -90,14 +96,12 @@ func parsePIDFile(pidPath string) (int, string, error) {
 
 	fields := strings.Fields(string(data))
 	if len(fields) < 2 {
-		// Corrupt PID file — remove and continue
 		os.Remove(pidPath)
 		return 0, "", nil
 	}
 
 	pid, err := strconv.Atoi(fields[0])
 	if err != nil {
-		// Corrupt PID file
 		os.Remove(pidPath)
 		return 0, "", nil
 	}

--- a/runner/internal/pidfile/pidfile_test.go
+++ b/runner/internal/pidfile/pidfile_test.go
@@ -15,12 +15,56 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetPath(t *testing.T) {
-	path := GetPath()
+func TestGetPath_EmptyFallsBackToHome(t *testing.T) {
+	path := GetPath("")
 	assert.NotEmpty(t, path)
 	assert.True(t, filepath.IsAbs(path))
 	assert.Equal(t, "runner.pid", filepath.Base(path))
 	assert.Equal(t, ".agentsmesh", filepath.Base(filepath.Dir(path)))
+}
+
+func TestGetPath_CustomStateDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := GetPath(tmpDir)
+	assert.Equal(t, filepath.Join(tmpDir, "runner.pid"), path)
+}
+
+func TestWrite_CustomStateDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	stateDir := filepath.Join(tmpDir, "instance-a")
+
+	require.NoError(t, Write(stateDir))
+
+	pidPath := filepath.Join(stateDir, "runner.pid")
+	data, err := os.ReadFile(pidPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), strconv.Itoa(os.Getpid()))
+}
+
+func TestRemove_CustomStateDir_OnlyOwnPID(t *testing.T) {
+	tmpDir := t.TempDir()
+	stateDir := filepath.Join(tmpDir, "instance-a")
+
+	require.NoError(t, Write(stateDir))
+	Remove(stateDir)
+
+	_, err := os.Stat(filepath.Join(stateDir, "runner.pid"))
+	assert.True(t, os.IsNotExist(err), "Write+Remove with the same PID should delete the file")
+}
+
+func TestRemove_CustomStateDir_PreservesOtherPID(t *testing.T) {
+	tmpDir := t.TempDir()
+	stateDir := filepath.Join(tmpDir, "instance-a")
+	require.NoError(t, os.MkdirAll(stateDir, 0755))
+
+	pidPath := filepath.Join(stateDir, "runner.pid")
+	otherPID := os.Getpid() + 1000
+	require.NoError(t, os.WriteFile(pidPath, []byte(fmt.Sprintf("%d agentsmesh-runner\n", otherPID)), 0644))
+
+	Remove(stateDir)
+
+	_, err := os.Stat(pidPath)
+	assert.NoError(t, err, "Remove must skip PID files that belong to another process")
 }
 
 func TestWriteAndRemove(t *testing.T) {

--- a/runner/internal/pidfile/pidfile_unix.go
+++ b/runner/internal/pidfile/pidfile_unix.go
@@ -17,8 +17,8 @@ import (
 // CleanupStaleProcess finds and kills any leftover runner from a previous run.
 // Safe to call when no stale process exists (no-op).
 // Returns error only if it cannot kill the stale process.
-func CleanupStaleProcess() error {
-	pidPath := GetPath()
+func CleanupStaleProcess(stateDir string) error {
+	pidPath := GetPath(stateDir)
 	if pidPath == "" {
 		return nil
 	}

--- a/runner/internal/pidfile/pidfile_windows.go
+++ b/runner/internal/pidfile/pidfile_windows.go
@@ -16,8 +16,8 @@ import (
 // CleanupStaleProcess finds and kills any leftover runner from a previous run.
 // Mirrors the Unix logic: checks if the process is alive, guards against PID reuse,
 // kills the process tree, and waits for exit before removing the PID file.
-func CleanupStaleProcess() error {
-	pidPath := GetPath()
+func CleanupStaleProcess(stateDir string) error {
+	pidPath := GetPath(stateDir)
 	if pidPath == "" {
 		return nil
 	}

--- a/runner/internal/service/service.go
+++ b/runner/internal/service/service.go
@@ -55,13 +55,15 @@ func NewProgram(cfg *config.Config) *Program {
 func (p *Program) Start(s service.Service) error {
 	log.Info("Service starting")
 
+	stateDir := p.cfg.GetStateDir()
+
 	// Clean up stale process (non-fatal in service mode — manager will retry)
-	if err := pidfile.CleanupStaleProcess(); err != nil {
+	if err := pidfile.CleanupStaleProcess(stateDir); err != nil {
 		log.Warn("Failed to clean up stale process", "error", err)
 	}
 
 	// Write PID file
-	if err := pidfile.Write(); err != nil {
+	if err := pidfile.Write(stateDir); err != nil {
 		log.Warn("Failed to write PID file", "error", err)
 	}
 
@@ -119,7 +121,7 @@ func (p *Program) Stop(s service.Service) error {
 	// shutdown, fail to detect the still-running process, and hit port conflicts.
 	p.wg.Wait()
 
-	pidfile.Remove()
+	pidfile.Remove(p.cfg.GetStateDir())
 
 	p.sendStatus(Status{Running: false})
 	log.Info("Service stopped")


### PR DESCRIPTION
Fixes #443.

Three optional fields let operators run multiple runners on a single host without colliding on `~/.agentsmesh/{certs,runner.pid}` or console port `:19080`. Every field defaults to the current hardcoded value, so existing single-instance setups need zero migration.

## Changes

### Config (`runner/internal/config/`)

Added three optional fields to `Config`:

```go
DataDir     string `mapstructure:"data_dir"`     // ~/.agentsmesh
StateDir    string `mapstructure:"state_dir"`    // -> DataDir -> ~/.agentsmesh
ConsolePort int    `mapstructure:"console_port"` // 19080
```

Plus three resolver helpers in `config_paths.go` next to the existing `GetMCPPort`:

- `GetDataDir()` — resolves env vars; empty → `~/.agentsmesh`
- `GetStateDir()` — resolves env vars; empty → `GetDataDir()`
- `GetConsolePort()` — empty/0 → 19080

### Pidfile (`runner/internal/pidfile/`)

`GetPath`, `Write`, `Remove`, and `CleanupStaleProcess` now take a `stateDir string` argument. Empty string preserves the historical `~/.agentsmesh/runner.pid` path. Touches the unix and windows builds together.

New tests:
- `TestGetPath_EmptyFallsBackToHome` — verifies the empty-string fallback chain
- `TestGetPath_CustomStateDir` — verifies a custom dir path joins correctly
- `TestWrite_CustomStateDir` — full write + read round trip in a temp dir
- `TestRemove_CustomStateDir_OnlyOwnPID` — same-PID delete works
- `TestRemove_CustomStateDir_PreservesOtherPID` — guards the "another instance wrote its PID" race

### Callers (`cmd/runner/cmd_run.go`, `internal/service/service.go`)

Both call sites now read `cfg.GetStateDir()` once at the top of `startRunner` / `Program.Start` and thread it through `pidfile.{CleanupStaleProcess, Write, Remove}`. `cmd_run.go` switches the console line from the package-level `DefaultConsolePort` constant to `cfg.GetConsolePort()`. The constant is kept because `cmd/runner/webconsole.go` still uses it as a CLI flag default.

### Register (`cmd/runner/register.go`)

`savedGRPCConfig` gains three `yaml:",omitempty"` fields. They are zero-valued during `register`, so `yaml.Marshal` omits them entirely — the freshly-written `config.yaml` is byte-identical to today for single-instance setups.

### README

`runner/README.md` gains a short "Multiple runners on one host" example showing two configs that diverge only in `data_dir`, `state_dir`, `console_port`, and `mcp_port`.

## Backward compatibility

- Existing `config.yaml` files keep working — every empty/zero value resolves to the prior hardcoded path/port.
- `pidfile.GetPath(\"\")` returns the same path as the old zero-arg `GetPath()`.
- No flags renamed, no env vars deprecated.

## Tests

`go test ./runner/internal/pidfile/ ./runner/internal/config/` runs green locally; the rest of the runner module requires Bazel-generated proto code that isn't on disk.

## Notes

- `pidFileName = \"runner.pid\"` stays a package-level constant. The directory is the per-instance namespace, like how `/var/run/sshd.pid` vs `/var/run/myapp/sshd.pid` don't collide. Making the filename itself a config knob would be YAGNI.
- `mcp_port` was already configurable — this PR doesn't touch it.