### PR TITLE
feat(ide): Lark-style layout polish — immersive window, floating cards, refined dialogs

### DIFF
--- a/clients/desktop/src/main/index.ts
+++ b/clients/desktop/src/main/index.ts
@@ -65,6 +65,8 @@ if (acquireSingleInstance()) {
 }
 
 function createWindow() {
+  const isMac = process.platform === "darwin";
+  const isWin = process.platform === "win32";
   const win = new BrowserWindow({
     width: 1280,
     height: 800,
@@ -74,6 +76,17 @@ function createWindow() {
     show: !isHeadlessTest,
     paintWhenInitiallyHidden: true,
     skipTaskbar: isHeadlessTest,
+    // Immersive titlebar: traffic lights float into the left rail's 52px top drag
+    // strip (renderer reserves it via --titlebar-drag-height). Linux keeps native frame.
+    ...(isMac
+      ? { titleBarStyle: "hiddenInset" as const, trafficLightPosition: { x: 14, y: 14 } }
+      : {}),
+    ...(isWin
+      ? {
+          titleBarStyle: "hidden" as const,
+          titleBarOverlay: { color: "#F6F8FA", symbolColor: "#656D76", height: 40 },
+        }
+      : {}),
     webPreferences: {
       preload: path.join(__dirname, "../preload/index.js"),
       contextIsolation: true,

--- a/clients/desktop/src/preload/index.ts
+++ b/clients/desktop/src/preload/index.ts
@@ -13,6 +13,7 @@ const serverConfigSnapshot = ipcRenderer.sendSync("serverConfig:getSync") as Ser
 
 const api = {
   apiUrl,
+  platform: process.platform,
   invoke: (channel: string, ...args: unknown[]) => ipcRenderer.invoke(channel, ...args),
   on: (channel: string, listener: (event: IpcRendererEvent, ...args: unknown[]) => void) => {
     ipcRenderer.on(channel, listener);

--- a/clients/desktop/src/renderer/globals.css
+++ b/clients/desktop/src/renderer/globals.css
@@ -26,6 +26,8 @@
   --border: #e5e5e5;
   --input: #e5e5e5;
   --ring: #0ea5e9;
+  --sidebar: #EBEBED;
+  --titlebar-drag-height: 0px;
 
   --terminal-bg: #1e1e1e;
   --terminal-bg-secondary: #252526;
@@ -58,6 +60,7 @@
   --border: #262626;
   --input: #262626;
   --ring: #22d3ee;
+  --sidebar: #141414;
 
   --terminal-bg: #1e1e1e;
   --terminal-bg-secondary: #252526;
@@ -90,6 +93,7 @@
   --border: #eee8d5;
   --input: #eee8d5;
   --ring: #268bd2;
+  --sidebar: #eee8d5;
 
   --terminal-bg: #002b36;
   --terminal-bg-secondary: #073642;
@@ -122,6 +126,7 @@
   --border: #073642;
   --input: #073642;
   --ring: #268bd2;
+  --sidebar: #073642;
 
   --terminal-bg: #002b36;
   --terminal-bg-secondary: #073642;
@@ -153,6 +158,7 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
+  --color-sidebar: var(--sidebar);
   --color-terminal-bg: var(--terminal-bg);
   --color-terminal-bg-secondary: var(--terminal-bg-secondary);
   --color-terminal-bg-hover: var(--terminal-bg-hover);
@@ -181,6 +187,25 @@ html:has(.app-shell),
 body:has(.app-shell) {
   height: 100%;
   overflow: hidden;
+}
+
+/* Immersive titlebar drag-region height — gated by platform class set in platform-init.ts */
+.platform-mac {
+  --titlebar-drag-height: 40px;
+}
+.platform-win {
+  --titlebar-drag-height: 40px;
+}
+.platform-linux {
+  --titlebar-drag-height: 0px;
+}
+
+/* Electron window drag regions */
+.app-drag {
+  -webkit-app-region: drag;
+}
+.app-no-drag {
+  -webkit-app-region: no-drag;
 }
 
 /* Typography prose — map to theme CSS variables */

--- a/clients/desktop/src/renderer/lib/platform-init.ts
+++ b/clients/desktop/src/renderer/lib/platform-init.ts
@@ -10,6 +10,7 @@ import { installRealtimeMirror } from "./realtime-mirror";
 // imports this module before React renders — so renderer console.warn/error
 // fans out via electronAPI.log → main core:log → Rust rolling file.
 installConsoleCapture();
+markDesktopPlatform();
 
 setPlatformInit(async () => {
   const provider = createElectronServiceProvider();
@@ -17,6 +18,17 @@ setPlatformInit(async () => {
   markServiceReady();
   installRealtimeMirror();
 });
+
+// Tag <html> so shared web components can gate desktop-only immersive-titlebar
+// spacing via CSS — web never runs this module, so --titlebar-drag-height stays 0.
+function markDesktopPlatform() {
+  const root = document.documentElement;
+  root.classList.add("platform-desktop");
+  const platform = window.electronAPI?.platform;
+  if (platform === "darwin") root.classList.add("platform-mac");
+  else if (platform === "win32") root.classList.add("platform-win");
+  else root.classList.add("platform-linux");
+}
 
 export function isElectron(): boolean {
   return typeof window !== "undefined" && !!(window as any).electronAPI;

--- a/clients/web/src/app/globals.css
+++ b/clients/web/src/app/globals.css
@@ -27,6 +27,8 @@
   --border-strong: #6E7681;
   --input: #D0D7DE;
   --ring: #0969DA;
+  --sidebar: #EBEDF0;
+  --titlebar-drag-height: 0px;
 
   /* Terminal colors (VS Code style for light theme) */
   --terminal-bg: #1e1e1e;
@@ -65,6 +67,7 @@
   --border-strong: #6E7681;
   --input: #30363D;
   --ring: #2F81F7;
+  --sidebar: #0B0E13;
 
   /* Terminal colors (VS Code style) */
   --terminal-bg: #1e1e1e;
@@ -98,6 +101,7 @@
   --border: #eee8d5;
   --input: #eee8d5;
   --ring: #268bd2;
+  --sidebar: #eee8d5;
 
   /* Terminal colors (Solarized Dark style for terminal) */
   --terminal-bg: #002b36;
@@ -131,6 +135,7 @@
   --border: #073642;
   --input: #073642;
   --ring: #268bd2;
+  --sidebar: #073642;
 
   /* Terminal colors (Solarized Dark style) */
   --terminal-bg: #002b36;
@@ -168,6 +173,7 @@
   --color-border-strong: var(--border-strong);
   --color-input: var(--input);
   --color-ring: var(--ring);
+  --color-sidebar: var(--sidebar);
   /* Terminal colors */
   --color-terminal-bg: var(--terminal-bg);
   --color-terminal-bg-secondary: var(--terminal-bg-secondary);
@@ -236,6 +242,14 @@ html:has(.app-shell),
 body:has(.app-shell) {
   height: 100%;
   overflow: hidden;
+}
+
+/* Electron window drag regions — no-op in browser (Tailwind can't express -webkit-app-region) */
+.app-drag {
+  -webkit-app-region: drag;
+}
+.app-no-drag {
+  -webkit-app-region: no-drag;
 }
 
 /* Fix for iOS Safari viewport height - only for app shell pages */

--- a/clients/web/src/components/ide/ActivityBar.tsx
+++ b/clients/web/src/components/ide/ActivityBar.tsx
@@ -106,15 +106,15 @@ export function ActivityBar({ className }: ActivityBarProps) {
     <TooltipProvider delayDuration={300}>
       <aside
         className={cn(
-          "w-[136px] bg-background border-r border-border flex flex-col",
+          "w-[136px] bg-sidebar flex flex-col",
           className
         )}
       >
-        <div className="flex h-12 items-center justify-start px-2 border-b border-border">
+        <div className="app-drag flex h-12 items-center justify-start px-2">
           <OrgSwitcher />
         </div>
 
-        <nav className="flex-1 flex flex-col items-stretch py-2 gap-0.5 px-2">
+        <nav className="flex-1 flex flex-col items-stretch py-3 gap-1 px-2.5">
           {mainActivities.map((activity, idx) => {
             const Icon = ICON_MAP[activity.icon] || Terminal;
             const isActive = activeActivity === activity.id;
@@ -126,23 +126,20 @@ export function ActivityBar({ className }: ActivityBarProps) {
             return (
               <React.Fragment key={activity.id}>
                 {showDivider && (
-                  <div className="my-1 h-px w-full bg-border" aria-hidden="true" />
+                  <div className="my-1 h-px w-full bg-border/60" aria-hidden="true" />
                 )}
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Link
                       href={getActivityRoute(activity.id)}
                       className={cn(
-                        "w-full h-9 px-2 flex items-center gap-2 rounded-md transition-colors relative",
+                        "w-full h-9 px-2 flex items-center gap-2 rounded-md transition-colors",
                         isActive
-                          ? "text-foreground bg-muted"
-                          : "text-muted-foreground hover:text-foreground hover:bg-muted/60",
+                          ? "bg-accent text-accent-foreground"
+                          : "text-muted-foreground hover:text-foreground hover:bg-foreground/[0.06]",
                       )}
                       onClick={() => setActiveActivity(activity.id)}
                     >
-                      {isActive && (
-                        <div className="absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-5 bg-primary rounded-r" />
-                      )}
                       <div className="relative shrink-0">
                         <Icon className="w-4 h-4" />
                         {showBadge && (
@@ -172,14 +169,14 @@ export function ActivityBar({ className }: ActivityBarProps) {
 
         <ReminderArea />
 
-        <nav className="flex flex-col items-stretch py-2 gap-0.5 px-2 border-t border-border">
+        <nav className="flex flex-col items-stretch py-2 gap-1 px-2.5 border-t border-border/60">
           <Tooltip>
             <TooltipTrigger asChild>
               <a
                 href="https://discord.gg/3RcX7VBbH9"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="w-full h-9 px-2 flex items-center gap-2 rounded-md transition-colors text-muted-foreground hover:text-foreground hover:bg-muted/60"
+                className="w-full h-9 px-2 flex items-center gap-2 rounded-md transition-colors text-muted-foreground hover:text-foreground hover:bg-foreground/[0.06]"
               >
                 <CircleHelp className="w-4 h-4 shrink-0" />
                 <span className="text-xs leading-tight font-medium truncate">
@@ -207,16 +204,13 @@ export function ActivityBar({ className }: ActivityBarProps) {
                   <Link
                     href={getActivityRoute(activity.id)}
                     className={cn(
-                      "w-full h-9 px-2 flex items-center gap-2 rounded-md transition-colors relative",
+                      "w-full h-9 px-2 flex items-center gap-2 rounded-md transition-colors",
                       isActive
-                        ? "text-foreground bg-muted"
-                        : "text-muted-foreground hover:text-foreground hover:bg-muted/60"
+                        ? "bg-accent text-accent-foreground"
+                        : "text-muted-foreground hover:text-foreground hover:bg-foreground/[0.06]"
                     )}
                     onClick={() => setActiveActivity(activity.id)}
                   >
-                    {isActive && (
-                      <div className="absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-5 bg-primary rounded-r" />
-                    )}
                     <Icon className="w-4 h-4 shrink-0" />
                     <span className="text-xs leading-tight font-medium truncate">
                       {t(`ide.activities.${activity.id}`)}

--- a/clients/web/src/components/ide/IDEShell.tsx
+++ b/clients/web/src/components/ide/IDEShell.tsx
@@ -9,23 +9,19 @@ import { SideBar } from "./SideBar";
 import { BottomPanel } from "./BottomPanel";
 import { CommandPalette } from "./CommandPalette";
 import { CreatePodModal } from "./CreatePodModal";
-import { WorkspaceSidebarContent } from "./sidebar/WorkspaceSidebarContent";
-import { TicketsSidebarContent } from "./sidebar/TicketsSidebarContent";
-import { RepositoriesSidebarContent } from "./sidebar/RepositoriesSidebarContent";
-import { RunnersSidebarContent } from "./sidebar/RunnersSidebarContent";
-import { InfraSidebarContent } from "./sidebar/InfraSidebarContent";
-import { MeshSidebarContent } from "./sidebar/MeshSidebarContent";
-import { ChannelsSidebarContent } from "./sidebar/ChannelsSidebarContent";
-import { LoopsSidebarContent } from "./sidebar/LoopsSidebarContent";
-import { SettingsSidebarContent } from "./sidebar/SettingsSidebarContent";
-import { BlocksSidebar } from "@/components/blocks/BlocksSidebar";
-import { useIDEStore, type ActivityType } from "@/stores/ide";
+import { getSidebarContent, type SidebarCallbacks } from "./sidebarContentResolver";
+import { useIDEStore } from "@/stores/ide";
 import { useWorkspaceStore } from "@/stores/workspace";
 import { usePodStore } from "@/stores/pod";
 import { toast } from "sonner";
 import { getPodDisplayName } from "@/lib/pod-display-name";
 import { AddRunnerModal } from "./modals/AddRunnerModal";
 import { ImportRepositoryModal } from "./modals/ImportRepositoryModal";
+import { CreateChannelDialog } from "@/components/channel";
+import { useChannelStore } from "@/stores/channel";
+import { Button } from "@/components/ui/button";
+import { Plus } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 interface IDEShellProps {
   children: React.ReactNode;
@@ -33,59 +29,21 @@ interface IDEShellProps {
   className?: string;
 }
 
-interface SidebarCallbacks {
-  onCreatePod?: () => void;
-  onAddRunner?: () => void;
-  onImportRepo?: () => void;
-}
-
-function getSidebarContent(
-  activity: ActivityType,
-  callbacks: SidebarCallbacks
-): React.ReactNode {
-  switch (activity) {
-    case "workspace":
-      return <WorkspaceSidebarContent onCreatePod={callbacks.onCreatePod} />;
-    case "tickets":
-      return <TicketsSidebarContent />;
-    case "channels":
-      return <ChannelsSidebarContent />;
-    case "mesh":
-      return <MeshSidebarContent />;
-    case "loops":
-      return <LoopsSidebarContent />;
-    case "blocks":
-      return <BlocksSidebar />;
-    case "infra":
-      return (
-        <InfraSidebarContent
-          onImportRepo={callbacks.onImportRepo}
-          onAddRunner={callbacks.onAddRunner}
-        />
-      );
-    case "repositories":
-      return <RepositoriesSidebarContent onImportRepo={callbacks.onImportRepo} />;
-    case "runners":
-      return <RunnersSidebarContent onAddRunner={callbacks.onAddRunner} />;
-    case "settings":
-      return <SettingsSidebarContent />;
-    default:
-      return null;
-  }
-}
-
 export function IDEShell({
   children,
   sidebarContent,
   className,
 }: IDEShellProps) {
+  const t = useTranslations();
   const bottomPanelOpen = useIDEStore((state) => state.bottomPanelOpen);
   const activeActivity = useIDEStore((state) => state.activeActivity);
   const _hasHydrated = useIDEStore((state) => state._hasHydrated);
   const addPane = useWorkspaceStore((state) => state.addPane);
   const fetchPods = usePodStore((state) => state.fetchPods);
+  const setSelectedChannelId = useChannelStore((state) => state.setSelectedChannelId);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const [createPodModalOpen, setCreatePodModalOpen] = useState(false);
+  const [createChannelOpen, setCreateChannelOpen] = useState(false);
   const addRunnerModal = useCtaModal();
   const importRepoModal = useCtaModal();
 
@@ -105,12 +63,32 @@ export function IDEShell({
     }
   }, [addPane, fetchPods]);
 
+  const handleChannelCreated = useCallback(
+    (channelId: number) => {
+      setCreateChannelOpen(false);
+      setSelectedChannelId(channelId);
+    },
+    [setSelectedChannelId],
+  );
+
   const sidebarCallbacks: SidebarCallbacks = {
     onCreatePod: handleCreatePod,
     onAddRunner: addRunnerModal.open,
     onImportRepo: importRepoModal.open,
   };
   const effectiveSidebarContent = sidebarContent ?? getSidebarContent(activeActivity, sidebarCallbacks);
+  const sidebarHeaderAction =
+    activeActivity === "channels" ? (
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-7 w-7 flex-shrink-0 p-0"
+        onClick={() => setCreateChannelOpen(true)}
+        aria-label={t("channels.sidebar.createChannel")}
+      >
+        <Plus className="h-4 w-4" />
+      </Button>
+    ) : undefined;
 
   if (!_hasHydrated) {
     return (
@@ -121,22 +99,32 @@ export function IDEShell({
   }
 
   return (
-    <div className={cn("app-shell flex h-screen bg-background overflow-hidden", className)}>
-      <ActivityBar className="flex-shrink-0" />
+    <div className={cn("app-shell flex flex-col h-screen bg-sidebar overflow-hidden", className)}>
+      <div
+        className="app-drag shrink-0"
+        style={{ height: "var(--titlebar-drag-height)" }}
+        aria-hidden="true"
+      />
 
-      <SideBar className="flex-shrink-0">{effectiveSidebarContent}</SideBar>
+      <div className="flex min-h-0 flex-1">
+        <ActivityBar className="flex-shrink-0" />
 
-      <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
-        <main
-          className={cn(
-            "flex-1 overflow-auto",
-            activeActivity === "workspace" && bottomPanelOpen ? "" : "pb-8"
-          )}
-        >
-          {children}
-        </main>
+        <div className="flex min-w-0 flex-1 gap-2 p-2">
+          <SideBar className="flex-shrink-0" headerAction={sidebarHeaderAction}>{effectiveSidebarContent}</SideBar>
 
-        {activeActivity === "workspace" && <BottomPanel />}
+          <div className="flex-1 flex flex-col min-w-0 overflow-hidden rounded-xl border border-border/50 bg-background shadow-sm">
+            <main
+              className={cn(
+                "flex-1 overflow-auto",
+                activeActivity === "workspace" && bottomPanelOpen ? "" : "pb-8"
+              )}
+            >
+              {children}
+            </main>
+
+            {activeActivity === "workspace" && <BottomPanel />}
+          </div>
+        </div>
       </div>
 
       <CommandPalette
@@ -160,6 +148,12 @@ export function IDEShell({
         open={importRepoModal.isOpen}
         onClose={importRepoModal.close}
         onImported={importRepoModal.commit}
+      />
+
+      <CreateChannelDialog
+        open={createChannelOpen}
+        onOpenChange={setCreateChannelOpen}
+        onCreated={handleChannelCreated}
       />
     </div>
   );

--- a/clients/web/src/components/ide/OrgSwitcher.tsx
+++ b/clients/web/src/components/ide/OrgSwitcher.tsx
@@ -49,7 +49,7 @@ export function OrgSwitcher() {
         onClick={() => setOpen((v) => !v)}
         aria-label={currentOrg?.name ?? "Organization"}
         className={cn(
-          "flex h-9 w-9 items-center justify-center rounded-lg text-[15px] font-semibold text-primary-foreground transition-colors",
+          "app-no-drag flex h-9 w-9 items-center justify-center rounded-lg text-[15px] font-semibold text-primary-foreground transition-colors",
           "bg-primary hover:bg-primary-hover",
           open && "ring-2 ring-primary/30 ring-offset-1 ring-offset-background",
         )}

--- a/clients/web/src/components/ide/SideBar.tsx
+++ b/clients/web/src/components/ide/SideBar.tsx
@@ -10,9 +10,10 @@ import { PanelLeftClose, PanelLeft } from "lucide-react";
 interface SideBarProps {
   className?: string;
   children?: React.ReactNode;
+  headerAction?: React.ReactNode;
 }
 
-export function SideBar({ className, children }: SideBarProps) {
+export function SideBar({ className, children, headerAction }: SideBarProps) {
   const t = useTranslations();
   const activeActivity = useIDEStore((s) => s.activeActivity);
   const sidebarOpen = useIDEStore((s) => s.sidebarOpen);
@@ -79,25 +80,28 @@ export function SideBar({ className, children }: SideBarProps) {
   return (
     <aside
       className={cn(
-        "bg-background border-r border-border flex flex-col relative",
+        "bg-background rounded-xl border border-border/50 shadow-sm overflow-hidden flex flex-col relative",
         className,
       )}
       style={{ width: sidebarWidth }}
     >
       {activeActivity !== "settings" && (
-        <div className="flex h-12 items-center justify-between border-b border-border px-3">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
-            {getActivityTitle(activeActivity)}
-          </span>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 w-7 flex-shrink-0 p-0"
-            onClick={toggleSidebar}
-            aria-label={t("ide.sidebar.collapse")}
-          >
-            <PanelLeftClose className="w-4 h-4" />
-          </Button>
+        <div className="flex h-12 items-center justify-between gap-2 border-b border-border/60 px-3">
+          <div className="flex min-w-0 items-center gap-1.5">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 w-7 flex-shrink-0 p-0"
+              onClick={toggleSidebar}
+              aria-label={t("ide.sidebar.collapse")}
+            >
+              <PanelLeftClose className="w-4 h-4" />
+            </Button>
+            <span className="truncate text-sm font-semibold text-foreground">
+              {getActivityTitle(activeActivity)}
+            </span>
+          </div>
+          {headerAction}
         </div>
       )}
 

--- a/clients/web/src/components/ide/sidebar/ChannelsSidebarContent.tsx
+++ b/clients/web/src/components/ide/sidebar/ChannelsSidebarContent.tsx
@@ -15,9 +15,8 @@ import {
 } from "@/stores/channel";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Search, Plus, Loader2, MessageSquare, RefreshCw } from "lucide-react";
+import { Search, Loader2, MessageSquare, RefreshCw } from "lucide-react";
 import { ChannelListItem } from "./ChannelListItem";
-import { CreateChannelDialog } from "@/components/channel";
 
 interface ChannelsSidebarContentProps {
   className?: string;
@@ -50,7 +49,7 @@ function classifyChannel(
 function SectionLabel({ children, count }: { children: string; count?: number }) {
   return (
     <div className="flex items-baseline justify-between px-4 pt-3 pb-1.5">
-      <span className="text-[10px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+      <span className="text-[11px] font-medium text-muted-foreground">
         {children}
       </span>
       {typeof count === "number" && count > 0 && (
@@ -78,7 +77,6 @@ export function ChannelsSidebarContent({ className }: ChannelsSidebarContentProp
   const unreadCounts = useUnreadCounts();
   const fetchUnreadCounts = useChannelMessageStore((s) => s.fetchUnreadCounts);
 
-  const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
 
   useEffect(() => {
@@ -122,14 +120,6 @@ export function ChannelsSidebarContent({ className }: ChannelsSidebarContentProp
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visible, _tick]);
 
-  const handleChannelCreated = useCallback(
-    (channelId: number) => {
-      setShowCreateDialog(false);
-      setSelectedChannelId(channelId);
-    },
-    [setSelectedChannelId],
-  );
-
   const handleRefresh = useCallback(async () => {
     setRefreshing(true);
     try {
@@ -172,14 +162,6 @@ export function ChannelsSidebarContent({ className }: ChannelsSidebarContentProp
             className="h-8 pl-8 text-[13px]"
           />
         </div>
-        <Button
-          size="sm"
-          onClick={() => setShowCreateDialog(true)}
-          className="h-8 w-full gap-1.5 text-[13px]"
-        >
-          <Plus className="h-3.5 w-3.5" />
-          {t("channels.sidebar.createChannel")}
-        </Button>
       </div>
 
       <div className="flex-1 overflow-y-auto">
@@ -205,7 +187,7 @@ export function ChannelsSidebarContent({ className }: ChannelsSidebarContentProp
         )}
       </div>
 
-      <div className="flex items-center justify-between border-t border-border px-3 py-2.5 text-[12px]">
+      <div className="flex items-center justify-between border-t border-border/60 px-3 py-2.5 text-[12px]">
         <button
           type="button"
           onClick={() => setShowArchived(!showArchived)}
@@ -226,12 +208,6 @@ export function ChannelsSidebarContent({ className }: ChannelsSidebarContentProp
           <RefreshCw className={cn("h-3.5 w-3.5", refreshing && "animate-spin")} />
         </Button>
       </div>
-
-      <CreateChannelDialog
-        open={showCreateDialog}
-        onOpenChange={setShowCreateDialog}
-        onCreated={handleChannelCreated}
-      />
     </div>
   );
 }

--- a/clients/web/src/components/ide/sidebarContentResolver.tsx
+++ b/clients/web/src/components/ide/sidebarContentResolver.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { type ActivityType } from "@/stores/ide";
+import { WorkspaceSidebarContent } from "./sidebar/WorkspaceSidebarContent";
+import { TicketsSidebarContent } from "./sidebar/TicketsSidebarContent";
+import { RepositoriesSidebarContent } from "./sidebar/RepositoriesSidebarContent";
+import { RunnersSidebarContent } from "./sidebar/RunnersSidebarContent";
+import { InfraSidebarContent } from "./sidebar/InfraSidebarContent";
+import { MeshSidebarContent } from "./sidebar/MeshSidebarContent";
+import { ChannelsSidebarContent } from "./sidebar/ChannelsSidebarContent";
+import { LoopsSidebarContent } from "./sidebar/LoopsSidebarContent";
+import { SettingsSidebarContent } from "./sidebar/SettingsSidebarContent";
+import { BlocksSidebar } from "@/components/blocks/BlocksSidebar";
+
+export interface SidebarCallbacks {
+  onCreatePod?: () => void;
+  onAddRunner?: () => void;
+  onImportRepo?: () => void;
+}
+
+export function getSidebarContent(
+  activity: ActivityType,
+  callbacks: SidebarCallbacks,
+): React.ReactNode {
+  switch (activity) {
+    case "workspace":
+      return <WorkspaceSidebarContent onCreatePod={callbacks.onCreatePod} />;
+    case "tickets":
+      return <TicketsSidebarContent />;
+    case "channels":
+      return <ChannelsSidebarContent />;
+    case "mesh":
+      return <MeshSidebarContent />;
+    case "loops":
+      return <LoopsSidebarContent />;
+    case "blocks":
+      return <BlocksSidebar />;
+    case "infra":
+      return (
+        <InfraSidebarContent
+          onImportRepo={callbacks.onImportRepo}
+          onAddRunner={callbacks.onAddRunner}
+        />
+      );
+    case "repositories":
+      return <RepositoriesSidebarContent onImportRepo={callbacks.onImportRepo} />;
+    case "runners":
+      return <RunnersSidebarContent onAddRunner={callbacks.onAddRunner} />;
+    case "settings":
+      return <SettingsSidebarContent />;
+    default:
+      return null;
+  }
+}

--- a/clients/web/src/components/ui/dialog.tsx
+++ b/clients/web/src/components/ui/dialog.tsx
@@ -57,7 +57,7 @@ export function Dialog({ open, onOpenChange, children }: DialogProps) {
     <div
       ref={overlayRef}
       data-dialog-overlay
-      className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4"
+      className="fixed inset-0 z-50 bg-black/40 backdrop-blur-sm flex items-center justify-center p-4"
       onClick={handleOverlayClick}
     >
       {children}
@@ -75,13 +75,13 @@ export function DialogContent({
   return (
     <div
       className={cn(
-        "bg-background rounded-lg shadow-lg w-full max-w-lg max-h-[90vh] overflow-hidden flex flex-col",
+        "bg-background rounded-2xl shadow-xl w-full max-w-lg max-h-[90vh] overflow-hidden flex flex-col",
         className
       )}
       onClick={(e) => e.stopPropagation()}
     >
       {(title || description) && (
-        <div className="px-6 py-4 border-b">
+        <div className="px-6 pt-6 pb-2">
           {title && <h2 className="text-lg font-semibold">{title}</h2>}
           {description && (
             <p className="text-sm text-muted-foreground mt-1">{description}</p>
@@ -101,7 +101,7 @@ export function DialogHeader({
   className?: string;
 }) {
   return (
-    <div className={cn("px-6 py-4 border-b", className)}>{children}</div>
+    <div className={cn("px-6 pt-6 pb-2", className)}>{children}</div>
   );
 }
 
@@ -138,7 +138,7 @@ export function DialogBody({
   children: React.ReactNode;
   className?: string;
 }) {
-  return <div className={cn("px-6 py-4", className)}>{children}</div>;
+  return <div className={cn("px-6 py-2", className)}>{children}</div>;
 }
 
 export function DialogFooter({
@@ -151,7 +151,7 @@ export function DialogFooter({
   return (
     <div
       className={cn(
-        "px-6 py-4 border-t flex items-center justify-end gap-2",
+        "px-6 pb-6 pt-3 flex items-center justify-end gap-2",
         className
       )}
     >


### PR DESCRIPTION
## What
对齐飞书桌面端，系统性精修三栏布局与弹窗审美。

### 改动
- **沉浸式窗口**（desktop）：macOS `hiddenInset` + `trafficLightPosition`，红绿灯融入左栏顶部；`--titlebar-drag-height` + 平台 class gate，web 端保持 0、无留白。
- **卡片化三栏**：灰画布 + 中栏/右栏白色圆角卡片（阴影 + gap）形成空间纵深，取代原贴合平面 + 粗边框。
- **中栏 header**：收起按钮挪到标题前；channels 在 header 右侧提供 "+" 新建按钮（去掉原全宽大蓝按钮，`CreateChannelDialog` 提升到 IDEShell，与 CreatePodModal 同模式）。
- **弹窗系统性优化**：去掉 header/footer 的无色边框（`currentColor` → 渲染成黑线），圆角加大（`rounded-2xl`）、overlay 毛玻璃、留白分层。改的是通用 `dialog.tsx`，所有弹窗受益。
- 新增 `--sidebar` 背景 token（web + desktop globals）；抽 `sidebarContentResolver` 保持 IDEShell < 200 行。

### 验证
- 本地 dev（web）逐项截图验证：卡片化纵深、accent 选中态、header 改动、弹窗去黑线。
- 三栏组件 web/desktop 共享，桌面端同步受益；沉浸式留白仅桌面 gate（web 回归无异常）。
- desktop main/preload/platform-init 经 tsc 确认改动无类型错误。