### PR TITLE
refactor(tickets): relocate detail actions above Spawn Pod (TICKET-154)

### DIFF
--- a/clients/web/src/components/tickets/TicketDetail.tsx
+++ b/clients/web/src/components/tickets/TicketDetail.tsx
@@ -12,6 +12,7 @@ import { LabelsList, CommentsList, SubTicketsList, RelationsList, CommitsList } 
 import { TicketDetailSidebar } from "./TicketDetailSidebar";
 import { InlineEditableText } from "./InlineEditableText";
 import { StatusSelect } from "./StatusSelect";
+import { TicketOverflowMenu } from "./TicketOverflowMenu";
 
 const BlockEditor = lazy(() => import("@/components/ui/block-editor"));
 
@@ -137,82 +138,57 @@ export function TicketDetail({ slug }: TicketDetailProps) {
     <div className="flex flex-col lg:flex-row gap-6 lg:gap-8">
       <div className="flex-1 min-w-0 space-y-6">
         <div className="border-b border-border pb-6">
-          <div className="flex items-start justify-between gap-6">
-            <div className="flex-1 min-w-0 space-y-3">
-              <div className="flex items-center gap-2.5">
-                <span className="font-mono text-[13px] text-muted-foreground">{slug}</span>
-                <StatusSelect value={currentTicket.status} onChange={handleStatusChange} showLabel size="sm" />
-              </div>
-              <InlineEditableText
-                value={currentTicket.title}
-                onSave={handleTitleSave}
-                placeholder={t("tickets.createDialog.titlePlaceholder")}
-                className="text-[22px] font-semibold leading-7 text-foreground"
-                inputClassName="text-[22px] font-semibold"
-              />
+          <div className="min-w-0 space-y-3">
+            <div className="flex items-center gap-2.5">
+              <span className="font-mono text-[13px] text-muted-foreground">{slug}</span>
+              <StatusSelect value={currentTicket.status} onChange={handleStatusChange} showLabel size="sm" />
+            </div>
+            <InlineEditableText
+              value={currentTicket.title}
+              onSave={handleTitleSave}
+              placeholder={t("tickets.createDialog.titlePlaceholder")}
+              className="text-[22px] font-semibold leading-7 text-foreground"
+              inputClassName="text-[22px] font-semibold"
+            />
 
-              <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-xs">
-                {currentTicket.repository && (
-                  <div className="flex items-center gap-1.5">
-                    <span className="text-muted-foreground">{t("tickets.detail.repository")}</span>
-                    <span className="font-mono font-medium text-foreground">
-                      {currentTicket.repository.name}
-                    </span>
-                  </div>
-                )}
-                {currentTicket.priority && (
-                  <div className="flex items-center gap-1.5">
-                    <span className="text-muted-foreground">{t("tickets.detail.priority")}</span>
-                    <span className="font-medium text-foreground">
-                      {t(`tickets.priority.${currentTicket.priority}`)}
-                    </span>
-                  </div>
-                )}
-                {currentTicket.due_date && (
-                  <div className="flex items-center gap-1.5">
-                    <span className="text-muted-foreground">{t("tickets.detail.dueDate")}</span>
-                    <span className="font-medium text-foreground">
-                      {new Date(currentTicket.due_date).toLocaleDateString()}
-                    </span>
-                  </div>
-                )}
-                {currentTicket.created_at && (
-                  <div className="flex items-center gap-1.5">
-                    <span className="text-muted-foreground">{t("tickets.detail.opened")}</span>
-                    <span className="text-foreground">
-                      {new Date(currentTicket.created_at).toLocaleDateString()}
-                    </span>
-                  </div>
-                )}
-              </div>
-
-              {currentTicket.labels && currentTicket.labels.length > 0 && (
-                <LabelsList labels={currentTicket.labels} compact />
+            <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-xs">
+              {currentTicket.repository && (
+                <div className="flex items-center gap-1.5">
+                  <span className="text-muted-foreground">{t("tickets.detail.repository")}</span>
+                  <span className="font-mono font-medium text-foreground">
+                    {currentTicket.repository.name}
+                  </span>
+                </div>
+              )}
+              {currentTicket.priority && (
+                <div className="flex items-center gap-1.5">
+                  <span className="text-muted-foreground">{t("tickets.detail.priority")}</span>
+                  <span className="font-medium text-foreground">
+                    {t(`tickets.priority.${currentTicket.priority}`)}
+                  </span>
+                </div>
+              )}
+              {currentTicket.due_date && (
+                <div className="flex items-center gap-1.5">
+                  <span className="text-muted-foreground">{t("tickets.detail.dueDate")}</span>
+                  <span className="font-medium text-foreground">
+                    {new Date(currentTicket.due_date).toLocaleDateString()}
+                  </span>
+                </div>
+              )}
+              {currentTicket.created_at && (
+                <div className="flex items-center gap-1.5">
+                  <span className="text-muted-foreground">{t("tickets.detail.opened")}</span>
+                  <span className="text-foreground">
+                    {new Date(currentTicket.created_at).toLocaleDateString()}
+                  </span>
+                </div>
               )}
             </div>
 
-            <div className="flex shrink-0 items-center gap-1.5">
-              <Button variant="outline" size="sm" className="h-7 px-3 text-xs">
-                {t("common.edit")}
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-7 px-3 text-xs"
-                onClick={() => handleStatusChange("done" as TicketStatus)}
-              >
-                {t("tickets.detail.markDone")}
-              </Button>
-              <Button
-                variant="outline"
-                size="icon"
-                className="h-7 w-7"
-                onClick={handleDelete}
-                aria-label={t("common.more")}
-              >
-                ⋯
-              </Button>
-            </div>
+            {currentTicket.labels && currentTicket.labels.length > 0 && (
+              <LabelsList labels={currentTicket.labels} compact />
+            )}
           </div>
         </div>
 
@@ -245,6 +221,7 @@ export function TicketDetail({ slug }: TicketDetailProps) {
         relations={relations}
         commits={commits}
         t={t}
+        actionsSlot={<TicketOverflowMenu onDelete={handleDelete} t={t} />}
         commentsSlot={
           <div className="lg:hidden">
             <CommentsList

--- a/clients/web/src/components/tickets/TicketDetailSidebar.tsx
+++ b/clients/web/src/components/tickets/TicketDetailSidebar.tsx
@@ -27,6 +27,7 @@ interface TicketDetailSidebarProps {
     url?: string;
   }>;
   t: (key: string, params?: Record<string, string | number>) => string;
+  actionsSlot?: React.ReactNode;
   commentsSlot?: React.ReactNode;
 }
 
@@ -37,6 +38,7 @@ export function TicketDetailSidebar({
   relations = [],
   commits = [],
   t,
+  actionsSlot,
   commentsSlot,
 }: TicketDetailSidebarProps) {
   const router = useRouter();
@@ -53,6 +55,7 @@ export function TicketDetailSidebar({
 
   return (
     <aside className="lg:w-80 shrink-0 space-y-4">
+      {actionsSlot && <div className="flex justify-end">{actionsSlot}</div>}
       <div className="space-y-1.5">
         <SpawnPodButton
           ticket={ticket}

--- a/clients/web/src/components/tickets/TicketOverflowMenu.tsx
+++ b/clients/web/src/components/tickets/TicketOverflowMenu.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+interface TicketOverflowMenuProps {
+  onDelete: () => void;
+  t: (key: string, params?: Record<string, string | number>) => string;
+}
+
+export function TicketOverflowMenu({ onDelete, t }: TicketOverflowMenuProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="icon" className="h-7 w-7" aria-label={t("common.more")}>
+          ⋯
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={onDelete} className="cursor-pointer text-destructive focus:text-destructive">
+          <Trash2 className="h-4 w-4" />
+          {t("common.delete")}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export default TicketOverflowMenu;


### PR DESCRIPTION
## What

On the Ticket Detail page, the header's top-right action cluster (编辑/Edit, 标记完成/Mark Done, ⋯) is removed, and the overflow control is relocated **above the Spawn Pod button** in the right sidebar as a proper "more actions" dropdown.

## Why

- **Edit** had no click handler — dead code. The title is already inline-editable and content auto-saves via the block editor.
- **Mark Done** was redundant: the header already has a `StatusSelect` dropdown next to the slug that sets any status (including Done). The user requested removing it rather than fixing it.
- **⋯** was a bare button wired straight to delete; it's now a real `DropdownMenu` with a **Delete** item ("more actions").

## Changes

- **New `TicketOverflowMenu.tsx`** — Radix dropdown (same primitives as `StatusSelect`) with a Delete item.
- **`TicketDetail.tsx`** — drop the header action cluster; pass `<TicketOverflowMenu>` to the sidebar via a new `actionsSlot` prop (mirrors the existing `commentsSlot` pattern, keeping delete logic + `ConfirmDialog` in `TicketDetail`).
- **`TicketDetailSidebar.tsx`** — add `actionsSlot`, rendered top-right above the Spawn Pod button.

No backend / Rust / proto changes — the status flow already worked end to end.

## Verification

- `bazel build //clients/web:src` (tsc) ✅
- `bazel test //clients/web:lint` ✅
- `bazel test //clients/web:unit` (1510 tests) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)