### PR TITLE
fix(desktop): remove full-width titlebar gap — spacer into left rail only

### DIFF
--- a/clients/web/src/components/ide/ActivityBar.tsx
+++ b/clients/web/src/components/ide/ActivityBar.tsx
@@ -110,6 +110,11 @@ export function ActivityBar({ className }: ActivityBarProps) {
           className
         )}
       >
+        <div
+          className="app-drag shrink-0"
+          style={{ height: "var(--titlebar-drag-height)" }}
+          aria-hidden="true"
+        />
         <div className="app-drag flex h-12 items-center justify-start px-2">
           <OrgSwitcher />
         </div>

--- a/clients/web/src/components/ide/IDEShell.tsx
+++ b/clients/web/src/components/ide/IDEShell.tsx
@@ -99,31 +99,23 @@ export function IDEShell({
   }
 
   return (
-    <div className={cn("app-shell flex flex-col h-screen bg-sidebar overflow-hidden", className)}>
-      <div
-        className="app-drag shrink-0"
-        style={{ height: "var(--titlebar-drag-height)" }}
-        aria-hidden="true"
-      />
+    <div className={cn("app-shell flex h-screen bg-sidebar overflow-hidden", className)}>
+      <ActivityBar className="flex-shrink-0" />
 
-      <div className="flex min-h-0 flex-1">
-        <ActivityBar className="flex-shrink-0" />
+      <div className="flex min-w-0 flex-1 gap-2 p-2">
+        <SideBar className="flex-shrink-0" headerAction={sidebarHeaderAction}>{effectiveSidebarContent}</SideBar>
 
-        <div className="flex min-w-0 flex-1 gap-2 p-2">
-          <SideBar className="flex-shrink-0" headerAction={sidebarHeaderAction}>{effectiveSidebarContent}</SideBar>
+        <div className="flex-1 flex flex-col min-w-0 overflow-hidden rounded-xl border border-border/50 bg-background shadow-sm">
+          <main
+            className={cn(
+              "flex-1 overflow-auto",
+              activeActivity === "workspace" && bottomPanelOpen ? "" : "pb-8"
+            )}
+          >
+            {children}
+          </main>
 
-          <div className="flex-1 flex flex-col min-w-0 overflow-hidden rounded-xl border border-border/50 bg-background shadow-sm">
-            <main
-              className={cn(
-                "flex-1 overflow-auto",
-                activeActivity === "workspace" && bottomPanelOpen ? "" : "pb-8"
-              )}
-            >
-              {children}
-            </main>
-
-            {activeActivity === "workspace" && <BottomPanel />}
-          </div>
+          {activeActivity === "workspace" && <BottomPanel />}
         </div>
       </div>
 


### PR DESCRIPTION
## Problem
v0.44.0 的沉浸式窗口在 desktop 顶部出现一条**横贯全宽的灰色空白带**：红绿灯 drag 区被做成了 IDEShell 顶部的全宽条，把 sidebar/main 卡片整体下推 `--titlebar-drag-height`（macOS 40px）。web 端因 `--titlebar-drag-height=0` 不受影响。

## Fix
把 drag spacer 从 IDEShell 顶部移回 `ActivityBar` 内部——红绿灯留白只占**左栏**顶部，sidebar/main 卡片顶到接近窗口顶部，横贯灰带消除。IDEShell 同时改回横向 flex（去掉多余的一层 flex-col 包裹）。

## 验证
web 端注入 `--titlebar-drag-height: 40px` 模拟 desktop 确认：左栏顶部为红绿灯留位、中右卡片不再被全宽下推。web 默认 `0` → spacer 折叠，无回归。

仅改 IDEShell + ActivityBar 两个共享组件，22 insertions / 25 deletions。