### PR TITLE
feat(desktop): multi-window + channel popout via WindowRegistry

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -284,9 +284,11 @@ jobs:
           bazelisk-cache: true
           disk-cache: true
           repository-cache: true
-      # Lint, type-check + Vitest all run via Bazel.
+      # Lint, type-check + Vitest all run via Bazel. Use :src_typecheck_test, NOT
+      # `bazel build :src` — the latter only transpiles (no_emit) and stays green
+      # on type errors, so it never gated. The typecheck test is the real gate.
       - name: Lint + Type-check + Vitest (Bazel)
-        run: bazel test //clients/web:lint //clients/web:unit && bazel build //clients/web:src //clients/web-admin:src
+        run: bazel test //clients/web:lint //clients/web:unit //clients/web:src_typecheck_test //clients/web-admin:src_typecheck_test
       # Desktop renderer reuses clients/web but routes Connect RPCs through the
       # electron-adapter proxy. Enforce its type-check + unit tests, and the
       # fail-closed routing guard that catches a desktop-only 404 (a wasm verb

--- a/clients/core/crates/relay/src/driver/mod.rs
+++ b/clients/core/crates/relay/src/driver/mod.rs
@@ -13,9 +13,7 @@ use crate::command::Command;
 use crate::connection;
 use crate::pool::PoolRouter;
 use crate::retry;
-use crate::types::{
-    OutputCallback, RelayStatus, RelayStatusInfo, StatusCallback, StatusSnapshot,
-};
+use crate::types::{OutputCallback, RelayStatus, RelayStatusInfo, StatusSnapshot};
 
 mod session;
 
@@ -202,19 +200,14 @@ impl<R: Runtime> Driver<R> {
 
     fn notify_status(&self) {
         let info = self.status_info();
-        let listeners: Vec<StatusCallback> = {
+        let listener = {
             let router = self.router.read();
-            router
-                .status_listeners
-                .get(&self.pod_key)
-                .cloned()
-                .unwrap_or_default()
+            router.status_listeners.get(&self.pod_key).cloned()
         };
-        for l in &listeners {
+        if let Some(l) = listener {
             // An app-supplied listener panic must not kill the driver task (which
             // would skip teardown and wedge the pod). catch_unwind isolates it on
             // native; wasm is panic=abort so this is a no-op there.
-            let info = info.clone();
             let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| l(info)));
         }
     }

--- a/clients/core/crates/relay/src/driver/session.rs
+++ b/clients/core/crates/relay/src/driver/session.rs
@@ -13,7 +13,7 @@ use super::{Driver, SessionEnd, IDLE_TICK_MS};
 use crate::command::Command;
 use crate::dispatch::{dispatch_message, DispatchAction};
 use crate::retry;
-use crate::types::{AcpCallback, OutputCallback, RelayStatus};
+use crate::types::{OutputCallback, RelayStatus};
 
 impl<R: Runtime> Driver<R> {
     /// One connected session: pump inbound frames, fire periodic timers
@@ -148,18 +148,13 @@ impl<R: Runtime> Driver<R> {
                     self.reconnect_attempts = 0;
                     self.set_status(RelayStatus::Connected);
                 }
-                let listeners: Vec<AcpCallback> = {
+                let listener = {
                     let router = self.router.read();
-                    router
-                        .acp_listeners
-                        .get(&self.pod_key)
-                        .cloned()
-                        .unwrap_or_default()
+                    router.acp_listeners.get(&self.pod_key).cloned()
                 };
-                for l in &listeners {
+                if let Some(l) = listener {
                     // Isolate a panicking ACP listener (same rationale as
                     // notify_status); native only, wasm is panic=abort.
-                    let payload = payload.clone();
                     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                         l(msg_type, payload)
                     }));

--- a/clients/core/crates/relay/src/integration_tests.rs
+++ b/clients/core/crates/relay/src/integration_tests.rs
@@ -504,3 +504,83 @@ async fn disconnect_with_subscriber_tears_down() {
         "disconnect wrongly revived and reconnected the link",
     );
 }
+
+// Single-value listener map (Phase 3): a re-registration for the same pod REPLACES
+// the previous listener rather than accumulating, so a status transition fires the
+// pod's one listener exactly once — the desync a Vec-append could reintroduce.
+#[tokio::test]
+async fn status_listener_replaces_not_accumulates() {
+    let mock = start_mock_relay().await;
+    let (pool, _rx) = RelayConnectionPool::new();
+    let (cb, _buf) = make_output_cb();
+    pool.subscribe("pod-1", "sub-1", &mock.url, "tok", cb).await;
+    assert!(wait_transport(&mock).await, "never connected");
+
+    let count_a = Arc::new(AtomicUsize::new(0));
+    {
+        let c = count_a.clone();
+        pool.on_status_change("pod-1", Arc::new(move |_info| {
+            c.fetch_add(1, SeqCst);
+        }))
+        .await;
+    }
+    let count_b = Arc::new(AtomicUsize::new(0));
+    {
+        let c = count_b.clone();
+        pool.on_status_change("pod-1", Arc::new(move |_info| {
+            c.fetch_add(1, SeqCst);
+        }))
+        .await;
+    }
+    let a_after_replace = count_a.load(SeqCst);
+
+    // Drive a transition (snapshot → Connected) so notify_status fires.
+    let snap = serde_json::json!({"serialized_content":"X","cols":80,"rows":24});
+    mock.push(MsgType::Snapshot, snap.to_string().as_bytes());
+    assert!(wait_ready(&pool, "pod-1").await, "never reached Connected");
+    assert!(
+        wait_until(|| count_b.load(SeqCst) > 1, Duration::from_secs(3)).await,
+        "replacement listener B never fired on the transition",
+    );
+    assert_eq!(
+        count_a.load(SeqCst),
+        a_after_replace,
+        "replaced listener A still fired — Vec-accumulate regression",
+    );
+}
+
+// Same single-value guarantee for ACP listeners.
+#[tokio::test]
+async fn acp_listener_replaces_not_accumulates() {
+    let mock = start_mock_relay().await;
+    let (pool, _rx) = RelayConnectionPool::new();
+    let (cb, _buf) = make_output_cb();
+    pool.subscribe("pod-1", "sub-1", &mock.url, "tok", cb).await;
+    assert!(wait_transport(&mock).await, "never connected");
+    mock.push(MsgType::AcpSnapshot, serde_json::json!({"session":{}}).to_string().as_bytes());
+    assert!(wait_ready(&pool, "pod-1").await, "never ready");
+
+    let count_a = Arc::new(AtomicUsize::new(0));
+    {
+        let c = count_a.clone();
+        pool.on_acp_message("pod-1", Arc::new(move |_mt, _val| {
+            c.fetch_add(1, SeqCst);
+        }))
+        .await;
+    }
+    let count_b = Arc::new(AtomicUsize::new(0));
+    {
+        let c = count_b.clone();
+        pool.on_acp_message("pod-1", Arc::new(move |_mt, _val| {
+            c.fetch_add(1, SeqCst);
+        }))
+        .await;
+    }
+
+    mock.push(MsgType::AcpEvent, serde_json::json!({"event":"started"}).to_string().as_bytes());
+    assert!(
+        wait_until(|| count_b.load(SeqCst) >= 1, Duration::from_secs(3)).await,
+        "replacement ACP listener B never fired",
+    );
+    assert_eq!(count_a.load(SeqCst), 0, "replaced ACP listener A still fired");
+}

--- a/clients/core/crates/relay/src/pool.rs
+++ b/clients/core/crates/relay/src/pool.rs
@@ -25,8 +25,10 @@ pub struct RelayConnectionPool<R: Runtime = PlatformRuntime> {
 
 pub(crate) struct PoolRouter {
     pub pods: HashMap<String, PodHandle>,
-    pub status_listeners: HashMap<String, Vec<StatusCallback>>,
-    pub acp_listeners: HashMap<String, Vec<AcpCallback>>,
+    // At most one listener per pod, enforced by the value type — every consumer
+    // registers once and fans out locally; re-registration replaces (no accumulate).
+    pub status_listeners: HashMap<String, StatusCallback>,
+    pub acp_listeners: HashMap<String, AcpCallback>,
     pub on_pod_disconnected: Option<DisconnectCallback>,
 }
 
@@ -190,9 +192,7 @@ impl<R: Runtime> RelayConnectionPool<R> {
             let mut router = self.inner.write();
             router
                 .status_listeners
-                .entry(pod_key.to_string())
-                .or_default()
-                .push(Arc::clone(&listener));
+                .insert(pod_key.to_string(), Arc::clone(&listener));
         }
         // Fire current status AFTER registering, reading the LATEST snapshot (not
         // one captured before the push): if the driver changes status between the
@@ -222,9 +222,7 @@ impl<R: Runtime> RelayConnectionPool<R> {
         self.inner
             .write()
             .acp_listeners
-            .entry(pod_key.to_string())
-            .or_default()
-            .push(listener);
+            .insert(pod_key.to_string(), listener);
     }
 
     pub async fn get_status(&self, pod_key: &str) -> RelayStatus {

--- a/clients/desktop/BUILD.bazel
+++ b/clients/desktop/BUILD.bazel
@@ -157,6 +157,7 @@ vitest_test(
     ] + glob(
         [
             "src/shared/**/*.ts",
+            "src/main/**/*.ts",
             "scripts/**/*.mjs",
             "scripts/**/*.cjs",
         ],

--- a/clients/desktop/e2e/tests/ipc/connect-routing.spec.ts
+++ b/clients/desktop/e2e/tests/ipc/connect-routing.spec.ts
@@ -25,6 +25,10 @@ test.describe("IPC · connect routing reaches the backend", () => {
       }, { s: service, m: method });
 
       if (err !== null) {
+        // Boot-order regression guard: connectCall must be registered at boot (not
+        // wiped by bindAppStateHandlers clearing appStateHandlers). A missing handler
+        // surfaces as "No handler registered", distinct from a backend 404.
+        expect(err, "connectCall handler missing at boot — bindAppStateHandlers order regression").not.toMatch(/no handler registered/i);
         expect(err, `${service}/${method} is unregistered — desktop-only 404`).not.toMatch(/page not found/i);
       }
     });

--- a/clients/desktop/e2e/tests/window/popout-channel.spec.ts
+++ b/clients/desktop/e2e/tests/window/popout-channel.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "../../fixtures";
+import { invokeIpc } from "../../helpers/ipc";
+
+// Phase 2 multi-window regression guard for the generic `window:open` path
+// (channel kind). Opens a chromeless single-channel window via IPC and asserts
+// it lands on the popout channel route + the primary survives its close (same
+// ref-count invariant as the popout-terminal spec, exercised through the
+// kind→route mapping in window_ipc.ts). channelId need not be a live channel —
+// we're verifying window creation + routing, not message loading.
+test.describe("Desktop multi-window · popout channel", () => {
+  test("window:open(channel) spawns a chromeless channel window; primary survives close", async ({ page, electronApp }) => {
+    const live = ["connecting", "connected", "reconnecting"];
+
+    await invokeIpc(page, "realtime:connect");
+    await page.waitForTimeout(1000);
+
+    const wcId = await invokeIpc<number>(page, "window:open", "channel", { id: "1" });
+    expect(typeof wcId, "window:open returns the new webContents id").toBe("number");
+
+    const popout = await electronApp.waitForEvent("window", { timeout: 15_000 });
+    await popout.waitForLoadState("domcontentloaded");
+    expect(popout.url(), "popout loads the chromeless channel route").toContain("/popout/channel/1");
+
+    await popout.close();
+    await page.waitForTimeout(1000);
+
+    const after = await invokeIpc<string>(page, "realtime:getState");
+    expect(live, `primary realtime must survive popout close, got ${after}`).toContain(after);
+  });
+});

--- a/clients/desktop/e2e/tests/window/popout-terminal.spec.ts
+++ b/clients/desktop/e2e/tests/window/popout-terminal.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "../../fixtures";
+import { invokeIpc } from "../../helpers/ipc";
+
+// Phase 1 multi-window regression guard.
+//
+// Desktop popout terminals open as their own BrowserWindow via the
+// `window:openTerminal` IPC (clients/desktop/src/main/window_ipc.ts), reusing
+// the chromeless `/popout/terminal/:podKey` route. The load-bearing invariant
+// this spec protects: closing a popout must NOT tear down realtime for the
+// primary window. Main ref-counts realtime:connect/disconnect by
+// webContentsId (clients/desktop/src/main/realtime.ts), so the shared EventBus
+// stream survives until the LAST window leaves — the pre-fix single-cast
+// bridge would `eventsDisconnect()` on the first window to close.
+//
+// Exercises window lifecycle + ref-counting only; the PTY data plane (relay
+// directed multicast to the popout) is covered by the terminal round-trip spec
+// plus manual verification — podKey here need not be a live pod.
+test.describe("Desktop multi-window · popout terminal", () => {
+  test("opens a popout window and the primary's realtime survives its close", async ({ page, electronApp }) => {
+    const live = ["connecting", "connected", "reconnecting"];
+
+    await invokeIpc(page, "realtime:connect");
+    await page.waitForTimeout(1500);
+    const before = await invokeIpc<string>(page, "realtime:getState");
+    expect(live, `primary realtime before popout: ${before}`).toContain(before);
+
+    const wcId = await invokeIpc<number>(page, "window:openTerminal", "e2e-popout-probe");
+    expect(typeof wcId, "window:openTerminal returns the new webContents id").toBe("number");
+
+    const popout = await electronApp.waitForEvent("window", { timeout: 15_000 });
+    await popout.waitForLoadState("domcontentloaded");
+    expect(popout.url(), "popout loads the chromeless terminal route").toContain("/popout/terminal/");
+
+    // The popout's RealtimeProvider connects too; closing it must only
+    // decrement the ref-count, not disconnect the shared stream.
+    await popout.close();
+    await page.waitForTimeout(1500);
+
+    const after = await invokeIpc<string>(page, "realtime:getState");
+    expect(live, `primary realtime must survive popout close, got ${after}`).toContain(after);
+  });
+});

--- a/clients/desktop/e2e/tests/window/primary-election.spec.ts
+++ b/clients/desktop/e2e/tests/window/primary-election.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from "../../fixtures";
+import { invokeIpc } from "../../helpers/ipc";
+
+// Primary-designation invariants (WindowRegistry.recomputePrimary). A primary is
+// always a full-shell (primaryEligible) window: chromeless popouts never win, and
+// when the incumbent primary closes the designation transfers to a surviving full
+// window (or becomes none if only popouts remain). window:isPrimary is a main-side
+// IPC, so it answers per webContents regardless of renderer auth state.
+test.describe("Desktop multi-window · primary election", () => {
+  test("a channel popout is never primary, even after the primary closes (#2)", async ({ page, electronApp }) => {
+    expect(await invokeIpc<boolean>(page, "window:isPrimary"), "the main window is primary").toBe(true);
+
+    await invokeIpc<number>(page, "window:open", "channel", { id: "1" });
+    const popout = await electronApp.waitForEvent("window", { timeout: 15_000 });
+    await popout.waitForLoadState("domcontentloaded");
+    expect(popout.url()).toContain("/popout/channel/");
+
+    expect(await invokeIpc<boolean>(popout, "window:isPrimary"),
+      "a kind:channel popout is chromeless / not primaryEligible").toBe(false);
+
+    // Close the primary; only the chromeless popout remains → there is no primary,
+    // so the popout still does not take over (electPrimary skips non-eligible kinds).
+    await page.close();
+    await popout.waitForTimeout(500);
+    expect(await invokeIpc<boolean>(popout, "window:isPrimary"),
+      "no primary when only a chromeless popout survives").toBe(false);
+  });
+
+  test("primary transfers to a surviving full window when the incumbent closes (#5)", async ({ page, electronApp }) => {
+    expect(await invokeIpc<boolean>(page, "window:isPrimary")).toBe(true);
+
+    // Open a second FULL window via File → New Window (kind:secondary, primaryEligible).
+    await electronApp.evaluate(({ Menu }) => {
+      const file = Menu.getApplicationMenu()?.items.find((i) => i.label === "File");
+      const newWindow = file?.submenu?.items.find((i) => i.label === "New Window");
+      if (!newWindow) throw new Error("File → New Window menu item not found");
+      (newWindow as unknown as { click(): void }).click();
+    });
+    const secondary = await electronApp.waitForEvent("window", { timeout: 15_000 });
+    await secondary.waitForLoadState("domcontentloaded");
+
+    expect(await invokeIpc<boolean>(secondary, "window:isPrimary"),
+      "a new full window does not preempt a live primary").toBe(false);
+
+    // Close the incumbent primary → recomputePrimary elects the surviving full window.
+    await page.close();
+    await expect
+      .poll(() => invokeIpc<boolean>(secondary, "window:isPrimary"), { timeout: 5_000 })
+      .toBe(true);
+  });
+});

--- a/clients/desktop/e2e/tests/window/server-switch.spec.ts
+++ b/clients/desktop/e2e/tests/window/server-switch.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "../../fixtures";
+import { invokeIpc } from "../../helpers/ipc";
+
+// On a server switch the AppState rebind tears down all relay links, so chromeless
+// popouts CLOSE (their pod/channel is on the old backend and can't migrate) rather
+// than reload into a wedged "Connecting forever" — WindowRegistry.applyConfigChange.
+test.describe("Desktop multi-window · server switch", () => {
+  test("switching servers closes chromeless terminal popouts", async ({ page, electronApp }) => {
+    await invokeIpc<number>(page, "window:openTerminal", "e2e-switch-probe");
+    const popout = await electronApp.waitForEvent("window", { timeout: 15_000 });
+    await popout.waitForLoadState("domcontentloaded");
+    expect(popout.url()).toContain("/popout/terminal/");
+
+    const terminalPopouts = () =>
+      electronApp.evaluate(({ BrowserWindow }) =>
+        BrowserWindow.getAllWindows().filter((w) =>
+          w.webContents.getURL().includes("/popout/terminal/"),
+        ).length,
+      );
+    expect(await terminalPopouts(), "the terminal popout is open").toBe(1);
+
+    // Switch to the CN preset (a different URL → urlChanged). Fire-and-forget so the
+    // primary's own reload doesn't destroy this invoke's execution context.
+    await page.evaluate(() => {
+      const api = (window as unknown as {
+        electronAPI: { invoke: (c: string, ...a: unknown[]) => Promise<unknown> };
+      }).electronAPI;
+      void api.invoke("serverConfig:set", { kind: "cn", customLabel: "", customUrl: "" });
+    });
+
+    // applyConfigChange closes the terminal popout (its pod is on the old backend).
+    await expect.poll(terminalPopouts, { timeout: 8_000 }).toBe(0);
+  });
+});

--- a/clients/desktop/src/main/app_state_handlers.ts
+++ b/clients/desktop/src/main/app_state_handlers.ts
@@ -1,0 +1,65 @@
+import { ipcMain } from "electron";
+import { logEvent, type AppState } from "@agentsmesh/node-bridge";
+import { type LocalRunnerStubMap } from "./local_runner_stubs";
+import { IPC_ALLOWLIST, IPC_ALLOWLIST_SET } from "./ipc-allowlist.generated";
+
+interface BindDeps {
+  appState: AppState;
+  stubs: LocalRunnerStubMap | null;
+  // Owned by the caller and reused across rebinds so removeHandler matches what
+  // was registered.
+  tracked: Set<string>;
+}
+
+// Called at boot and after server switch (new AppState). MUST removeHandler
+// first because ipcMain.handle throws on duplicate registration.
+//
+// Allowlist-driven (vs reflect-everything): the IPC channel set comes from
+// `ipc-allowlist.generated.ts` — auto-generated from the same NAPI binary symbol
+// enumeration that drives e2e contract specs, so the two stay in lock-step. Any
+// NAPI method not in the allowlist is unreachable from the renderer even if it
+// exists on AppState.prototype. Drift is logged (warn, not crash) so a Bazel
+// rebuild lag doesn't block dev workflows.
+export function bindAppStateHandlers({ appState, stubs, tracked }: BindDeps): void {
+  for (const ch of [...tracked]) ipcMain.removeHandler(ch);
+  tracked.clear();
+
+  const proto = Object.getPrototypeOf(appState);
+  const protoMethods = new Set(
+    Object.getOwnPropertyNames(proto).filter(
+      (k) => k !== "constructor" && typeof (appState as any)[k] === "function",
+    ),
+  );
+
+  const missingFromBinary = IPC_ALLOWLIST.filter((n) => !protoMethods.has(n));
+  const missingFromAllowlist = [...protoMethods].filter((n) => !IPC_ALLOWLIST_SET.has(n));
+  if (missingFromBinary.length > 0) {
+    logEvent("warn", "ipc", `allowlist drift: ${missingFromBinary.length} listed but missing from binary`);
+    console.warn(`[electron] IPC allowlist drift: ${missingFromBinary.length} methods listed but not in AppState.prototype — regenerate with \`pnpm --filter desktop e2e:gen\``);
+  }
+  if (missingFromAllowlist.length > 0) {
+    logEvent("warn", "ipc", `allowlist drift: ${missingFromAllowlist.length} methods denied (not in allowlist)`);
+    console.warn(`[electron] IPC allowlist drift: ${missingFromAllowlist.length} AppState methods not in allowlist (denied to renderer) — regenerate with \`pnpm --filter desktop e2e:gen\``);
+  }
+
+  let registered = 0;
+  for (const m of IPC_ALLOWLIST) {
+    if (!protoMethods.has(m)) continue;
+    ipcMain.handle(m, async (_e, ...args: unknown[]) => {
+      try {
+        if (stubs && m in stubs) return await stubs[m](...args);
+        return await (appState as any)[m](...args);
+      } catch (err) {
+        const msg = err instanceof Error
+          ? err.message
+          : typeof err === "string" ? err : String(err);
+        logEvent("warn", "ipc", `${m} failed: ${msg}`);
+        throw err instanceof Error ? err : new Error(String(err));
+      }
+    });
+    tracked.add(m);
+    registered++;
+  }
+  logEvent("info", "ipc", `registered ${registered} handlers (allowlist ${IPC_ALLOWLIST.length}, methods ${protoMethods.size})`);
+  console.log(`[electron] Registered ${registered} IPC handlers (allowlist: ${IPC_ALLOWLIST.length}, AppState methods: ${protoMethods.size})`);
+}

--- a/clients/desktop/src/main/cold_start.ts
+++ b/clients/desktop/src/main/cold_start.ts
@@ -1,0 +1,19 @@
+import { isValidServerUrl } from "../shared/server-config-types";
+import * as serverConfig from "./server_config";
+
+// Cold-start API URL resolution: (1) AGENTSMESH_API_URL env override (dev/e2e,
+// process-only, does NOT pollute SSOT) → (2) activeUrl(currentCfg). Returns the
+// resolution error (config invalid) rather than mutating module state, so the
+// caller owns the pending-dialog decision. After save, serverConfig:set rebinds
+// directly, shadowing env.
+export function resolveColdStartApiUrl(
+  cfg: serverConfig.ServerConfig,
+): { apiUrl: string; error: string | null } {
+  const envOverride = process.env.AGENTSMESH_API_URL;
+  if (envOverride && isValidServerUrl(envOverride)) return { apiUrl: envOverride, error: null };
+  try {
+    return { apiUrl: serverConfig.activeUrl(cfg), error: null };
+  } catch (e) {
+    return { apiUrl: serverConfig.activeUrl(serverConfig.DEFAULT), error: (e as Error).message };
+  }
+}

--- a/clients/desktop/src/main/connect-json.ts
+++ b/clients/desktop/src/main/connect-json.ts
@@ -1,0 +1,54 @@
+// Shape adapters for the legacy IPC aliases (legacy_api_aliases.ts): bridge the
+// Connect-JSON wire back to the REST-shaped envelopes desktop e2e specs + the
+// renderer caches read. Pure functions, no AppState/network dependency.
+
+// camelCase → snake_case deep key rename.
+export function snakeCaseDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(snakeCaseDeep);
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      const sk = k.replace(/([A-Z])/g, "_$1").toLowerCase();
+      out[sk] = snakeCaseDeep(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+// Connect-JSON serializes int64 as a JSON string to preserve precision; IPC
+// callers may forward it as either a number or string.
+export const toIdNumber = (v: number | string): number =>
+  typeof v === "number" ? v : Number(v);
+
+// Recursively coerce numeric-looking strings to numbers for known int64 fields.
+// Connect-JSON emits them as strings, but desktop e2e callers + the legacy Rust
+// napi shape expect numbers (`expect(joined.agent_count).toBe(1)` fails on "1").
+const INT64_KEYS = new Set([
+  "id", "organization_id", "repository_id", "ticket_id",
+  "created_by_user_id", "member_count", "agent_count",
+  "message_count", "sender_user_id", "channel_id", "reply_to",
+]);
+
+export function coerceInt64(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(coerceInt64);
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (INT64_KEYS.has(k) && typeof v === "string" && /^-?\d+$/.test(v)) {
+        out[k] = Number(v);
+      } else {
+        out[k] = coerceInt64(v);
+      }
+    }
+    return out;
+  }
+  return value;
+}
+
+// Connect-JSON omits proto3 defaults (0/""/false); the legacy napi shape always
+// emitted them. Channel responses need these present so e2e `toBe(0)` gets a
+// number, not undefined.
+export function ensureChannelDefaults(value: Record<string, unknown>): Record<string, unknown> {
+  return { agent_count: 0, member_count: 0, is_member: false, is_archived: false, ...value };
+}

--- a/clients/desktop/src/main/connect_call.ts
+++ b/clients/desktop/src/main/connect_call.ts
@@ -1,0 +1,87 @@
+import { ipcMain } from "electron";
+import { logEvent, type AppState } from "@agentsmesh/node-bridge";
+import { connectFetch } from "./connect-fetch";
+import { connectErrorFromResponse, connectNetworkError } from "./connect-error";
+
+interface Deps {
+  // Getters (not values): AppState + resolved API URL rebind on server switch,
+  // so each call reads the current ones.
+  getAppState: () => AppState;
+  getApiUrl: () => string;
+}
+
+export interface ConnectCaller {
+  callConnectJson(service: string, method: string, payload?: unknown): Promise<string>;
+  orgSlug(): string;
+}
+
+// Main → backend Connect egress over the JSON wire. Used by the legacy IPC
+// aliases (legacy_api_aliases.ts). Rewrites the `unauthenticated` envelope to
+// the `auth_expired` token the renderer + e2e specs key off.
+export function makeConnectCaller({ getAppState, getApiUrl }: Deps): ConnectCaller {
+  const callConnectJson = async (service: string, method: string, payload: unknown = {}): Promise<string> => {
+    const url = `${getApiUrl()}/${service}/${method}`;
+    const token = (getAppState() as { authGetToken?: () => string | null }).authGetToken?.();
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "Connect-Protocol-Version": "1",
+    };
+    if (token) headers.Authorization = `Bearer ${token}`;
+    const res = await connectFetch(url, { method: "POST", headers, body: JSON.stringify(payload) });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      logEvent("warn", "ipc-rpc", `${service}/${method} → ${res.status}`);
+      const message = body.includes("unauthenticated")
+        ? `auth_expired ${res.status} ${url} ${body}`
+        : `${res.status} ${res.statusText} ${url} ${body}`;
+      throw new Error(message.trim());
+    }
+    return await res.text();
+  };
+
+  const orgSlug = () => {
+    const raw = (getAppState() as { authGetCurrentOrgJson?: () => string | null }).authGetCurrentOrgJson?.();
+    if (!raw) return "";
+    try { return (JSON.parse(raw) as { slug?: string }).slug ?? ""; }
+    catch { return ""; }
+  };
+
+  return { callConnectJson, orgSlug };
+}
+
+// Generic binary Connect-RPC proxy — NOT a legacy alias. Web's wasm services
+// expose `<method>Connect(Uint8Array)`; ElectronXxxService adapters without a
+// hand-written `_connect` handler route through this. Protobuf encode/decode
+// stays on the renderer; main only ferries bytes (number[]) to the backend —
+// the renderer has no wasm, so this is the sole egress point for those RPCs.
+export function registerConnectCall(
+  { getAppState, getApiUrl }: Deps,
+  tracked: Set<string>,
+): void {
+  // Remove before re-register so rebind (which runs bindAppStateHandlers first,
+  // clearing tracked) can re-register with fresh closures. Safe at boot too.
+  ipcMain.removeHandler("connectCall");
+  tracked.add("connectCall");
+  ipcMain.handle("connectCall", async (_e, service: string, method: string, bodyArr: number[]) => {
+    const url = `${getApiUrl()}/${service}/${method}`;
+    const token = (getAppState() as { authGetToken?: () => string | null }).authGetToken?.();
+    const headers: Record<string, string> = {
+      "Content-Type": "application/proto",
+      "Connect-Protocol-Version": "1",
+    };
+    if (token) headers.Authorization = `Bearer ${token}`;
+    logEvent("debug", "ipc-rpc", `${service}/${method} (${bodyArr.length}B)`);
+    let res: Response;
+    try {
+      res = await connectFetch(url, { method: "POST", headers, body: Uint8Array.from(bodyArr) });
+    } catch (err) {
+      logEvent("warn", "ipc-rpc", `${service}/${method} → network error`);
+      throw connectNetworkError(err);
+    }
+    if (!res.ok) {
+      logEvent("warn", "ipc-rpc", `${service}/${method} → ${res.status}`);
+      throw await connectErrorFromResponse(res);
+    }
+    return Array.from(new Uint8Array(await res.arrayBuffer()));
+  });
+}

--- a/clients/desktop/src/main/create_window.ts
+++ b/clients/desktop/src/main/create_window.ts
@@ -1,0 +1,74 @@
+import { BrowserWindow, shell } from "electron";
+import path from "path";
+import { type WindowRegistry, type WindowKind } from "./window_registry";
+
+interface CreateOpts {
+  kind: WindowKind;
+  route?: string;
+  width?: number;
+  height?: number;
+  onClosed?: (wcId: number) => void;
+}
+
+const isHeadlessTest = process.env.NODE_ENV === "test";
+
+// Immersive titlebar: mac traffic lights float into the left rail's top drag
+// strip (renderer reserves it via --titlebar-drag-height); Windows uses an
+// overlay; Linux keeps the native frame.
+function titlebarOpts(): Electron.BrowserWindowConstructorOptions {
+  if (process.platform === "darwin")
+    return { titleBarStyle: "hiddenInset", trafficLightPosition: { x: 14, y: 14 } };
+  if (process.platform === "win32")
+    return {
+      titleBarStyle: "hidden",
+      titleBarOverlay: { color: "#F6F8FA", symbolColor: "#656D76", height: 40 },
+    };
+  return {};
+}
+
+export function createAppWindow(registry: WindowRegistry, opts: CreateOpts): BrowserWindow {
+  const win = new BrowserWindow({
+    width: opts.width ?? 1280,
+    height: opts.height ?? 800,
+    minWidth: 900,
+    minHeight: 600,
+    title: "AgentsMesh",
+    show: !isHeadlessTest,
+    paintWhenInitiallyHidden: true,
+    skipTaskbar: isHeadlessTest,
+    ...titlebarOpts(),
+    webPreferences: {
+      preload: path.join(__dirname, "../preload/index.js"),
+      contextIsolation: true,
+      sandbox: false,
+      nodeIntegration: false,
+      // Read synchronously by preload to scope per-window UI-layout persistence.
+      additionalArguments: [`--agentsmesh-window-kind=${opts.kind}`],
+    },
+  });
+
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    if (/^https?:\/\//i.test(url) || url.startsWith("mailto:") || url.startsWith("agentsmesh://")) {
+      shell.openExternal(url);
+    }
+    return { action: "deny" };
+  });
+
+  const devUrl = process.env.ELECTRON_RENDERER_URL;
+  if (devUrl) {
+    win.loadURL(opts.route ? `${devUrl}#${opts.route}` : devUrl);
+    // One detached devtools is enough; extra windows would stack noisy panels.
+    if (opts.kind === "primary") win.webContents.openDevTools({ mode: "detach" });
+  } else {
+    const indexHtml = path.join(__dirname, "../renderer/index.html");
+    win.loadFile(indexHtml, opts.route ? { hash: opts.route } : undefined);
+  }
+
+  const id = win.webContents.id;
+  registry.register(win, opts.kind);
+  win.on("closed", () => {
+    registry.unregister(id);
+    opts.onClosed?.(id);
+  });
+  return win;
+}

--- a/clients/desktop/src/main/index.ts
+++ b/clients/desktop/src/main/index.ts
@@ -1,17 +1,19 @@
-import { app, BrowserWindow, dialog, ipcMain, Menu, shell } from "electron";
+import { app, dialog, ipcMain, shell } from "electron";
 import path from "path";
 import { AppState, initLogger, logEvent } from "@agentsmesh/node-bridge";
-import { create as protoCreate, toBinary } from "@bufbuild/protobuf";
-import { ReplaceChannelPodsRequestSchema } from "@proto/channel_state/v1/mutations_pb";
-import { PodSchema } from "@proto/pod/v1/pod_pb";
 import { createLocalRunnerStubs, type LocalRunnerStubMap } from "./local_runner_stubs";
 import { acquireSingleInstance } from "./single_instance";
-import { IPC_ALLOWLIST, IPC_ALLOWLIST_SET } from "./ipc-allowlist.generated";
+import { bindAppStateHandlers } from "./app_state_handlers";
+import { resolveColdStartApiUrl } from "./cold_start";
 import { setupRealtimeBridge, type RealtimeBridge } from "./realtime";
 import { setupRelayBridge, type RelayBridge } from "./relay";
 import { setupAutoUpdater } from "./auto_updater";
-import { connectFetch } from "./connect-fetch";
-import { connectErrorFromResponse, connectNetworkError } from "./connect-error";
+import { WindowRegistry } from "./window_registry";
+import { createAppWindow } from "./create_window";
+import { registerWindowIpc } from "./window_ipc";
+import { buildMenu } from "./menu";
+import { registerConnectCall } from "./connect_call";
+import { registerLegacyApiAliases } from "./legacy_api_aliases";
 import {
   registerProtocol,
   attachSecondInstanceUrlHandler,
@@ -20,29 +22,13 @@ import {
   flushPendingUrl,
 } from "./oauth_deep_link";
 import * as serverConfig from "./server_config";
-import { isValidServerUrl } from "../shared/server-config-types";
 
-// Cold-start resolution: (1) AGENTSMESH_API_URL env override (dev/e2e, process-only,
-// does NOT pollute SSOT) → (2) activeUrl(currentCfg). After save, serverConfig:set
-// rebinds directly, shadowing env. Env-override lives here (not server_config.ts) to keep
-// that module pure.
 // pendingStartupErrorMsg is module-load stashed; flushed in whenReady because
 // dialog.showErrorBox is unreliable before app.ready fires.
-let pendingStartupErrorMsg: string | null = null;
-
-function resolveColdStartApiUrl(cfg: serverConfig.ServerConfig): string {
-  const envOverride = process.env.AGENTSMESH_API_URL;
-  if (envOverride && isValidServerUrl(envOverride)) return envOverride;
-  try {
-    return serverConfig.activeUrl(cfg);
-  } catch (e) {
-    pendingStartupErrorMsg = (e as Error).message;
-    return serverConfig.activeUrl(serverConfig.DEFAULT);
-  }
-}
-
 let currentCfg = serverConfig.load();
-let currentApiUrl = resolveColdStartApiUrl(currentCfg);
+const coldStart = resolveColdStartApiUrl(currentCfg);
+let currentApiUrl = coldStart.apiUrl;
+let pendingStartupErrorMsg: string | null = coldStart.error;
 
 const storageDir = path.join(app.getPath("userData"), "agentsmesh");
 const logsDir = app.getPath("logs");
@@ -51,146 +37,40 @@ const isHeadlessTest = process.env.NODE_ENV === "test";
 
 let appState: AppState;
 let stubs: LocalRunnerStubMap | null = null;
-let mainWindow: BrowserWindow | null = null;
 let realtimeBridge: RealtimeBridge | null = null;
 let relayBridge: RelayBridge | null = null;
 const appStateHandlers = new Set<string>();
+const registry = new WindowRegistry();
 
-const getMainWindow = () => mainWindow;
+const getPrimaryWindow = () => registry.getPrimary();
+
+// oauth deep-links need a real window; getPrimary() is null when only popouts
+// survive, so spawn one on demand.
+function ensurePrimaryWindow() {
+  return registry.getPrimary() ?? (createPrimaryWindow(), registry.getPrimary());
+}
+
+// A closing window never runs the renderer's unsubscribe — release its relay/
+// realtime ref-counts here so shared links tear down once the last window leaves.
+function onWindowClosed(wcId: number): void {
+  relayBridge?.releaseWebContents(wcId);
+  realtimeBridge?.releaseWebContents(wcId);
+}
 
 if (acquireSingleInstance()) {
   registerProtocol();
-  attachSecondInstanceUrlHandler(getMainWindow);
+  attachSecondInstanceUrlHandler(ensurePrimaryWindow);
   captureColdLaunchUrl();
 }
 
-function createWindow() {
-  const isMac = process.platform === "darwin";
-  const isWin = process.platform === "win32";
-  const win = new BrowserWindow({
-    width: 1280,
-    height: 800,
-    minWidth: 900,
-    minHeight: 600,
-    title: "AgentsMesh",
-    show: !isHeadlessTest,
-    paintWhenInitiallyHidden: true,
-    skipTaskbar: isHeadlessTest,
-    // Immersive titlebar: traffic lights float into the left rail's 52px top drag
-    // strip (renderer reserves it via --titlebar-drag-height). Linux keeps native frame.
-    ...(isMac
-      ? { titleBarStyle: "hiddenInset" as const, trafficLightPosition: { x: 14, y: 14 } }
-      : {}),
-    ...(isWin
-      ? {
-          titleBarStyle: "hidden" as const,
-          titleBarOverlay: { color: "#F6F8FA", symbolColor: "#656D76", height: 40 },
-        }
-      : {}),
-    webPreferences: {
-      preload: path.join(__dirname, "../preload/index.js"),
-      contextIsolation: true,
-      sandbox: false,
-      nodeIntegration: false,
-    },
-  });
-
-  win.webContents.setWindowOpenHandler(({ url }) => {
-    if (/^https?:\/\//i.test(url) || url.startsWith("mailto:") || url.startsWith("agentsmesh://")) {
-      shell.openExternal(url);
-    }
-    return { action: "deny" };
-  });
-
-  if (process.env.ELECTRON_RENDERER_URL) {
-    win.loadURL(process.env.ELECTRON_RENDERER_URL);
-    win.webContents.openDevTools({ mode: "detach" });
-  } else {
-    win.loadFile(path.join(__dirname, "../renderer/index.html"));
-  }
-
-  mainWindow = win;
-  logEvent("info", "electron-main", "window created");
-  win.on("closed", () => {
-    logEvent("info", "electron-main", "window closed");
-    if (mainWindow === win) mainWindow = null;
-  });
-  flushPendingUrl(getMainWindow);
-}
-
-// Called at boot and after server switch (new AppState). MUST removeHandler first
-// because ipcMain.handle throws on duplicate registration.
-//
-// Allowlist-driven (vs reflect-everything): the set of methods exposed as IPC
-// channels comes from `ipc-allowlist.generated.ts` — auto-generated from the
-// same NAPI binary symbol enumeration that drives e2e contract specs, so the
-// two stay in lock-step. Any NAPI method not in the allowlist is unreachable
-// from the renderer even if it exists on AppState.prototype. Drift (allowlist
-// references a method that's missing from AppState, or vice-versa) is logged
-// at boot.
-function bindAppStateHandlers() {
-  for (const ch of appStateHandlers) {
-    ipcMain.removeHandler(ch);
-  }
-  appStateHandlers.clear();
-
-  const proto = Object.getPrototypeOf(appState);
-  const protoMethods = new Set(
-    Object.getOwnPropertyNames(proto).filter(
-      (k) => k !== "constructor" && typeof (appState as any)[k] === "function",
-    ),
-  );
-
-  // Drift detection: warn (don't crash) on either side mismatching the
-  // allowlist. Crash would block legitimate dev workflows after a Bazel
-  // rebuild lag; a warn surfaces the issue immediately in the dev log
-  // while keeping renderer paths working.
-  const missingFromBinary: string[] = [];
-  for (const name of IPC_ALLOWLIST) {
-    if (!protoMethods.has(name)) missingFromBinary.push(name);
-  }
-  const missingFromAllowlist: string[] = [];
-  for (const name of protoMethods) {
-    if (!IPC_ALLOWLIST_SET.has(name)) missingFromAllowlist.push(name);
-  }
-  if (missingFromBinary.length > 0) {
-    logEvent("warn", "ipc", `allowlist drift: ${missingFromBinary.length} listed but missing from binary`);
-    console.warn(
-      `[electron] IPC allowlist drift: ${missingFromBinary.length} methods listed but not in AppState.prototype — regenerate with \`pnpm --filter desktop e2e:gen\``,
-    );
-  }
-  if (missingFromAllowlist.length > 0) {
-    logEvent("warn", "ipc", `allowlist drift: ${missingFromAllowlist.length} methods denied (not in allowlist)`);
-    console.warn(
-      `[electron] IPC allowlist drift: ${missingFromAllowlist.length} AppState methods not in allowlist (denied to renderer) — regenerate with \`pnpm --filter desktop e2e:gen\``,
-    );
-  }
-
-  let registered = 0;
-  for (const m of IPC_ALLOWLIST) {
-    if (!protoMethods.has(m)) continue; // skip missing methods (logged above)
-    ipcMain.handle(m, async (_e, ...args: unknown[]) => {
-      try {
-        if (stubs && m in stubs) {
-          return await stubs[m](...args);
-        }
-        return await (appState as any)[m](...args);
-      } catch (err) {
-        const msg = typeof err === "string" ? err : ((err as Error)?.message ?? String(err));
-        logEvent("warn", "ipc", `${m} failed: ${msg}`);
-        throw typeof err === "string" ? new Error(err) : err;
-      }
-    });
-    appStateHandlers.add(m);
-    registered++;
-  }
-  logEvent("info", "ipc", `registered ${registered} handlers (allowlist ${IPC_ALLOWLIST.length}, methods ${protoMethods.size})`);
-  console.log(`[electron] Registered ${registered} IPC handlers (allowlist: ${IPC_ALLOWLIST.length}, AppState methods: ${protoMethods.size})`);
+function createPrimaryWindow(): void {
+  createAppWindow(registry, { kind: "primary", onClosed: onWindowClosed });
+  flushPendingUrl(getPrimaryWindow);
 }
 
 // Known leak: LocalRunnerManager / RelayManager have no shutdown hook, so their tokio
 // tasks may outlive the rebind. Rare in practice (server switches are uncommon).
-function rebindAppState(newApiUrl: string) {
+async function rebindAppState(newApiUrl: string) {
   logEvent("info", "electron-main", `rebind AppState → ${newApiUrl}`);
   console.log(`[electron] Rebinding AppState: ${currentApiUrl} → ${newApiUrl}`);
   // Dispose old realtime bridge before swapping AppState — its NAPI
@@ -207,11 +87,13 @@ function rebindAppState(newApiUrl: string) {
   if (isHeadlessTest) {
     stubs = createLocalRunnerStubs();
   }
-  bindAppStateHandlers();
-  void setupRealtimeBridge(appState, getMainWindow).then((bridge) => {
-    realtimeBridge = bridge;
-  });
-  relayBridge = setupRelayBridge(appState, getMainWindow);
+  bindAppStateHandlers({ appState, stubs, tracked: appStateHandlers });
+  registerConnectCall({ getAppState: () => appState, getApiUrl: () => currentApiUrl }, appStateHandlers);
+  registerLegacyApiAliases({ getAppState: () => appState, getApiUrl: () => currentApiUrl }, appStateHandlers);
+  // Await so realtime:connect/getState are registered before serverConfig:set
+  // reloads windows — else a reloaded renderer's connect rejects and stays dead.
+  realtimeBridge = await setupRealtimeBridge(appState, registry);
+  relayBridge = setupRelayBridge(appState, registry);
   currentApiUrl = newApiUrl;
 }
 
@@ -232,9 +114,9 @@ function registerStaticHandlers() {
   });
 
   // Sync IPC by design: preload populates window.electronAPI.apiUrl synchronously at boot
-  // (before any renderer code runs — no UI thread to block). mainWindow.reload() re-runs
+  // (before any renderer code runs — no UI thread to block). Reloading a window re-runs
   // preload to propagate serverConfig:set updates.
-  // Invariant: registerStaticHandlers() MUST run before createWindow() (enforced by ordering below).
+  // Invariant: registerStaticHandlers() MUST run before createPrimaryWindow() (enforced by ordering below).
   ipcMain.on("serverConfig:getActiveUrlSync", (e) => {
     e.returnValue = currentApiUrl;
   });
@@ -250,386 +132,14 @@ function registerStaticHandlers() {
     const next = serverConfig.save(raw);
     const newUrl = serverConfig.activeUrl(next);
     currentCfg = next;
-    if (newUrl !== currentApiUrl) {
-      rebindAppState(newUrl);
+    // Capture before rebindAppState mutates currentApiUrl.
+    const urlChanged = newUrl !== currentApiUrl;
+    if (urlChanged) {
+      await rebindAppState(newUrl);
     }
-    // Always reload: even when resolved URL is unchanged (env override masks both), the cfg
-    // fields the dialog reads can have changed (kind/custom*). Reload re-snapshots preload.
-    mainWindow?.reload();
+    // Re-snapshots preload even on a same-URL edit (dialog cfg fields can change).
+    registry.applyConfigChange(urlChanged);
   });
-
-  registerLegacyApiAliases();
-}
-
-// Recursively rename object keys from camelCase to snake_case. Used by
-// the legacy IPC aliases so renderer code written against the REST shape
-// can keep reading snake_case fields off the Connect-JSON envelope.
-function snakeCaseDeep(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(snakeCaseDeep);
-  if (value !== null && typeof value === "object") {
-    const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      const sk = k.replace(/([A-Z])/g, "_$1").toLowerCase();
-      out[sk] = snakeCaseDeep(v);
-    }
-    return out;
-  }
-  return value;
-}
-
-// Legacy IPC aliases for method names that predate the R6 Connect-RPC
-// refactor. Desktop e2e specs still invoke `userGetMe` /
-// `autopilotFetchControllers` / `runnerFetchRunners` /
-// `channelCreateChannel` by name. The Rust napi handlers were renamed
-// (and switched to proto binary payloads) without an alias hop, so the
-// invokes hit `No handler registered`. We forward through the Connect
-// JSON wire here — it preserves the failure-surface details the
-// orbstack-port-conflict spec depends on (status + URL in the error
-// message) and avoids dragging proto-js into the main bundle.
-function registerLegacyApiAliases() {
-  const callConnectJson = async (
-    service: string,
-    method: string,
-    payload: unknown = {},
-  ): Promise<string> => {
-    const url = `${currentApiUrl}/${service}/${method}`;
-    const token = (appState as { authGetToken?: () => string | null }).authGetToken?.();
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-      "Connect-Protocol-Version": "1",
-    };
-    if (token) headers.Authorization = `Bearer ${token}`;
-    const res = await connectFetch(url, {
-      method: "POST",
-      headers,
-      body: JSON.stringify(payload),
-    });
-    if (!res.ok) {
-      const body = await res.text().catch(() => "");
-      logEvent("warn", "ipc-rpc", `${service}/${method} → ${res.status}`);
-      // Surface the standard `auth_expired` token the desktop renderer +
-      // e2e specs key off when the backend returned an Unauthorized.
-      // The Connect-JSON error envelope is `{"code":"unauthenticated", ...}`
-      // — rewrite the code so callers don't need to know two vocabularies.
-      const message = body.includes("unauthenticated")
-        ? `auth_expired ${res.status} ${url} ${body}`
-        : `${res.status} ${res.statusText} ${url} ${body}`;
-      throw new Error(message.trim());
-    }
-    return await res.text();
-  };
-
-  const orgSlug = () => {
-    const raw = (appState as { authGetCurrentOrgJson?: () => string | null })
-      .authGetCurrentOrgJson?.();
-    if (!raw) return "";
-    try { return (JSON.parse(raw) as { slug?: string }).slug ?? ""; }
-    catch { return ""; }
-  };
-
-  ipcMain.handle("userGetMe", () =>
-    callConnectJson("proto.user.v1.UserService", "GetMe"),
-  );
-  ipcMain.handle("autopilotFetchControllers", () =>
-    callConnectJson(
-      "proto.autopilot.v1.AutopilotControllerService",
-      "ListAutopilotControllers",
-      { orgSlug: orgSlug() },
-    ),
-  );
-
-  // R6 dropped the Rust channel_join_channel napi (replaced by direct
-  // ChannelService.JoinChannelPod). Renderer paths use wasm Connect; main
-  // exposes these aliases for desktop e2e specs that still invoke through
-  // IPC by name. The cache update is necessary because main's AppState
-  // holds a separate Rust state from the renderer wasm — without the
-  // app_channel_replace_pods fan-out into runtime.state, appChannelPodsJson
-  // returns empty.
-  //
-  // Connect-JSON serializes int64 as a JSON string to preserve precision —
-  // IPC callers parse the channel response and forward `id` to us as a
-  // string. Coerce to a JS number before handing it to napi (i64 binding).
-  const toIdNumber = (v: number | string): number =>
-    typeof v === "number" ? v : Number(v);
-
-  // Recursively coerce numeric-looking string values to numbers for keys
-  // known to be int64 fields. The Connect-JSON wire serializes int64 as a
-  // string, but desktop e2e callers (and the legacy Rust napi shape) expect
-  // numbers — `expect(joined.agent_count).toBe(1)` would fail on "1".
-  const INT64_KEYS = new Set([
-    "id", "organization_id", "repository_id", "ticket_id",
-    "created_by_user_id", "member_count", "agent_count",
-    "message_count", "sender_user_id", "channel_id", "reply_to",
-  ]);
-  const coerceInt64 = (value: unknown): unknown => {
-    if (Array.isArray(value)) return value.map(coerceInt64);
-    if (value !== null && typeof value === "object") {
-      const out: Record<string, unknown> = {};
-      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-        if (INT64_KEYS.has(k) && typeof v === "string" && /^-?\d+$/.test(v)) {
-          out[k] = Number(v);
-        } else {
-          out[k] = coerceInt64(v);
-        }
-      }
-      return out;
-    }
-    return value;
-  };
-
-  // Connect-JSON omits proto3 default values (0, "", false). The legacy
-  // Rust napi shape always emitted them explicitly. Channel-shaped responses
-  // need agent_count / member_count present as numbers so e2e specs that
-  // do `expect(channel.agent_count).toBe(0)` get a number, not undefined.
-  const ensureChannelDefaults = (value: Record<string, unknown>): Record<string, unknown> => {
-    const defaults: Record<string, unknown> = {
-      agent_count: 0,
-      member_count: 0,
-      is_member: false,
-      is_archived: false,
-    };
-    return { ...defaults, ...value };
-  };
-
-  ipcMain.handle("channelCreateChannel", async (_e, requestJson: string) => {
-    const req = JSON.parse(requestJson) as Record<string, unknown>;
-    const raw = await callConnectJson(
-      "proto.channel.v1.ChannelService",
-      "CreateChannel",
-      { orgSlug: orgSlug(), ...req },
-    );
-    // Coerce int64-string fields and emit proto3 defaults (Connect-JSON
-    // omits zero values; legacy Rust napi shape always included them).
-    const parsed = JSON.parse(raw) as Record<string, unknown>;
-    return JSON.stringify(ensureChannelDefaults(coerceInt64(parsed) as Record<string, unknown>));
-  });
-
-  const refreshChannelPodsCache = async (channelId: number): Promise<void> => {
-    const raw = await callConnectJson(
-      "proto.channel.v1.ChannelService",
-      "ListChannelPods",
-      { orgSlug: orgSlug(), id: channelId },
-    );
-    const parsed = JSON.parse(raw) as { items?: Array<Record<string, unknown>> };
-    // Wrap the 5 ChannelPod summary fields into proto.pod.v1.Pod (other
-    // fields default to proto3 zeros) and dispatch via the cross-domain
-    // SSOT mutator on the NAPI bridge.
-    const protoPods = (parsed.items ?? []).map((p) => protoCreate(PodSchema, {
-      id: BigInt(typeof p.id === "number" ? p.id : Number(p.id ?? 0)),
-      podKey: String(p.podKey ?? p.pod_key ?? ""),
-      alias: p.alias != null ? String(p.alias) : undefined,
-      status: String(p.status ?? ""),
-      agentStatus: String(p.agentStatus ?? p.agent_status ?? ""),
-    }));
-    const req = protoCreate(ReplaceChannelPodsRequestSchema, {
-      channelId: BigInt(channelId),
-      pods: protoPods,
-    });
-    const bytes = toBinary(ReplaceChannelPodsRequestSchema, req);
-    // napi-rs Vec<u8> binding expects `Array<number>` over the JS boundary;
-    // Uint8Array works in some paths but the channelJoinChannel ipcMain
-    // handler (called from renderer through serialised IPC) sees the value
-    // as an opaque object without a `length` accessor. Materialise as a
-    // plain array to match the rest of the proto-bytes NAPI surface.
-    await (appState as { appChannelReplacePods: (b: number[]) => Promise<void> })
-      .appChannelReplacePods(Array.from(bytes));
-  };
-
-  const fetchChannelEnvelope = async (channelId: number): Promise<string> => {
-    const channelRaw = await callConnectJson(
-      "proto.channel.v1.ChannelService",
-      "GetChannel",
-      { orgSlug: orgSlug(), id: channelId },
-    );
-    const parsed = JSON.parse(channelRaw) as Record<string, unknown>;
-    const coerced = coerceInt64(snakeCaseDeep(parsed)) as Record<string, unknown>;
-    return JSON.stringify(ensureChannelDefaults(coerced));
-  };
-
-  ipcMain.handle("channelJoinChannel", async (_e, rawId: number | string, podKey: string) => {
-    const channelId = toIdNumber(rawId);
-    await callConnectJson(
-      "proto.channel.v1.ChannelService",
-      "JoinChannelPod",
-      { orgSlug: orgSlug(), id: channelId, podKey },
-    );
-    await refreshChannelPodsCache(channelId);
-    return fetchChannelEnvelope(channelId);
-  });
-
-  ipcMain.handle("channelLeaveChannel", async (_e, rawId: number | string, podKey: string) => {
-    const channelId = toIdNumber(rawId);
-    await callConnectJson(
-      "proto.channel.v1.ChannelService",
-      "LeaveChannelPod",
-      { orgSlug: orgSlug(), id: channelId, podKey },
-    );
-    await refreshChannelPodsCache(channelId);
-    return fetchChannelEnvelope(channelId);
-  });
-
-  ipcMain.handle("channelGetChannelPods", async (_e, rawId: number | string) => {
-    const channelId = toIdNumber(rawId);
-    await refreshChannelPodsCache(channelId);
-    // ElectronChannelService.get_channel_pods (electron-adapter) expects the
-    // legacy envelope `{pods: [...], total: N}` so it can mirror the array
-    // into its renderer-side cache. The Rust cache JSON is a bare array —
-    // wrap it back into the legacy shape.
-    const cacheJson = await (appState as { appChannelPodsJson: (id: number) => Promise<string> })
-      .appChannelPodsJson(channelId);
-    const pods = JSON.parse(cacheJson) as unknown[];
-    return JSON.stringify({ pods, total: pods.length });
-  });
-
-  // ElectronOrgService.create_personal() invokes this — main → backend
-  // proto.org.v1.OrgService/CreatePersonalOrg. Server derives slug from
-  // users.username; we return the raw Organization JSON unchanged.
-  ipcMain.handle("orgCreatePersonal", () =>
-    callConnectJson("proto.org.v1.OrgService", "CreatePersonalOrg", {}),
-  );
-
-  // ElectronAgentService.list_agents() invokes this. Renderer hooks parse
-  // the response as `{builtin_agents, custom_agents}` (snake_case); the
-  // Connect endpoint emits proto camelCase, so we remap and also rename
-  // nested keys recursively.
-  ipcMain.handle("agentListAgents", async () => {
-    const raw = await callConnectJson(
-      "proto.agent.v1.AgentService",
-      "ListAgents",
-      { orgSlug: orgSlug() },
-    );
-    const parsed = JSON.parse(raw) as {
-      builtinAgents?: unknown[];
-      customAgents?: unknown[];
-      builtin_agents?: unknown[];
-      custom_agents?: unknown[];
-    };
-    return JSON.stringify({
-      builtin_agents: (parsed.builtin_agents ?? parsed.builtinAgents ?? []).map(snakeCaseDeep),
-      custom_agents: (parsed.custom_agents ?? parsed.customAgents ?? []).map(snakeCaseDeep),
-    });
-  });
-
-  // ElectronRepositoryService.list() invokes this. The renderer cache
-  // expects `{repositories: [...]}` (legacy REST shape) while the
-  // Connect endpoint returns `{items, total, ...}` — remap. Also
-  // convert proto camelCase fields to snake_case for legacy callers.
-  ipcMain.handle("repositoryList", async () => {
-    const raw = await callConnectJson(
-      "proto.repository.v1.RepositoryService",
-      "ListRepositories",
-      { orgSlug: orgSlug() },
-    );
-    const parsed = JSON.parse(raw) as { items?: unknown[] };
-    return JSON.stringify({ repositories: (parsed.items ?? []).map(snakeCaseDeep) });
-  });
-
-  // ElectronRunnerService list flows through Connect now; desktop e2e specs
-  // still seed pods via `runnerFetchRunners` by name. Connect returns
-  // `{items, ...}` — remap to the legacy `{runners: [...]}` shape the specs
-  // parse, snake_case nested fields, and coerce the int64 `id` to a number
-  // (the specs reuse it as `runner_id` for podCreatePod).
-  ipcMain.handle("runnerFetchRunners", async () => {
-    const raw = await callConnectJson(
-      "proto.runner_api.v1.RunnerService",
-      "ListRunners",
-      { orgSlug: orgSlug() },
-    );
-    const parsed = JSON.parse(raw) as { items?: unknown[] };
-    return JSON.stringify({
-      runners: (parsed.items ?? []).map((r) => coerceInt64(snakeCaseDeep(r))),
-    });
-  });
-
-  // ElectronPodService.create_pod() invokes this. The renderer hands us
-  // a JSON request payload using snake_case (legacy REST shape); we
-  // upgrade it to the proto camelCase shape Connect expects and remap
-  // the response back to snake_case for the renderer's pod cache.
-  ipcMain.handle("podCreatePod", async (_e, requestJson: string) => {
-    const req = JSON.parse(requestJson) as Record<string, unknown>;
-    // Pass through every field unchanged; the Connect JSON layer accepts
-    // both proto camelCase AND grpc-gateway snake_case via @bufbuild/protobuf.
-    const raw = await callConnectJson(
-      "proto.pod.v1.PodService",
-      "CreatePod",
-      { orgSlug: orgSlug(), ...req },
-    );
-    const parsed = JSON.parse(raw) as Record<string, unknown>;
-    return JSON.stringify(snakeCaseDeep(parsed));
-  });
-
-  // Counterpart to podCreatePod. The realtime bridge e2e specs depend on
-  // it for cleanup. Renderer hands us a pod_key string; we route to
-  // Connect proto.pod.v1.PodService/TerminatePod.
-  ipcMain.handle("podTerminatePod", async (_e, podKey: string) => {
-    await callConnectJson(
-      "proto.pod.v1.PodService",
-      "TerminatePod",
-      { orgSlug: orgSlug(), podKey },
-    );
-  });
-
-  // Generic binary Connect-RPC proxy. Web's wasm-side services expose
-  // `<method>Connect(Uint8Array) -> Uint8Array`; ElectronXxxService
-  // adapters that don't yet have hand-written `_connect` IPC handlers
-  // route through this instead. The protobuf encode/decode stays on the
-  // renderer; main only ferries bytes (as number[]) over IPC and forwards
-  // to the backend Connect endpoint.
-  ipcMain.handle("connectCall", async (
-    _e, service: string, method: string, bodyArr: number[],
-  ) => {
-    const url = `${currentApiUrl}/${service}/${method}`;
-    const token = (appState as { authGetToken?: () => string | null }).authGetToken?.();
-    const headers: Record<string, string> = {
-      "Content-Type": "application/proto",
-      "Connect-Protocol-Version": "1",
-    };
-    if (token) headers.Authorization = `Bearer ${token}`;
-    // Desktop's renderer has no wasm, so ElectronXxxService RPCs egress HERE,
-    // bypassing the Rust api-client connect_call sink — this is the only place
-    // these calls are observable. Log method + byte count, never headers/body.
-    logEvent("debug", "ipc-rpc", `${service}/${method} (${bodyArr.length}B)`);
-    let res: Response;
-    try {
-      res = await connectFetch(url, {
-        method: "POST",
-        headers,
-        body: Uint8Array.from(bodyArr),
-      });
-    } catch (err) {
-      logEvent("warn", "ipc-rpc", `${service}/${method} → network error`);
-      throw connectNetworkError(err);
-    }
-    if (!res.ok) {
-      logEvent("warn", "ipc-rpc", `${service}/${method} → ${res.status}`);
-      throw await connectErrorFromResponse(res);
-    }
-    const bytes = new Uint8Array(await res.arrayBuffer());
-    return Array.from(bytes);
-  });
-}
-
-function buildMenu() {
-  const isMac = process.platform === "darwin";
-  const template: Electron.MenuItemConstructorOptions[] = [
-    ...(isMac ? ([{ role: "appMenu" }] as Electron.MenuItemConstructorOptions[]) : []),
-    { role: "fileMenu" },
-    { role: "editMenu" },
-    { role: "viewMenu" },
-    { role: "windowMenu" },
-    {
-      role: "help",
-      submenu: [
-        {
-          label: "Open Logs",
-          click: async () => {
-            await shell.openPath(logsDir);
-          },
-        },
-      ],
-    },
-  ];
-  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 }
 
 app.whenReady().then(() => {
@@ -658,22 +168,31 @@ app.whenReady().then(() => {
     stubs = createLocalRunnerStubs();
   }
   registerStaticHandlers();
-  bindAppStateHandlers();
-  // Wire the realtime EventBus bridge BEFORE createWindow() so the renderer's
+  bindAppStateHandlers({ appState, stubs, tracked: appStateHandlers });
+  // MUST follow bindAppStateHandlers (which clears appStateHandlers): connectCall +
+  // aliases aren't in the allowlist, so registering earlier gets them wiped.
+  registerConnectCall({ getAppState: () => appState, getApiUrl: () => currentApiUrl }, appStateHandlers);
+  registerLegacyApiAliases({ getAppState: () => appState, getApiUrl: () => currentApiUrl }, appStateHandlers);
+  // Wire the realtime EventBus bridge BEFORE createPrimaryWindow() so the renderer's
   // EventSubscriptionManager finds `realtime:connect` etc. registered as soon
   // as preload runs. The stream itself doesn't start until renderer calls
   // electronAPI.invoke("realtime:connect").
-  void setupRealtimeBridge(appState, getMainWindow).then((bridge) => {
+  void setupRealtimeBridge(appState, registry).then((bridge) => {
     realtimeBridge = bridge;
   });
-  relayBridge = setupRelayBridge(appState, getMainWindow);
-  setupAutoUpdater(getMainWindow);
-  buildMenu();
-  installOpenUrlHandler(getMainWindow);
-  createWindow();
+  relayBridge = setupRelayBridge(appState, registry);
+  setupAutoUpdater(getPrimaryWindow);
+  registerWindowIpc(registry, onWindowClosed);
+  registry.setPrimaryChangeListener(() => registry.broadcast("window:primary-changed", null));
+  buildMenu({
+    logsDir,
+    onNewWindow: () => void createAppWindow(registry, { kind: "secondary", onClosed: onWindowClosed }),
+  });
+  installOpenUrlHandler(ensurePrimaryWindow);
+  createPrimaryWindow();
 
   app.on("activate", () => {
-    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+    if (!registry.hasWindows()) createPrimaryWindow();
   });
 });
 

--- a/clients/desktop/src/main/legacy_api_aliases.ts
+++ b/clients/desktop/src/main/legacy_api_aliases.ts
@@ -1,0 +1,194 @@
+import { ipcMain } from "electron";
+import { create as protoCreate, toBinary } from "@bufbuild/protobuf";
+import { ReplaceChannelPodsRequestSchema } from "@proto/channel_state/v1/mutations_pb";
+import { PodSchema } from "@proto/pod/v1/pod_pb";
+import { type AppState } from "@agentsmesh/node-bridge";
+import { makeConnectCaller } from "./connect_call";
+import { snakeCaseDeep, coerceInt64, ensureChannelDefaults, toIdNumber } from "./connect-json";
+
+const LEGACY_ALIAS_HANDLERS = [
+  "userGetMe",
+  "autopilotFetchControllers",
+  "channelCreateChannel",
+  "channelJoinChannel",
+  "channelLeaveChannel",
+  "channelGetChannelPods",
+  "orgCreatePersonal",
+  "agentListAgents",
+  "repositoryList",
+  "runnerFetchRunners",
+  "podCreatePod",
+  "podTerminatePod",
+] as const;
+
+interface LegacyAliasDeps {
+  // Getters (not values) because AppState + the resolved API URL are rebound on
+  // server switch — handlers must read the current ones each call.
+  getAppState: () => AppState;
+  getApiUrl: () => string;
+}
+
+// Legacy IPC aliases for method names that predate the R6 Connect-RPC refactor.
+// Desktop e2e specs still invoke `userGetMe` / `autopilotFetchControllers` /
+// `runnerFetchRunners` / `channelCreateChannel` by name. The Rust napi handlers
+// were renamed (and switched to proto binary payloads) without an alias hop, so
+// the invokes hit `No handler registered`. We forward through the Connect JSON
+// wire here — it preserves the failure-surface details the orbstack-port-conflict
+// spec depends on (status + URL in the error message) and avoids dragging
+// proto-js into the main bundle.
+export function registerLegacyApiAliases(
+  { getAppState, getApiUrl }: LegacyAliasDeps,
+  tracked: Set<string>,
+): void {
+  for (const ch of LEGACY_ALIAS_HANDLERS) {
+    ipcMain.removeHandler(ch);
+    tracked.add(ch);
+  }
+  const { callConnectJson, orgSlug } = makeConnectCaller({ getAppState, getApiUrl });
+
+  ipcMain.handle("userGetMe", () =>
+    callConnectJson("proto.user.v1.UserService", "GetMe"),
+  );
+  ipcMain.handle("autopilotFetchControllers", () =>
+    callConnectJson(
+      "proto.autopilot.v1.AutopilotControllerService",
+      "ListAutopilotControllers",
+      { orgSlug: orgSlug() },
+    ),
+  );
+
+  // R6 dropped the Rust channel_join_channel napi (replaced by direct
+  // ChannelService.JoinChannelPod). Renderer paths use wasm Connect; main
+  // exposes these aliases for desktop e2e specs that still invoke through IPC by
+  // name. The cache update is necessary because main's AppState holds a separate
+  // Rust state from the renderer wasm — without the app_channel_replace_pods
+  // fan-out into runtime.state, appChannelPodsJson returns empty.
+  ipcMain.handle("channelCreateChannel", async (_e, requestJson: string) => {
+    const req = JSON.parse(requestJson) as Record<string, unknown>;
+    const raw = await callConnectJson(
+      "proto.channel.v1.ChannelService",
+      "CreateChannel",
+      { orgSlug: orgSlug(), ...req },
+    );
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    return JSON.stringify(ensureChannelDefaults(coerceInt64(snakeCaseDeep(parsed)) as Record<string, unknown>));
+  });
+
+  const refreshChannelPodsCache = async (channelId: number): Promise<void> => {
+    const raw = await callConnectJson(
+      "proto.channel.v1.ChannelService",
+      "ListChannelPods",
+      { orgSlug: orgSlug(), id: channelId },
+    );
+    const parsed = JSON.parse(raw) as { items?: Array<Record<string, unknown>> };
+    // Wrap the 5 ChannelPod summary fields into proto.pod.v1.Pod (other fields
+    // default to proto3 zeros) and dispatch via the cross-domain SSOT mutator.
+    const protoPods = (parsed.items ?? []).map((p) => protoCreate(PodSchema, {
+      id: BigInt(typeof p.id === "number" ? p.id : Number(p.id ?? 0)),
+      podKey: String(p.podKey ?? p.pod_key ?? ""),
+      alias: p.alias != null ? String(p.alias) : undefined,
+      status: String(p.status ?? ""),
+      agentStatus: String(p.agentStatus ?? p.agent_status ?? ""),
+    }));
+    const req = protoCreate(ReplaceChannelPodsRequestSchema, {
+      channelId: BigInt(channelId),
+      pods: protoPods,
+    });
+    const bytes = toBinary(ReplaceChannelPodsRequestSchema, req);
+    // napi-rs Vec<u8> wants Array<number> over the JS boundary (Uint8Array is
+    // seen as an opaque object without a length accessor through serialised IPC).
+    await (getAppState() as { appChannelReplacePods: (b: number[]) => Promise<void> })
+      .appChannelReplacePods(Array.from(bytes));
+  };
+
+  const fetchChannelEnvelope = async (channelId: number): Promise<string> => {
+    const channelRaw = await callConnectJson(
+      "proto.channel.v1.ChannelService",
+      "GetChannel",
+      { orgSlug: orgSlug(), id: channelId },
+    );
+    const parsed = JSON.parse(channelRaw) as Record<string, unknown>;
+    const coerced = coerceInt64(snakeCaseDeep(parsed)) as Record<string, unknown>;
+    return JSON.stringify(ensureChannelDefaults(coerced));
+  };
+
+  ipcMain.handle("channelJoinChannel", async (_e, rawId: number | string, podKey: string) => {
+    const channelId = toIdNumber(rawId);
+    await callConnectJson(
+      "proto.channel.v1.ChannelService",
+      "JoinChannelPod",
+      { orgSlug: orgSlug(), id: channelId, podKey },
+    );
+    await refreshChannelPodsCache(channelId);
+    return fetchChannelEnvelope(channelId);
+  });
+
+  ipcMain.handle("channelLeaveChannel", async (_e, rawId: number | string, podKey: string) => {
+    const channelId = toIdNumber(rawId);
+    await callConnectJson(
+      "proto.channel.v1.ChannelService",
+      "LeaveChannelPod",
+      { orgSlug: orgSlug(), id: channelId, podKey },
+    );
+    await refreshChannelPodsCache(channelId);
+    return fetchChannelEnvelope(channelId);
+  });
+
+  ipcMain.handle("channelGetChannelPods", async (_e, rawId: number | string) => {
+    const channelId = toIdNumber(rawId);
+    await refreshChannelPodsCache(channelId);
+    // ElectronChannelService.get_channel_pods expects `{pods, total}`; the Rust
+    // cache JSON is a bare array — wrap it back into the legacy shape.
+    const cacheJson = await (getAppState() as { appChannelPodsJson: (id: number) => Promise<string> })
+      .appChannelPodsJson(channelId);
+    const pods = JSON.parse(cacheJson) as unknown[];
+    return JSON.stringify({ pods, total: pods.length });
+  });
+
+  ipcMain.handle("orgCreatePersonal", () =>
+    callConnectJson("proto.org.v1.OrgService", "CreatePersonalOrg", {}),
+  );
+
+  // Renderer parses `{builtin_agents, custom_agents}` (snake_case); Connect emits
+  // proto camelCase — remap + rename nested keys recursively.
+  ipcMain.handle("agentListAgents", async () => {
+    const raw = await callConnectJson("proto.agent.v1.AgentService", "ListAgents", { orgSlug: orgSlug() });
+    const parsed = JSON.parse(raw) as {
+      builtinAgents?: unknown[]; customAgents?: unknown[];
+      builtin_agents?: unknown[]; custom_agents?: unknown[];
+    };
+    return JSON.stringify({
+      builtin_agents: (parsed.builtin_agents ?? parsed.builtinAgents ?? []).map(snakeCaseDeep),
+      custom_agents: (parsed.custom_agents ?? parsed.customAgents ?? []).map(snakeCaseDeep),
+    });
+  });
+
+  // Renderer cache expects `{repositories: [...]}`; Connect returns `{items}`.
+  ipcMain.handle("repositoryList", async () => {
+    const raw = await callConnectJson("proto.repository.v1.RepositoryService", "ListRepositories", { orgSlug: orgSlug() });
+    const parsed = JSON.parse(raw) as { items?: unknown[] };
+    return JSON.stringify({ repositories: (parsed.items ?? []).map(snakeCaseDeep) });
+  });
+
+  // e2e seeds pods via `runnerFetchRunners`; remap `{items}`→`{runners}`,
+  // snake_case nested fields, coerce int64 `id` (reused as runner_id).
+  ipcMain.handle("runnerFetchRunners", async () => {
+    const raw = await callConnectJson("proto.runner_api.v1.RunnerService", "ListRunners", { orgSlug: orgSlug() });
+    const parsed = JSON.parse(raw) as { items?: unknown[] };
+    return JSON.stringify({
+      runners: (parsed.items ?? []).map((r) => coerceInt64(snakeCaseDeep(r))),
+    });
+  });
+
+  // Renderer hands snake_case (legacy REST); Connect JSON accepts both shapes.
+  ipcMain.handle("podCreatePod", async (_e, requestJson: string) => {
+    const req = JSON.parse(requestJson) as Record<string, unknown>;
+    const raw = await callConnectJson("proto.pod.v1.PodService", "CreatePod", { orgSlug: orgSlug(), ...req });
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    return JSON.stringify(snakeCaseDeep(parsed));
+  });
+
+  ipcMain.handle("podTerminatePod", async (_e, podKey: string) => {
+    await callConnectJson("proto.pod.v1.PodService", "TerminatePod", { orgSlug: orgSlug(), podKey });
+  });
+}

--- a/clients/desktop/src/main/menu.ts
+++ b/clients/desktop/src/main/menu.ts
@@ -1,0 +1,29 @@
+import { Menu, shell, type MenuItemConstructorOptions } from "electron";
+
+interface MenuDeps {
+  logsDir: string;
+  onNewWindow: () => void;
+}
+
+export function buildMenu(deps: MenuDeps): void {
+  const isMac = process.platform === "darwin";
+  const template: MenuItemConstructorOptions[] = [
+    ...(isMac ? [{ role: "appMenu" } as MenuItemConstructorOptions] : []),
+    {
+      label: "File",
+      submenu: [
+        { label: "New Window", accelerator: "CmdOrCtrl+N", click: deps.onNewWindow },
+        { type: "separator" },
+        isMac ? { role: "close" } : { role: "quit" },
+      ],
+    },
+    { role: "editMenu" },
+    { role: "viewMenu" },
+    { role: "windowMenu" },
+    {
+      role: "help",
+      submenu: [{ label: "Open Logs", click: () => void shell.openPath(deps.logsDir) }],
+    },
+  ];
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}

--- a/clients/desktop/src/main/realtime.ts
+++ b/clients/desktop/src/main/realtime.ts
@@ -1,242 +1,55 @@
-import { BrowserWindow, ipcMain, app, powerMonitor } from "electron";
+import { ipcMain, app, powerMonitor } from "electron";
 import { logEvent, type AppState } from "@agentsmesh/node-bridge";
+import { type WindowRegistry } from "./window_registry";
+import { pushAllSnapshots } from "./realtime_snapshots";
 
-// Bridges the backend EventBus realtime stream into the Electron renderer.
+// Bridges the backend EventBus realtime stream into renderers.
 //
 // Topology:
 //   backend EventsService.Subscribe (Connect HTTP/2)
-//     ↓
-//   AppState.eventsSubscribeAll(jsonCallback) — Rust events crate, owned by
-//   main process (single connection per AppState instance, lives until
-//   AppState is replaced via server switch).
-//     ↓
-//   webContents.send("realtime:event", eventJson)
-//     ↓
-//   preload `onRealtimeEvent` listener → renderer ElectronEventsManager →
-//   wasm-shaped EventSubscriptionManager → handler dispatch.
+//     ↓ AppState.eventsSubscribeAll(jsonCallback) — Rust events crate, single
+//       connection per AppState instance, owned by the main process.
+//     ↓ registry.broadcast("realtime:event", json) — every window's
+//       ElectronEventsManager needs the stream; each mirrors snapshots into its
+//       own renderer-local cache.
 //
-// Why route through main and not stream Connect directly from renderer:
-// the auth token + base URL + reconnect policy already live in the Rust
-// AppState. Spawning a parallel renderer-side Connect client would duplicate
-// auth state, fight over org-switch races, and require shipping the Rust
-// events crate via wasm (the whole reason desktop exists separately).
+// Routed through main (not a per-renderer Connect client) because the auth
+// token + base URL + reconnect policy live in the Rust AppState; a parallel
+// renderer client would duplicate auth state and fight org-switch races.
 
 type RealtimeState = "disconnected" | "connecting" | "connected" | "reconnecting";
 
-const CHANNEL_MESSAGE_EVENTS = new Set([
-  "channel:message",
-  "channel:message_edited",
-  "channel:message_deleted",
-]);
-
-const POD_EVENTS = new Set([
-  "pod:status_changed",
-  "pod:agent_status_changed",
-  "pod:terminated",
-  "pod:title_changed",
-  "pod:alias_changed",
-  "pod:perpetual_changed",
-]);
-
-const RUNNER_EVENTS = new Set([
-  "runner:online",
-  "runner:offline",
-  "runner:updated",
-]);
-
-const AUTOPILOT_EVENTS = new Set([
-  "autopilot:status_changed",
-  "autopilot:iteration",
-  "autopilot:thinking",
-  "autopilot:terminated",
-]);
-
-// status/agent patch a mesh node in place; structural changes (created/terminated)
-// go through the renderer's fetchTopology, not here.
-const MESH_NODE_EVENTS = new Set([
-  "pod:status_changed",
-  "pod:agent_status_changed",
-]);
-
-// After a channel message event, read the post-dispatch runtime.state channel
-// snapshot (messages + unread + mention, all Rust-computed) and push it to the
-// renderer over a dedicated IPC channel. The renderer mirrors it into its
-// ElectronChannelService cache — that cache is renderer-local and, unlike web's
-// wasm, is NOT the same memory the dispatch wrote, so a push is the only way
-// the SSOT result reaches the view.
-function pushChannelSnapshot(
-  appState: AppState,
-  eventJson: string,
-  send: (channel: string, payload: unknown) => void,
-): void {
-  let ev: { type?: string; data?: Record<string, unknown> };
-  try {
-    ev = JSON.parse(eventJson) as { type?: string; data?: Record<string, unknown> };
-  } catch {
-    return;
-  }
-  if (!ev.type || !CHANNEL_MESSAGE_EVENTS.has(ev.type)) return;
-  const rawId = ev.data?.channel_id ?? ev.data?.channelId;
-  const channelId = Number(rawId);
-  if (!Number.isFinite(channelId) || channelId <= 0) return;
-  try {
-    send("realtime:state-sync", JSON.stringify({
-      domain: "channel",
-      channelId,
-      messages: appState.appChannelMessagesJson(channelId),
-      unreadCounts: appState.appChannelUnreadCountsJson(),
-      mentionCounts: appState.appChannelMentionCountsJson(),
-    }));
-  } catch {
-    /* best-effort: a stale window or lock contention must not break forwarding */
-  }
-}
-
-// Surgical pod snapshot: read the single Rust-computed pod from runtime.state
-// and push it. The renderer upserts it in-place only if already cached (the
-// pod sidebar is filtered — a brand-new pod arrives via the handler's
-// fetchPod refetch, not this mirror). Empty pod → nothing to mirror.
-function pushPodSnapshot(
-  appState: AppState,
-  eventJson: string,
-  send: (channel: string, payload: unknown) => void,
-): void {
-  let ev: { type?: string; data?: Record<string, unknown> };
-  try {
-    ev = JSON.parse(eventJson) as { type?: string; data?: Record<string, unknown> };
-  } catch {
-    return;
-  }
-  if (!ev.type || !POD_EVENTS.has(ev.type)) return;
-  const rawKey = ev.data?.pod_key ?? ev.data?.podKey;
-  if (typeof rawKey !== "string" || rawKey.length === 0) return;
-  try {
-    const podBytes = appState.appGetPodProto(rawKey);
-    if (podBytes.length)
-      send("realtime:state-sync", JSON.stringify({ domain: "pod", podKey: rawKey, pod: Array.from(podBytes) }));
-  } catch {
-    /* best-effort */
-  }
-}
-
-// Runner online/offline/updated → push the Rust-computed runner lists. The
-// renderer replaces its three caches (runners + available + current). Runner
-// realtime has no refetch fallback on desktop, so this mirror is what keeps
-// the runner views live after the JS pure-patch is removed.
-function pushRunnerSnapshot(
-  appState: AppState,
-  eventJson: string,
-  send: (channel: string, payload: unknown) => void,
-): void {
-  let ev: { type?: string };
-  try {
-    ev = JSON.parse(eventJson) as { type?: string };
-  } catch {
-    return;
-  }
-  if (!ev.type || !RUNNER_EVENTS.has(ev.type)) return;
-  try {
-    send("realtime:state-sync", JSON.stringify({
-      domain: "runner",
-      runners: Array.from(appState.appRunnersProto()),
-      available: Array.from(appState.appAvailableRunnersProto()),
-      current: Array.from(appState.appCurrentRunnerProto()),
-    }));
-  } catch {
-    /* best-effort */
-  }
-}
-
-// Autopilot status/iteration/thinking/terminated → push the Rust-computed
-// controller list + the affected key's iterations + thinking + history. The
-// renderer mirrors into its per-key caches. autopilot:created stays on the
-// handler's refetch (full payload from server).
-function pushAutopilotSnapshot(
-  appState: AppState,
-  eventJson: string,
-  send: (channel: string, payload: unknown) => void,
-): void {
-  let ev: { type?: string; data?: Record<string, unknown> };
-  try {
-    ev = JSON.parse(eventJson) as { type?: string; data?: Record<string, unknown> };
-  } catch {
-    return;
-  }
-  if (!ev.type || !AUTOPILOT_EVENTS.has(ev.type)) return;
-  const rawKey = ev.data?.autopilot_controller_key ?? ev.data?.autopilotControllerKey;
-  const key = typeof rawKey === "string" ? rawKey : "";
-  try {
-    send("realtime:state-sync", JSON.stringify({
-      domain: "autopilot",
-      key,
-      controllers: Array.from(appState.appAutopilotControllersProto()),
-      iterations: key ? Array.from(appState.appAutopilotIterationsProto(key)) : [],
-      thinking: key ? appState.appAutopilotThinkingJson(key) : "",
-      thinkingHistory: key ? appState.appAutopilotThinkingHistoryJson(key) : "",
-    }));
-  } catch {
-    /* best-effort */
-  }
-}
-
-// Read the Rust-patched mesh node and push it for the renderer to patch its
-// topology cache in place. Empty node → not a topology node, skip.
-function pushMeshNodeSnapshot(
-  appState: AppState,
-  eventJson: string,
-  send: (channel: string, payload: unknown) => void,
-): void {
-  let ev: { type?: string; data?: Record<string, unknown> };
-  try {
-    ev = JSON.parse(eventJson) as { type?: string; data?: Record<string, unknown> };
-  } catch {
-    return;
-  }
-  if (!ev.type || !MESH_NODE_EVENTS.has(ev.type)) return;
-  const rawKey = ev.data?.pod_key ?? ev.data?.podKey;
-  if (typeof rawKey !== "string" || rawKey.length === 0) return;
-  try {
-    const node = appState.appGetMeshNodeJson(rawKey);
-    if (node) send("realtime:state-sync", JSON.stringify({ domain: "mesh", podKey: rawKey, node }));
-  } catch {
-    /* best-effort */
-  }
-}
-
 export interface RealtimeBridge {
-  // Tear down the subscription, forwarder, and IPC handlers. Required
-  // before swapping AppState (server-switch flow) so the old stream's
-  // callback closure doesn't keep firing into a stale window.
   dispose: () => Promise<void>;
   currentState: () => RealtimeState;
+  releaseWebContents: (wcId: number) => void;
 }
 
 export async function setupRealtimeBridge(
   appState: AppState,
-  getMainWindow: () => BrowserWindow | null,
+  registry: WindowRegistry,
 ): Promise<RealtimeBridge> {
   let state: RealtimeState = "disconnected";
+  const send = (channel: string, payload: unknown) => registry.broadcast(channel, payload);
 
-  const send = (channel: string, payload: unknown) => {
-    const win = getMainWindow();
-    if (!win || win.isDestroyed()) return;
-    win.webContents.send(channel, payload);
+  // The EventBus connection lives iff ≥1 window's RealtimeProvider is mounted.
+  // connect() always runs (it re-targets the current org on switch); disconnect()
+  // only tears down the shared stream when the LAST window leaves — otherwise
+  // closing a popout would kill realtime for every other window.
+  const connectedWcs = new Set<number>();
+  const disconnectIfIdle = async (): Promise<void> => {
+    // Prune ids whose window died without firing `closed` (e.g. renderer crash),
+    // else a leaked id would pin the shared stream open forever.
+    for (const id of connectedWcs) if (!registry.has(id)) connectedWcs.delete(id);
+    if (connectedWcs.size > 0) return;
+    logEvent("info", "realtime", "disconnect requested (last window)");
+    await appState.eventsDisconnect();
   };
 
-  // napi-rs ThreadsafeFunction<T> defaults to CalleeHandled=true, so
-  // the JS callback signature is `(err, value)` — not `(value)`. The
-  // first argument is null on success; the actual payload is the second.
   const eventSubId = await appState.eventsSubscribeAll((_err: unknown, eventJson: string) => {
     send("realtime:event", eventJson);
-    // The dispatch hook has already mutated runtime.state by the time this
-    // external subscriber fires (hook runs before subscribers). Read the
-    // Rust-computed channel snapshot and push it so the renderer — which has
-    // no in-process Rust — can mirror unread/mention/preview the SSOT derived.
-    pushChannelSnapshot(appState, eventJson, send);
-    pushPodSnapshot(appState, eventJson, send);
-    pushRunnerSnapshot(appState, eventJson, send);
-    pushAutopilotSnapshot(appState, eventJson, send);
-    pushMeshNodeSnapshot(appState, eventJson, send);
+    // Skip the (up to 5) Rust proto-encodes when no window is open to receive them.
+    if (registry.hasWindows()) pushAllSnapshots(appState, eventJson, send);
   });
   logEvent("info", "realtime", "bridge subscribed");
   const stateSubId = await appState.eventsOnConnectionStateChange((_err: unknown, next: string) => {
@@ -247,24 +60,20 @@ export async function setupRealtimeBridge(
     send("realtime:state", next);
   });
 
-  const connectHandler = async (): Promise<void> => {
+  ipcMain.handle("realtime:connect", async (e) => {
+    connectedWcs.add(e.sender.id);
     logEvent("info", "realtime", "connect requested");
     await appState.eventsConnect();
-  };
-  const disconnectHandler = async (): Promise<void> => {
-    logEvent("info", "realtime", "disconnect requested");
-    await appState.eventsDisconnect();
-  };
-  const getStateHandler = (): RealtimeState => state;
-
-  ipcMain.handle("realtime:connect", () => connectHandler());
-  ipcMain.handle("realtime:disconnect", () => disconnectHandler());
+  });
+  ipcMain.handle("realtime:disconnect", async (e) => {
+    connectedWcs.delete(e.sender.id);
+    await disconnectIfIdle();
+  });
   ipcMain.handle("realtime:nudge", () => appState.eventsNudge());
-  ipcMain.handle("realtime:getState", () => getStateHandler());
+  ipcMain.handle("realtime:getState", () => state);
 
-  // Re-arm on laptop wake / app refocus: skip the Rust reconnect backoff and
-  // retry now. nudge() is a no-op when already connected, so firing it on every
-  // focus is harmless. powerMonitor covers system resume the renderer can't see.
+  // Re-arm on laptop wake / app refocus: skip the Rust reconnect backoff.
+  // nudge() is a no-op when already connected, so firing on every focus is safe.
   const reArm = () => {
     logEvent("debug", "realtime", "re-arm (resume/focus) → nudge");
     void appState.eventsNudge();
@@ -274,14 +83,17 @@ export async function setupRealtimeBridge(
 
   return {
     currentState: () => state,
+    releaseWebContents: (wcId: number) => {
+      connectedWcs.delete(wcId);
+      void disconnectIfIdle();
+    },
     dispose: async () => {
       logEvent("info", "realtime", "bridge disposed");
-      ipcMain.removeHandler("realtime:connect");
-      ipcMain.removeHandler("realtime:disconnect");
-      ipcMain.removeHandler("realtime:nudge");
-      ipcMain.removeHandler("realtime:getState");
+      for (const ch of ["realtime:connect", "realtime:disconnect", "realtime:nudge", "realtime:getState"])
+        ipcMain.removeHandler(ch);
       powerMonitor.removeListener("resume", reArm);
       app.removeListener("browser-window-focus", reArm);
+      connectedWcs.clear();
       try { await appState.eventsDisconnect(); } catch { /* best-effort */ }
       try { await appState.eventsUnsubscribe(eventSubId); } catch { /* best-effort */ }
       try { await appState.eventsUnsubscribe(stateSubId); } catch { /* best-effort */ }

--- a/clients/desktop/src/main/realtime_snapshots.ts
+++ b/clients/desktop/src/main/realtime_snapshots.ts
@@ -1,0 +1,136 @@
+import { type AppState } from "@agentsmesh/node-bridge";
+
+// Surgical runtime.state snapshot pushes. After each EventBus dispatch the Rust
+// hook has already mutated runtime.state; we read the Rust-computed result and
+// push it so renderers — which have no in-process Rust — can mirror the SSOT
+// into their renderer-local service caches. Broadcast to every window: each
+// mirrors into its own cache.
+
+type Send = (channel: string, payload: unknown) => void;
+
+const CHANNEL_MESSAGE_EVENTS = new Set([
+  "channel:message",
+  "channel:message_edited",
+  "channel:message_deleted",
+]);
+
+const POD_EVENTS = new Set([
+  "pod:status_changed",
+  "pod:agent_status_changed",
+  "pod:terminated",
+  "pod:title_changed",
+  "pod:alias_changed",
+  "pod:perpetual_changed",
+]);
+
+const RUNNER_EVENTS = new Set(["runner:online", "runner:offline", "runner:updated"]);
+
+const AUTOPILOT_EVENTS = new Set([
+  "autopilot:status_changed",
+  "autopilot:iteration",
+  "autopilot:thinking",
+  "autopilot:terminated",
+]);
+
+// status/agent patch a mesh node in place; structural changes (created/terminated)
+// go through the renderer's fetchTopology, not here.
+const MESH_NODE_EVENTS = new Set(["pod:status_changed", "pod:agent_status_changed"]);
+
+function parseEvent(eventJson: string): { type?: string; data?: Record<string, unknown> } | null {
+  try {
+    return JSON.parse(eventJson) as { type?: string; data?: Record<string, unknown> };
+  } catch {
+    return null;
+  }
+}
+
+export function pushAllSnapshots(appState: AppState, eventJson: string, send: Send): void {
+  const ev = parseEvent(eventJson);
+  if (!ev?.type) return;
+  pushChannelSnapshot(appState, ev, send);
+  pushPodSnapshot(appState, ev, send);
+  pushRunnerSnapshot(appState, ev, send);
+  pushAutopilotSnapshot(appState, ev, send);
+  pushMeshNodeSnapshot(appState, ev, send);
+}
+
+type Ev = { type?: string; data?: Record<string, unknown> };
+
+function pushChannelSnapshot(appState: AppState, ev: Ev, send: Send): void {
+  if (!ev.type || !CHANNEL_MESSAGE_EVENTS.has(ev.type)) return;
+  const rawId = ev.data?.channel_id ?? ev.data?.channelId;
+  if (rawId == null) return;
+  const channelId = Number(rawId);
+  if (!Number.isFinite(channelId) || channelId <= 0) return;
+  try {
+    send("realtime:state-sync", JSON.stringify({
+      domain: "channel",
+      channelId,
+      messages: appState.appChannelMessagesJson(channelId),
+      unreadCounts: appState.appChannelUnreadCountsJson(),
+      mentionCounts: appState.appChannelMentionCountsJson(),
+    }));
+  } catch {
+    /* best-effort: a stale window or lock contention must not break forwarding */
+  }
+}
+
+// Surgical pod snapshot: read the single Rust-computed pod and push it. The
+// renderer upserts in place only if already cached (a brand-new pod arrives via
+// the handler's fetchPod refetch, not this mirror). Empty pod → nothing to do.
+function pushPodSnapshot(appState: AppState, ev: Ev, send: Send): void {
+  if (!ev.type || !POD_EVENTS.has(ev.type)) return;
+  const rawKey = ev.data?.pod_key ?? ev.data?.podKey;
+  if (typeof rawKey !== "string" || rawKey.length === 0) return;
+  try {
+    const podBytes = appState.appGetPodProto(rawKey);
+    if (podBytes.length)
+      send("realtime:state-sync", JSON.stringify({ domain: "pod", podKey: rawKey, pod: Array.from(podBytes) }));
+  } catch {
+    /* best-effort */
+  }
+}
+
+function pushRunnerSnapshot(appState: AppState, ev: Ev, send: Send): void {
+  if (!ev.type || !RUNNER_EVENTS.has(ev.type)) return;
+  try {
+    send("realtime:state-sync", JSON.stringify({
+      domain: "runner",
+      runners: Array.from(appState.appRunnersProto()),
+      available: Array.from(appState.appAvailableRunnersProto()),
+      current: Array.from(appState.appCurrentRunnerProto()),
+    }));
+  } catch {
+    /* best-effort */
+  }
+}
+
+function pushAutopilotSnapshot(appState: AppState, ev: Ev, send: Send): void {
+  if (!ev.type || !AUTOPILOT_EVENTS.has(ev.type)) return;
+  const rawKey = ev.data?.autopilot_controller_key ?? ev.data?.autopilotControllerKey;
+  const key = typeof rawKey === "string" ? rawKey : "";
+  try {
+    send("realtime:state-sync", JSON.stringify({
+      domain: "autopilot",
+      key,
+      controllers: Array.from(appState.appAutopilotControllersProto()),
+      iterations: key ? Array.from(appState.appAutopilotIterationsProto(key)) : [],
+      thinking: key ? appState.appAutopilotThinkingJson(key) : "",
+      thinkingHistory: key ? appState.appAutopilotThinkingHistoryJson(key) : "",
+    }));
+  } catch {
+    /* best-effort */
+  }
+}
+
+function pushMeshNodeSnapshot(appState: AppState, ev: Ev, send: Send): void {
+  if (!ev.type || !MESH_NODE_EVENTS.has(ev.type)) return;
+  const rawKey = ev.data?.pod_key ?? ev.data?.podKey;
+  if (typeof rawKey !== "string" || rawKey.length === 0) return;
+  try {
+    const node = appState.appGetMeshNodeJson(rawKey);
+    if (node) send("realtime:state-sync", JSON.stringify({ domain: "mesh", podKey: rawKey, node }));
+  } catch {
+    /* best-effort */
+  }
+}

--- a/clients/desktop/src/main/relay.ts
+++ b/clients/desktop/src/main/relay.ts
@@ -1,35 +1,38 @@
-import { BrowserWindow, ipcMain } from "electron";
+import { ipcMain } from "electron";
 import { logEvent, type AppState } from "@agentsmesh/node-bridge";
+import { type WindowRegistry } from "./window_registry";
 
 // Bridges the Rust `RelayConnectionPool` (terminal data plane SSOT, owned by the
-// main process) to the renderer. Renderer → main: `relay:*` invoke handlers map
-// onto the `appState.relay*` NAPI methods. Main → renderer: the pool's
-// output/status/acp callbacks fan out via `webContents.send`.
+// main process) to renderers. Renderer → main: `relay:*` invoke handlers map onto
+// `appState.relay*` NAPI methods. Main → renderer: output/status/acp fan out via
+// the registry, DIRECTED to only the webContents subscribed to that pod — PTY
+// bytes are high-volume, never broadcast them to uninterested windows.
 //
-// The pool fans output to EVERY subscriber. To keep ONE coalesced IPC stream
-// per pod (and avoid doubling when terminal + ACP share a pod), the bridge is
-// itself the single pool subscriber per pod (`__bridge__`); the renderer's
-// ElectronRelayManager re-fans the stream to its per-subId callbacks. Renderer
-// subIds drive ref-counting only — when the last one unsubscribes the bridge
-// drops `__bridge__`, letting the pool's grace timer disconnect.
+// The pool fans output to EVERY subscriber, so to keep ONE coalesced Rust link
+// per pod (and avoid doubling when terminal + ACP share a pod) the bridge is the
+// single pool subscriber per pod (`__bridge__`). `rendererSubs` is both the
+// multicast routing table and the cross-window ref-count: a pod's Rust link lives
+// iff ≥1 webContents subscribes it. Keyed by webContentsId so two windows viewing
+// the same pod don't collide on the (podKey-derived) subId string. Every teardown
+// path (unsubscribe / disconnect / disconnectAll / window close) is per-webContents
+// so one window leaving never tears down a link another window still needs.
 
 const BRIDGE_SUB = "__bridge__";
 
 export interface RelayBridge {
+  releaseWebContents: (wcId: number) => void;
   dispose: () => void;
 }
 
-export function setupRelayBridge(
-  appState: AppState,
-  getMainWindow: () => BrowserWindow | null,
-): RelayBridge {
-  const send = (channel: string, payload: unknown) => {
-    const win = getMainWindow();
-    if (!win || win.isDestroyed()) return;
-    win.webContents.send(channel, payload);
+export function setupRelayBridge(appState: AppState, registry: WindowRegistry): RelayBridge {
+  const rendererSubs = new Map<string, Map<number, Set<string>>>();
+
+  const sendToPod = (podKey: string, channel: string, payload: unknown) => {
+    const byWc = rendererSubs.get(podKey);
+    if (!byWc) return;
+    for (const wcId of byWc.keys()) registry.sendTo(wcId, channel, payload);
   };
 
-  // Per-pod output coalescing: accumulate frames, flush once on the next tick.
   const pending = new Map<string, number[]>();
   let flushScheduled = false;
   const scheduleFlush = () => {
@@ -38,7 +41,7 @@ export function setupRelayBridge(
     setImmediate(() => {
       flushScheduled = false;
       for (const [podKey, bytes] of pending) {
-        send("relay:output", { podKey, data: Uint8Array.from(bytes) });
+        sendToPod(podKey, "relay:output", { podKey, data: Uint8Array.from(bytes) });
       }
       pending.clear();
     });
@@ -50,75 +53,127 @@ export function setupRelayBridge(
     scheduleFlush();
   };
 
-  const rendererSubs = new Map<string, Set<string>>();
-  // status/acp listeners are pod-scoped and survive reconnects (the pool keeps
-  // them keyed by pod, and has no per-listener removal) — wire them once.
-  const listenersWired = new Set<string>();
+  const subscribe = async (wcId: number, podKey: string, subId: string, url: string, token: string) => {
+    const existed = rendererSubs.has(podKey);
+    let byWc = rendererSubs.get(podKey);
+    if (!byWc) {
+      byWc = new Map();
+      rendererSubs.set(podKey, byWc);
+    }
+    let subs = byWc.get(wcId);
+    if (!subs) {
+      subs = new Set();
+      byWc.set(wcId, subs);
+    }
+    subs.add(subId);
+    if (existed) {
+      logEvent("debug", "relay", `subscribe ${podKey} (reuse, ${byWc.size} win)`);
+      return;
+    }
+    logEvent("info", "relay", `subscribe ${podKey} (new link)`);
+    await appState.relaySubscribe(podKey, BRIDGE_SUB, url, token, onOutput(podKey));
+    // Wire status/ACP on every new link. The Rust pool replaces (not appends) the
+    // per-pod listener, so re-wiring after a teardown→resubscribe stays a single
+    // listener — no stale guard to desync, no double-fire.
+    await appState.relayOnStatusChange(podKey, (_e: unknown, json: string) =>
+      sendToPod(podKey, "relay:status", { podKey, json }),
+    );
+    await appState.relayOnAcpMessage(podKey, (_e: unknown, json: string) =>
+      sendToPod(podKey, "relay:acp", { podKey, json }),
+    );
+  };
+
+  // Returns true when this drop emptied the pod across ALL windows (caller tears
+  // down the Rust link).
+  const dropSub = (wcId: number, podKey: string, subId: string): boolean => {
+    const byWc = rendererSubs.get(podKey);
+    if (!byWc) return false;
+    const subs = byWc.get(wcId);
+    if (!subs) return false;
+    subs.delete(subId);
+    if (subs.size === 0) byWc.delete(wcId);
+    if (byWc.size > 0) return false;
+    rendererSubs.delete(podKey);
+    return true;
+  };
+
+  const unsubscribe = (wcId: number, podKey: string, subId: string) => {
+    if (!dropSub(wcId, podKey, subId)) {
+      logEvent("debug", "relay", `unsubscribe ${podKey}`);
+      return undefined;
+    }
+    logEvent("info", "relay", `unsubscribe ${podKey} (last, dropping link)`);
+    return appState.relayUnsubscribe(podKey, BRIDGE_SUB);
+  };
+
+  // Drop a single window's hold on one pod. Only when no window subscribes the
+  // pod anymore do we actually disconnect the Rust link — a renderer-driven
+  // `relay:disconnect` must not tear down a pod another window still views.
+  const disconnectPodForWc = (wcId: number, podKey: string) => {
+    const byWc = rendererSubs.get(podKey);
+    if (!byWc || !byWc.has(wcId)) return undefined;
+    byWc.delete(wcId);
+    if (byWc.size > 0) return undefined;
+    rendererSubs.delete(podKey);
+    return appState.relayDisconnect(podKey);
+  };
+
+  // A window closing (or its renderer's beforeunload) releases only ITS OWN
+  // subscriptions and ref-counts each pod's Rust link down — never a global
+  // teardown, which would starve every other live window's terminals.
+  const releaseWebContents = (wcId: number) => {
+    for (const [podKey, byWc] of [...rendererSubs]) {
+      if (!byWc.has(wcId)) continue;
+      byWc.delete(wcId);
+      if (byWc.size === 0) {
+        rendererSubs.delete(podKey);
+        void appState.relayUnsubscribe(podKey, BRIDGE_SUB).catch((e: unknown) =>
+          logEvent("warn", "relay", `relayUnsubscribe ${podKey} failed: ${e}`),
+        );
+      }
+    }
+  };
+
+  ipcMain.handle("relay:subscribe", (e, podKey: string, subId: string, url: string, token: string) =>
+    subscribe(e.sender.id, podKey, subId, url, token),
+  );
+  ipcMain.handle("relay:unsubscribe", (e, podKey: string, subId: string) =>
+    unsubscribe(e.sender.id, podKey, subId),
+  );
+  ipcMain.handle("relay:disconnect", (e, podKey: string) => disconnectPodForWc(e.sender.id, podKey));
+  // beforeunload fires this from the unloading window — release just its subs.
+  ipcMain.handle("relay:disconnectAll", (e) => releaseWebContents(e.sender.id));
 
   const handlers: Record<string, (...args: never[]) => unknown> = {
-    "relay:subscribe": async (podKey: string, subId: string, url: string, token: string) => {
-      const subs = rendererSubs.get(podKey);
-      if (subs) {
-        subs.add(subId);
-        logEvent("debug", "relay", `subscribe ${podKey} (reuse, ${subs.size} subs)`);
-        return;
-      }
-      rendererSubs.set(podKey, new Set([subId]));
-      logEvent("info", "relay", `subscribe ${podKey} (new link)`);
-      await appState.relaySubscribe(podKey, BRIDGE_SUB, url, token, onOutput(podKey));
-      if (!listenersWired.has(podKey)) {
-        listenersWired.add(podKey);
-        await appState.relayOnStatusChange(podKey, (_e: unknown, json: string) =>
-          send("relay:status", { podKey, json }),
-        );
-        await appState.relayOnAcpMessage(podKey, (_e: unknown, json: string) =>
-          send("relay:acp", { podKey, json }),
-        );
-      }
-    },
-    "relay:unsubscribe": (podKey: string, subId: string) => {
-      const subs = rendererSubs.get(podKey);
-      if (!subs) return undefined;
-      subs.delete(subId);
-      if (subs.size > 0) {
-        logEvent("debug", "relay", `unsubscribe ${podKey} (${subs.size} left)`);
-        return undefined;
-      }
-      rendererSubs.delete(podKey);
-      logEvent("info", "relay", `unsubscribe ${podKey} (last, dropping link)`);
-      return appState.relayUnsubscribe(podKey, BRIDGE_SUB);
-    },
     "relay:send": (podKey: string, data: string) => appState.relaySend(podKey, data),
     "relay:resize": (podKey: string, cols: number, rows: number) => appState.relaySendResize(podKey, cols, rows),
     "relay:forceResize": (podKey: string, cols: number, rows: number) => appState.relayForceResize(podKey, cols, rows),
     "relay:acpCommand": (podKey: string, command: string) => appState.relaySendAcpCommand(podKey, command),
-    "relay:disconnect": (podKey: string) => appState.relayDisconnect(podKey),
-    "relay:disconnectAll": () => appState.relayDisconnectAll(),
     "relay:getStatus": (podKey: string) => appState.relayGetStatus(podKey),
     "relay:isRunnerDisconnected": (podKey: string) => appState.relayIsRunnerDisconnected(podKey),
     "relay:getPodSize": (podKey: string) => appState.relayGetPodSize(podKey),
   };
-
   for (const [channel, fn] of Object.entries(handlers)) {
     ipcMain.handle(channel, (_e, ...args) => (fn as (...a: unknown[]) => unknown)(...args));
   }
 
-  // Single pod-disconnected sink: the pool fires this once a pod's connection
-  // is fully torn down (having already cleared that pod's status/ACP listeners).
-  // Reset the per-pod wired guard so the next subscribe re-registers them, and
-  // tell the renderer's mirror to drop its guards too.
   void appState.relayOnPodDisconnected((_e: unknown, podKey: string) => {
-    listenersWired.delete(podKey);
     logEvent("info", "relay", `pod disconnected ${podKey}`);
-    send("relay:pod-disconnected", { podKey });
+    sendToPod(podKey, "relay:pod-disconnected", { podKey });
   });
 
+  const allChannels = [
+    "relay:subscribe", "relay:unsubscribe", "relay:disconnect", "relay:disconnectAll",
+    ...Object.keys(handlers),
+  ];
   return {
+    releaseWebContents,
     dispose: () => {
-      for (const channel of Object.keys(handlers)) ipcMain.removeHandler(channel);
+      for (const channel of allChannels) ipcMain.removeHandler(channel);
       rendererSubs.clear();
-      listenersWired.clear();
-      void appState.relayDisconnectAll().catch(() => undefined);
+      void appState.relayDisconnectAll().catch((e: unknown) =>
+        logEvent("warn", "relay", `relayDisconnectAll failed: ${e}`),
+      );
     },
   };
 }

--- a/clients/desktop/src/main/window_ipc.ts
+++ b/clients/desktop/src/main/window_ipc.ts
@@ -1,0 +1,32 @@
+import { ipcMain } from "electron";
+import { createAppWindow } from "./create_window";
+import { type WindowRegistry, type WindowKind } from "./window_registry";
+
+// Renderer-driven popout windows: each kind maps to a WindowKind + a chromeless route.
+const POPOUTS: Record<string, { kind: WindowKind; route: (p: Record<string, string>) => string | null }> = {
+  channel: { kind: "channel", route: (p) => (p.id ? `/popout/channel/${p.id}` : null) },
+};
+
+export function registerWindowIpc(registry: WindowRegistry, onClosed: (wcId: number) => void): void {
+  ipcMain.handle("window:openTerminal", (_e, podKey: string) => {
+    const win = createAppWindow(registry, {
+      kind: "terminal",
+      route: `/popout/terminal/${podKey}`,
+      width: 900,
+      height: 640,
+      onClosed,
+    });
+    return win.webContents.id;
+  });
+
+  ipcMain.handle("window:open", (_e, kind: string, params: Record<string, string> = {}) => {
+    const spec = POPOUTS[kind];
+    if (!spec) throw new Error(`window:open: unknown kind "${kind}"`);
+    const route = spec.route(params);
+    if (!route) throw new Error(`window:open: "${kind}" missing required params`);
+    const win = createAppWindow(registry, { kind: spec.kind, route, onClosed });
+    return win.webContents.id;
+  });
+
+  ipcMain.handle("window:isPrimary", (e) => registry.isPrimary(e.sender.id));
+}

--- a/clients/desktop/src/main/window_registry.test.ts
+++ b/clients/desktop/src/main/window_registry.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi } from "vitest";
+import type { BrowserWindow } from "electron";
+import { WindowRegistry, type WindowKind } from "./window_registry";
+
+let nextId = 1;
+function fakeWin(destroyed = false) {
+  const send = vi.fn();
+  const reload = vi.fn();
+  const close = vi.fn();
+  const id = nextId++;
+  const win = {
+    webContents: { id, send },
+    isDestroyed: () => destroyed,
+    reload,
+    close,
+  } as unknown as BrowserWindow;
+  return { win, id, send, reload, close };
+}
+
+function reg(r: WindowRegistry, kind: WindowKind, destroyed = false) {
+  const f = fakeWin(destroyed);
+  r.register(f.win, kind);
+  return f;
+}
+
+describe("WindowRegistry · primary election", () => {
+  it("the first primary wins", () => {
+    const r = new WindowRegistry();
+    const p = reg(r, "primary");
+    expect(r.getPrimary()).toBe(p.win);
+    expect(r.isPrimary(p.id)).toBe(true);
+  });
+
+  it("a chromeless popout alone is NOT elected primary (#2)", () => {
+    const r = new WindowRegistry();
+    reg(r, "terminal");
+    expect(r.getPrimary()).toBeNull();
+    reg(r, "channel");
+    expect(r.getPrimary()).toBeNull();
+  });
+
+  it("a terminal never wins even as the first window — register agrees with electPrimary (#5)", () => {
+    const r = new WindowRegistry();
+    const t = reg(r, "terminal");
+    expect(r.isPrimary(t.id)).toBe(false);
+    expect(r.getPrimary()).toBeNull();
+  });
+
+  it("a new secondary does not preempt a live primary", () => {
+    const r = new WindowRegistry();
+    const p = reg(r, "primary");
+    reg(r, "secondary");
+    expect(r.getPrimary()).toBe(p.win);
+  });
+
+  it("closing the primary re-elects the next eligible window", () => {
+    const r = new WindowRegistry();
+    const p = reg(r, "primary");
+    const s = reg(r, "secondary");
+    r.unregister(p.id);
+    expect(r.getPrimary()).toBe(s.win);
+  });
+
+  it("with only popouts left, getPrimary is null (#2/#4)", () => {
+    const r = new WindowRegistry();
+    const p = reg(r, "primary");
+    reg(r, "terminal");
+    r.unregister(p.id);
+    expect(r.getPrimary()).toBeNull();
+  });
+
+  it("a destroyed primary is never returned", () => {
+    const r = new WindowRegistry();
+    reg(r, "primary", /* destroyed */ true);
+    expect(r.getPrimary()).toBeNull();
+  });
+
+  it("fires onPrimaryChange only when the designation changes", () => {
+    const r = new WindowRegistry();
+    const cb = vi.fn();
+    r.setPrimaryChangeListener(cb);
+    reg(r, "primary"); // null → primary
+    expect(cb).toHaveBeenCalledTimes(1);
+    reg(r, "secondary"); // incumbent kept, no change
+    expect(cb).toHaveBeenCalledTimes(1);
+    reg(r, "terminal"); // popout, no change
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("WindowRegistry · membership", () => {
+  it("has / hasWindows reflect live membership", () => {
+    const r = new WindowRegistry();
+    expect(r.hasWindows()).toBe(false);
+    const p = reg(r, "primary");
+    expect(r.has(p.id)).toBe(true);
+    expect(r.hasWindows()).toBe(true);
+    r.unregister(p.id);
+    expect(r.has(p.id)).toBe(false);
+    expect(r.hasWindows()).toBe(false);
+  });
+
+  it("a destroyed window is not 'live' for has/hasWindows", () => {
+    const r = new WindowRegistry();
+    const d = reg(r, "terminal", true);
+    expect(r.has(d.id)).toBe(false);
+    expect(r.hasWindows()).toBe(false);
+  });
+});
+
+describe("WindowRegistry · applyConfigChange", () => {
+  it("server switch: chromeless popouts close, full windows reload (#4/C)", () => {
+    const r = new WindowRegistry();
+    const p = reg(r, "primary");
+    const s = reg(r, "secondary");
+    const t = reg(r, "terminal");
+    const ch = reg(r, "channel");
+    r.applyConfigChange(/* urlChanged */ true);
+    expect(p.reload).toHaveBeenCalledTimes(1);
+    expect(s.reload).toHaveBeenCalledTimes(1);
+    expect(t.close).toHaveBeenCalledTimes(1);
+    expect(ch.close).toHaveBeenCalledTimes(1);
+    expect(t.reload).not.toHaveBeenCalled();
+    expect(p.close).not.toHaveBeenCalled();
+  });
+
+  it("cosmetic same-URL edit: reload reloadOnConfigEdit windows, spare live terminals", () => {
+    const r = new WindowRegistry();
+    const p = reg(r, "primary");
+    const t = reg(r, "terminal");
+    const ch = reg(r, "channel");
+    r.applyConfigChange(/* urlChanged */ false);
+    expect(p.reload).toHaveBeenCalledTimes(1);
+    expect(ch.reload).toHaveBeenCalledTimes(1);
+    expect(t.reload).not.toHaveBeenCalled();
+    expect(t.close).not.toHaveBeenCalled();
+  });
+});
+
+describe("WindowRegistry · messaging", () => {
+  it("sendTo targets one window; broadcast hits all live windows", () => {
+    const r = new WindowRegistry();
+    const a = reg(r, "primary");
+    const b = reg(r, "secondary");
+    r.sendTo(a.id, "ch", { x: 1 });
+    expect(a.send).toHaveBeenCalledWith("ch", { x: 1 });
+    expect(b.send).not.toHaveBeenCalled();
+    r.broadcast("ev", null);
+    expect(a.send).toHaveBeenCalledWith("ev", null);
+    expect(b.send).toHaveBeenCalledWith("ev", null);
+  });
+});

--- a/clients/desktop/src/main/window_registry.ts
+++ b/clients/desktop/src/main/window_registry.ts
@@ -1,0 +1,95 @@
+import { type BrowserWindow } from "electron";
+import { type WindowKind, windowTraits } from "../shared/window-kind";
+
+export { type WindowKind } from "../shared/window-kind";
+
+interface Entry {
+  win: BrowserWindow;
+  kind: WindowKind;
+}
+
+// `primaryId` is derived, recomputed through one path (recomputePrimary) so
+// register and election can't drift; a primary is always primaryEligible, so
+// chromeless popouts never receive oauth/updater/notifications.
+export class WindowRegistry {
+  private entries = new Map<number, Entry>();
+  private primaryId: number | null = null;
+  private onPrimaryChange?: () => void;
+
+  setPrimaryChangeListener(cb: () => void): void {
+    this.onPrimaryChange = cb;
+  }
+
+  register(win: BrowserWindow, kind: WindowKind): void {
+    this.entries.set(win.webContents.id, { win, kind });
+    this.recomputePrimary();
+  }
+
+  unregister(wcId: number): void {
+    this.entries.delete(wcId);
+    this.recomputePrimary();
+  }
+
+  getPrimary(): BrowserWindow | null {
+    const e = this.primaryId === null ? undefined : this.entries.get(this.primaryId);
+    return e && !e.win.isDestroyed() ? e.win : null;
+  }
+
+  isPrimary(wcId: number): boolean {
+    return this.primaryId === wcId;
+  }
+
+  has(wcId: number): boolean {
+    const e = this.entries.get(wcId);
+    return e !== undefined && !e.win.isDestroyed();
+  }
+
+  hasWindows(): boolean {
+    for (const e of this.entries.values()) if (!e.win.isDestroyed()) return true;
+    return false;
+  }
+
+  all(): BrowserWindow[] {
+    return [...this.entries.values()].map((e) => e.win).filter((w) => !w.isDestroyed());
+  }
+
+  // On a URL switch, chromeless popouts close instead of reloading — their pod/
+  // channel lives on the old backend and can't migrate, so a reload only wedges.
+  applyConfigChange(urlChanged: boolean): void {
+    for (const e of [...this.entries.values()]) {
+      if (e.win.isDestroyed()) continue;
+      const t = windowTraits(e.kind);
+      if (urlChanged && !t.primaryEligible) e.win.close();
+      else if (urlChanged || t.reloadOnConfigEdit) e.win.reload();
+    }
+  }
+
+  broadcast(channel: string, payload: unknown): void {
+    for (const w of this.all()) w.webContents.send(channel, payload);
+  }
+
+  sendTo(wcId: number, channel: string, payload: unknown): void {
+    const e = this.entries.get(wcId);
+    if (e && !e.win.isDestroyed()) e.win.webContents.send(channel, payload);
+  }
+
+  private isLiveEligible(wcId: number): boolean {
+    const e = this.entries.get(wcId);
+    return e !== undefined && !e.win.isDestroyed() && windowTraits(e.kind).primaryEligible;
+  }
+
+  // No preemption: keep a live+eligible incumbent; re-elect only once it's gone.
+  private recomputePrimary(): void {
+    const prev = this.primaryId;
+    const keep = this.primaryId !== null && this.isLiveEligible(this.primaryId);
+    if (!keep) this.primaryId = this.electPrimary();
+    if (this.primaryId !== prev) this.onPrimaryChange?.();
+  }
+
+  private electPrimary(): number | null {
+    for (const id of this.entries.keys()) {
+      if (this.isLiveEligible(id)) return id;
+    }
+    return null;
+  }
+}

--- a/clients/desktop/src/preload/index.ts
+++ b/clients/desktop/src/preload/index.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer, IpcRendererEvent } from "electron";
 import { type ServerConfig } from "../shared/server-config-types";
 import { type UpdaterSnapshot } from "../shared/updater-reducer";
+import { windowTraits, type WindowKind } from "../shared/window-kind";
 
 // Sync IPC by design: renderer code (env.ts, OAuth URL builders, WS connect) is synchronous.
 // Reading at preload (before any renderer code runs) blocks no UI thread; mainWindow.reload()
@@ -10,10 +11,16 @@ import { type UpdaterSnapshot } from "../shared/updater-reducer";
 // Invariant: main MUST register serverConfig:*Sync handlers before createWindow() (main/index.ts).
 const apiUrl = ipcRenderer.sendSync("serverConfig:getActiveUrlSync") as string;
 const serverConfigSnapshot = ipcRenderer.sendSync("serverConfig:getSync") as ServerConfig;
+// Project the capability table (window-kind.ts) so the renderer reads booleans, not
+// the kind string. windowKind comes from create_window.ts additionalArguments.
+const windowKind = (process.argv.find((a) => a.startsWith("--agentsmesh-window-kind="))?.split("=")[1] ?? "primary") as WindowKind;
+const traits = windowTraits(windowKind);
 
 const api = {
   apiUrl,
   platform: process.platform,
+  ephemeralLayout: traits.ephemeralLayout,
+  ownsNotificationsSeed: traits.seedsNotificationOwner,
   invoke: (channel: string, ...args: unknown[]) => ipcRenderer.invoke(channel, ...args),
   on: (channel: string, listener: (event: IpcRendererEvent, ...args: unknown[]) => void) => {
     ipcRenderer.on(channel, listener);
@@ -42,6 +49,14 @@ const api = {
     const listener = (_e: IpcRendererEvent, state: string) => handler(state);
     ipcRenderer.on("realtime:state", listener);
     return () => ipcRenderer.removeListener("realtime:state", listener);
+  },
+  // Fired when the main-process primary-window designation changes (e.g. the
+  // current primary closes). Renderers re-query window:isPrimary to update
+  // notification ownership.
+  onPrimaryChanged: (handler: () => void) => {
+    const listener = () => handler();
+    ipcRenderer.on("window:primary-changed", listener);
+    return () => ipcRenderer.removeListener("window:primary-changed", listener);
   },
   // Rust-computed domain snapshot pushed after each EventBus dispatch. The
   // renderer mirrors it into the Electron service cache (the renderer has no

--- a/clients/desktop/src/renderer/pages/layouts/DashboardShell.tsx
+++ b/clients/desktop/src/renderer/pages/layouts/DashboardShell.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback } from "react";
+import React, { useEffect, useCallback, useState } from "react";
 import { useRouter, useParams } from "next/navigation";
 import {
   useAuthStore,
@@ -11,6 +11,7 @@ import { RealtimeProvider } from "@/providers/RealtimeProvider";
 import { useBrowserNotification, useSessionKeepAlive } from "@/hooks";
 import { handleNotificationEvent } from "@/stores/notificationHandler";
 import type { RealtimeEvent } from "@/lib/realtime";
+import { queryIsPrimaryWindow, onPrimaryWindowChanged, electronApi } from "@/lib/windowing";
 
 export function DashboardShell({
   children,
@@ -26,6 +27,23 @@ export function DashboardShell({
   const currentOrg = useCurrentOrg();
   const { permission, showNotification, requestPermission } = useBrowserNotification();
   useSessionKeepAlive();
+
+  // Notification ownership follows the live primary (survives re-election). Seed from
+  // the kind projection (only the boot primary → true; web → true) so there's no flash
+  // before the async queryIsPrimaryWindow resolves.
+  const [isNotificationOwner, setIsNotificationOwner] = useState(() => {
+    if (typeof window === "undefined") return true;
+    return electronApi()?.ownsNotificationsSeed ?? true;
+  });
+  useEffect(() => {
+    let active = true;
+    const refresh = () => {
+      void queryIsPrimaryWindow().then((p) => { if (active) setIsNotificationOwner(p); });
+    };
+    refresh();
+    const off = onPrimaryWindowChanged(refresh);
+    return () => { active = false; off(); };
+  }, []);
 
   // Evaluate per-render so token expiry (a time-driven flip with no store
   // event) becomes an effect-dependency change. Calling isAuthenticated
@@ -87,7 +105,7 @@ export function DashboardShell({
   }
 
   return (
-    <RealtimeProvider onEvent={handleEvent}>
+    <RealtimeProvider onEvent={isNotificationOwner ? handleEvent : undefined}>
       <ResponsiveShell>{children}</ResponsiveShell>
     </RealtimeProvider>
   );

--- a/clients/desktop/src/renderer/pages/popout/channel/PopoutChannelPage.tsx
+++ b/clients/desktop/src/renderer/pages/popout/channel/PopoutChannelPage.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+import { useParams } from "next/navigation";
+import { useCurrentUser } from "@/stores/auth";
+import { RealtimeProvider } from "@/providers/RealtimeProvider";
+import { ChannelChatPanel } from "@/components/channel";
+
+// Chromeless single-channel window (no DashboardShell). Renders ChannelChatPanel
+// directly off the :id route param — it self-loads via useChannelChat. View
+// state is renderer-local; the channel data cache syncs across windows through
+// the main-process realtime mirror.
+export function PopoutChannelPage() {
+  const { id } = useParams<{ id: string }>();
+  const user = useCurrentUser();
+  const channelId = Number(id);
+
+  // Static title to match the web sibling: this popout's renderer-local channel
+  // cache is empty (no channel-list fetch here), so deriving channel.name never
+  // resolved anyway.
+  useEffect(() => {
+    document.title = "Channel";
+  }, []);
+
+  if (!user || !Number.isFinite(channelId) || channelId <= 0) return null;
+
+  return (
+    <RealtimeProvider>
+      <div className="h-screen w-screen bg-background">
+        <ChannelChatPanel channelId={channelId} />
+      </div>
+    </RealtimeProvider>
+  );
+}

--- a/clients/desktop/src/renderer/router.tsx
+++ b/clients/desktop/src/renderer/router.tsx
@@ -41,6 +41,7 @@ import { SupportPage } from "@/pages/support/SupportPage";
 import { SupportTicketDetailPage } from "@/pages/support/detail/SupportDetailPage";
 
 import { PopoutTerminalPage } from "@/pages/popout/terminal/PopoutTerminalPage";
+import { PopoutChannelPage } from "@/pages/popout/channel/PopoutChannelPage";
 
 import { RouteErrorBoundary } from "@/pages/RouteErrorBoundary";
 
@@ -86,6 +87,7 @@ export const router = createBrowserRouter([
   // Popout (no shell): window.open()-spawned renderer runs its own AppProviders.PlatformGate
   // bootstrap, so session has been rehydrated from localStorage by the time this route mounts.
   { path: "/popout/terminal/:podKey", element: <RequireAuth><PopoutTerminalPage /></RequireAuth> },
+  { path: "/popout/channel/:id", element: <RequireAuth><PopoutChannelPage /></RequireAuth> },
 
   {
     path: "/:org",

--- a/clients/desktop/src/shared/window-kind.test.ts
+++ b/clients/desktop/src/shared/window-kind.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { windowTraits, type WindowKind } from "./window-kind";
+
+describe("windowTraits", () => {
+  it("primary: full shell, persistent layout, seeds notifications", () => {
+    expect(windowTraits("primary")).toEqual({
+      primaryEligible: true,
+      reloadOnConfigEdit: true,
+      ephemeralLayout: false,
+      seedsNotificationOwner: true,
+    });
+  });
+
+  it("secondary: eligible but ephemeral layout, not the notification seed", () => {
+    expect(windowTraits("secondary")).toMatchObject({
+      primaryEligible: true,
+      ephemeralLayout: true,
+      seedsNotificationOwner: false,
+    });
+  });
+
+  it("terminal popout: not eligible, not reloaded on a cosmetic edit", () => {
+    expect(windowTraits("terminal")).toMatchObject({
+      primaryEligible: false,
+      reloadOnConfigEdit: false,
+      ephemeralLayout: true,
+    });
+  });
+
+  it("channel popout: not eligible (chromeless) but reloaded on a cosmetic edit", () => {
+    expect(windowTraits("channel")).toMatchObject({
+      primaryEligible: false,
+      reloadOnConfigEdit: true,
+      ephemeralLayout: true,
+    });
+  });
+
+  it("no chromeless popout is primaryEligible (oauth/updater/notifications never land on one)", () => {
+    expect(windowTraits("terminal").primaryEligible).toBe(false);
+    expect(windowTraits("channel").primaryEligible).toBe(false);
+  });
+
+  it("falls back to primary for an unknown kind (guards preload's `as WindowKind` cast)", () => {
+    expect(windowTraits("nonsense" as WindowKind)).toEqual(windowTraits("primary"));
+  });
+});

--- a/clients/desktop/src/shared/window-kind.ts
+++ b/clients/desktop/src/shared/window-kind.ts
@@ -1,0 +1,25 @@
+// Single source for per-kind window policy (election, reload, layout storage,
+// notification seed) — modules read this table instead of re-deriving from
+// scattered `kind === "..."` tests. Adding a kind means editing one row.
+
+export type WindowKind = "primary" | "secondary" | "terminal" | "channel";
+
+export interface WindowTraits {
+  primaryEligible: boolean;
+  reloadOnConfigEdit: boolean;
+  // sessionStorage when true — non-primary windows share the file:// localStorage origin.
+  ephemeralLayout: boolean;
+  seedsNotificationOwner: boolean;
+}
+
+const WINDOW_TRAITS: Record<WindowKind, WindowTraits> = {
+  primary: { primaryEligible: true, reloadOnConfigEdit: true, ephemeralLayout: false, seedsNotificationOwner: true },
+  secondary: { primaryEligible: true, reloadOnConfigEdit: true, ephemeralLayout: true, seedsNotificationOwner: false },
+  terminal: { primaryEligible: false, reloadOnConfigEdit: false, ephemeralLayout: true, seedsNotificationOwner: false },
+  channel: { primaryEligible: false, reloadOnConfigEdit: true, ephemeralLayout: true, seedsNotificationOwner: false },
+};
+
+export function windowTraits(kind: WindowKind): WindowTraits {
+  // Fallback guards preload's `as WindowKind` cast — a bogus argv must not crash preload.
+  return WINDOW_TRAITS[kind] ?? WINDOW_TRAITS.primary;
+}

--- a/clients/web/src/app/popout/channel/[id]/page.tsx
+++ b/clients/web/src/app/popout/channel/[id]/page.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect } from "react";
+import { useParams } from "next/navigation";
+import { useCurrentUser } from "@/stores/auth";
+import { RealtimeProvider } from "@/providers/RealtimeProvider";
+import { ChannelChatPanel } from "@/components/channel";
+
+// Popout single-channel window (browser popout on web; native window on
+// desktop). Mirrors the popout terminal page: AuthBootstrap (popout/layout)
+// rehydrates the session, RealtimeProvider drives live messages, and
+// ChannelChatPanel self-loads from the :id route param via useChannelChat.
+export default function PopoutChannelPage() {
+  const { id } = useParams<{ id: string }>();
+  const user = useCurrentUser();
+  const channelId = Number(id);
+
+  useEffect(() => {
+    document.title = "Channel";
+  }, []);
+
+  if (!user || !Number.isFinite(channelId) || channelId <= 0) return null;
+
+  return (
+    <RealtimeProvider>
+      <div className="h-screen w-screen bg-background">
+        <ChannelChatPanel channelId={channelId} />
+      </div>
+    </RealtimeProvider>
+  );
+}

--- a/clients/web/src/components/ide/sidebar/ChannelContextMenu.tsx
+++ b/clients/web/src/components/ide/sidebar/ChannelContextMenu.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { ExternalLink } from "lucide-react";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import { openChannelWindow } from "@/lib/windowing";
+
+// `children` is the ChannelListItem button (forwardRef + prop-spread), so the
+// trigger attaches `asChild` straight onto the focusable <button> — keyboard
+// context-menu invocation (Shift+F10) works, unlike a non-focusable wrapper div.
+export function ChannelContextMenu({
+  channelId,
+  children,
+}: {
+  channelId: number;
+  children: React.ReactNode;
+}) {
+  const t = useTranslations("channels");
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+      <ContextMenuContent className="w-48">
+        <ContextMenuItem onClick={() => openChannelWindow(channelId)}>
+          <ExternalLink className="mr-2 h-4 w-4" />
+          {t("contextMenu.openInNewWindow")}
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}

--- a/clients/web/src/components/ide/sidebar/ChannelListItem.tsx
+++ b/clients/web/src/components/ide/sidebar/ChannelListItem.tsx
@@ -1,16 +1,19 @@
 "use client";
 
+import { forwardRef, type ComponentPropsWithoutRef } from "react";
 import { cn } from "@/lib/utils";
 import type { Channel, ChannelLastMessage } from "@/stores/channel";
 import { formatRelativeShort } from "@/lib/format-relative-time";
 import { Lock } from "lucide-react";
 
-interface ChannelListItemProps {
+// Extends button props so a ContextMenuTrigger `asChild` can forward its ref +
+// onContextMenu onto the focusable <button> directly (keyboard Shift+F10 works).
+interface ChannelListItemProps extends Omit<ComponentPropsWithoutRef<"button">, "onClick"> {
   channel: Channel;
   isSelected: boolean;
   unreadCount?: number;
   lastMessage?: ChannelLastMessage | null;
-  onClick: () => void;
+  onClick?: () => void;
 }
 
 /**
@@ -18,13 +21,10 @@ interface ChannelListItemProps {
  * `channel_row` + `channel_row_active`: hash + name + last message preview +
  * short time + unread dot. Private channels use the lock icon in place of #.
  */
-export function ChannelListItem({
-  channel,
-  isSelected,
-  unreadCount = 0,
-  lastMessage,
-  onClick,
-}: ChannelListItemProps) {
+export const ChannelListItem = forwardRef<HTMLButtonElement, ChannelListItemProps>(function ChannelListItem(
+  { channel, isSelected, unreadCount = 0, lastMessage, onClick, className, ...rest },
+  ref,
+) {
   const hasUnread = unreadCount > 0 && !isSelected;
   const isPrivate = channel.visibility === "private";
   const preview = lastMessage
@@ -36,6 +36,7 @@ export function ChannelListItem({
 
   return (
     <button
+      ref={ref}
       type="button"
       onClick={onClick}
       data-testid="channel-list-item"
@@ -43,7 +44,9 @@ export function ChannelListItem({
       className={cn(
         "group flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-left transition-colors",
         isSelected ? "bg-muted" : "hover:bg-muted/50",
+        className,
       )}
+      {...rest}
     >
       <span
         className={cn(
@@ -82,6 +85,6 @@ export function ChannelListItem({
       </span>
     </button>
   );
-}
+});
 
 export default ChannelListItem;

--- a/clients/web/src/components/ide/sidebar/ChannelsSidebarContent.tsx
+++ b/clients/web/src/components/ide/sidebar/ChannelsSidebarContent.tsx
@@ -17,6 +17,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Search, Loader2, MessageSquare, RefreshCw } from "lucide-react";
 import { ChannelListItem } from "./ChannelListItem";
+import { ChannelContextMenu } from "./ChannelContextMenu";
 
 interface ChannelsSidebarContentProps {
   className?: string;
@@ -136,14 +137,15 @@ export function ChannelsSidebarContent({ className }: ChannelsSidebarContentProp
         <SectionLabel count={rows.length}>{label}</SectionLabel>
         <div className="flex flex-col gap-0.5 px-2">
           {rows.map(({ channel, lastMsg }) => (
-            <ChannelListItem
-              key={channel.id}
-              channel={channel}
-              isSelected={selectedChannelId === channel.id}
-              unreadCount={unreadCounts[channel.id] || 0}
-              lastMessage={lastMsg}
-              onClick={() => setSelectedChannelId(channel.id)}
-            />
+            <ChannelContextMenu key={channel.id} channelId={channel.id}>
+              <ChannelListItem
+                channel={channel}
+                isSelected={selectedChannelId === channel.id}
+                unreadCount={unreadCounts[channel.id] || 0}
+                lastMessage={lastMsg}
+                onClick={() => setSelectedChannelId(channel.id)}
+              />
+            </ChannelContextMenu>
           ))}
         </div>
       </>

--- a/clients/web/src/components/ide/sidebar/SidebarPodContextMenu.tsx
+++ b/clients/web/src/components/ide/sidebar/SidebarPodContextMenu.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { Pencil, Share2, Square, RefreshCw } from "lucide-react";
+import { Pencil, Share2, Square, RefreshCw, ExternalLink } from "lucide-react";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -10,6 +10,7 @@ import {
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
 import type { Pod } from "@/stores/pod";
+import { openTerminalWindow } from "@/lib/windowing";
 
 interface SidebarPodContextMenuProps {
   pod: Pod;
@@ -42,6 +43,11 @@ export function SidebarPodContextMenu({
         <ContextMenuItem onClick={onShare}>
           <Share2 className="mr-2 h-4 w-4" />
           {t("contextMenu.share")}
+        </ContextMenuItem>
+
+        <ContextMenuItem onClick={() => openTerminalWindow(pod.pod_key)} disabled={!isActive}>
+          <ExternalLink className="mr-2 h-4 w-4" />
+          {t("contextMenu.openInNewWindow")}
         </ContextMenuItem>
 
         {isActive && (

--- a/clients/web/src/components/mesh/PodContextMenu.tsx
+++ b/clients/web/src/components/mesh/PodContextMenu.tsx
@@ -21,6 +21,7 @@ import type { MeshNode } from "@/stores/mesh";
 import { useMeshStore } from "@/stores/mesh";
 import { usePodStore } from "@/stores/pod";
 import { useWorkspaceStore } from "@/stores/workspace";
+import { openTerminalWindow } from "@/lib/windowing";
 
 interface PodContextMenuProps {
   node: MeshNode;
@@ -87,6 +88,14 @@ export default function PodContextMenu({ node, children }: PodContextMenuProps) 
           >
             <Terminal className="mr-2 h-4 w-4" />
             {t("contextMenu.openTerminal")}
+          </ContextMenuItem>
+
+          <ContextMenuItem
+            onClick={() => openTerminalWindow(node.pod_key)}
+            disabled={!isActive}
+          >
+            <ExternalLink className="mr-2 h-4 w-4" />
+            {t("contextMenu.openInNewWindow")}
           </ContextMenuItem>
 
           <ContextMenuItem onClick={() => setRenameOpen(true)}>

--- a/clients/web/src/components/workspace/TerminalPaneHeader.tsx
+++ b/clients/web/src/components/workspace/TerminalPaneHeader.tsx
@@ -7,6 +7,7 @@ import { AgentStatusBadge } from "@/components/shared/AgentStatusBadge";
 import { usePod } from "@/stores/pod";
 import { usePodTitle } from "@/hooks/usePodTitle";
 import { getShortPodKey } from "@/lib/pod-display-name";
+import { isOutsideCurrentWindow } from "@/lib/windowing";
 import type { ConnectionStatus } from "@/stores/relayConnection";
 import {
   X,
@@ -52,6 +53,21 @@ export function TerminalPaneHeader({
   onClose,
 }: TerminalPaneHeaderProps) {
   const title = usePodTitle(podKey);
+  const canTearOff = Boolean(onPopout && onClose);
+
+  // Tab tear-off: dragging the title strip out of the window frame spawns a
+  // standalone terminal window (= popout) and drops the pane here. Scrollback
+  // does not migrate — the new window rebuilds from the relay snapshot.
+  const handleDragEnd = (e: React.DragEvent) => {
+    // (0,0) is the cancel / no-drop sentinel (Esc, or release on no target) —
+    // not a real out-of-window drop. Ignore it so an aborted drag of the title
+    // strip doesn't accidentally tear the pane off.
+    if (e.screenX === 0 && e.screenY === 0) return;
+    if (canTearOff && isOutsideCurrentWindow(e.screenX, e.screenY)) {
+      onPopout!();
+      onClose!();
+    }
+  };
 
   const statusColor = (() => {
     if (isRunnerDisconnected) return "text-red-500 dark:text-red-400";
@@ -65,7 +81,12 @@ export function TerminalPaneHeader({
 
   return (
     <div className="h-8 flex items-center justify-between px-2 bg-terminal-bg-secondary border-b border-terminal-border">
-      <div className="flex items-center gap-2 min-w-0">
+      <div
+        className="flex items-center gap-2 min-w-0"
+        draggable={canTearOff}
+        onDragStart={(e) => e.dataTransfer.setData("text/plain", podKey)}
+        onDragEnd={handleDragEnd}
+      >
         <Circle className={cn("w-2 h-2 flex-shrink-0", statusColor)} />
         <span className="text-xs text-terminal-text truncate">{title}</span>
         <code className="text-[10px] text-terminal-text-muted truncate">

--- a/clients/web/src/components/workspace/WorkspaceManager.tsx
+++ b/clients/web/src/components/workspace/WorkspaceManager.tsx
@@ -9,6 +9,7 @@ import { TerminalGrid } from "./TerminalGrid";
 import { TerminalSwiper } from "./TerminalSwiper";
 import { TerminalToolbar } from "./TerminalToolbar";
 import { PodSelectorModal } from "./PodSelectorModal";
+import { openTerminalWindow } from "@/lib/windowing";
 
 interface WorkspaceManagerProps {
   className?: string;
@@ -34,17 +35,7 @@ export function WorkspaceManager({ className }: WorkspaceManagerProps) {
 
   const handlePopout = (paneId: string) => {
     const pane = panes.find((p) => p.id === paneId);
-    if (!pane) return;
-
-    const popoutUrl = `/popout/terminal/${pane.podKey}`;
-    const popoutWindow = window.open(
-      popoutUrl,
-      `terminal-${pane.podKey}`,
-      "width=800,height=600,menubar=no,toolbar=no,location=no,status=no"
-    );
-
-    if (popoutWindow) {
-    }
+    if (pane) openTerminalWindow(pane.podKey);
   };
 
   if (!_hasHydrated) {

--- a/clients/web/src/lib/__tests__/windowing.test.ts
+++ b/clients/web/src/lib/__tests__/windowing.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  openTerminalWindow,
+  openChannelWindow,
+  queryIsPrimaryWindow,
+  isOutsideCurrentWindow,
+} from "../windowing";
+
+type WinWithApi = { electronAPI?: { invoke?: (c: string, ...a: unknown[]) => Promise<unknown> } };
+const setApi = (api: WinWithApi["electronAPI"] | undefined) => {
+  (window as unknown as WinWithApi).electronAPI = api;
+};
+
+afterEach(() => {
+  setApi(undefined);
+  vi.restoreAllMocks();
+});
+
+describe("windowing · electron path (electronAPI.invoke present)", () => {
+  let invoke: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    invoke = vi.fn().mockResolvedValue(undefined);
+    setApi({ invoke });
+  });
+
+  it("openTerminalWindow routes through window:openTerminal IPC", () => {
+    openTerminalWindow("pod-1");
+    expect(invoke).toHaveBeenCalledWith("window:openTerminal", "pod-1");
+  });
+
+  it("openChannelWindow routes through window:open with a stringified id", () => {
+    openChannelWindow(42);
+    expect(invoke).toHaveBeenCalledWith("window:open", "channel", { id: "42" });
+  });
+
+  it("openChannelWindow ignores a non-positive / non-finite id", () => {
+    openChannelWindow(0);
+    openChannelWindow(-1);
+    openChannelWindow(Number.NaN);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("queryIsPrimaryWindow asks main and coerces the result", async () => {
+    invoke.mockResolvedValue(true);
+    await expect(queryIsPrimaryWindow()).resolves.toBe(true);
+    expect(invoke).toHaveBeenCalledWith("window:isPrimary");
+  });
+
+  it("queryIsPrimaryWindow resolves false when the invoke rejects", async () => {
+    invoke.mockRejectedValue(new Error("ipc down"));
+    await expect(queryIsPrimaryWindow()).resolves.toBe(false);
+  });
+});
+
+describe("windowing · web fallback (no electronAPI)", () => {
+  let open: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    setApi(undefined);
+    open = vi.fn();
+    Object.defineProperty(window, "open", { value: open, configurable: true, writable: true });
+  });
+
+  it("openTerminalWindow opens a browser popout", () => {
+    openTerminalWindow("pod-1");
+    expect(open).toHaveBeenCalledWith("/popout/terminal/pod-1", "terminal-pod-1", expect.any(String));
+  });
+
+  it("openChannelWindow opens a browser popout", () => {
+    openChannelWindow(7);
+    expect(open).toHaveBeenCalledWith("/popout/channel/7", "channel-7", expect.any(String));
+  });
+
+  it("queryIsPrimaryWindow resolves true (the sole tab owns notifications)", async () => {
+    await expect(queryIsPrimaryWindow()).resolves.toBe(true);
+  });
+});
+
+describe("isOutsideCurrentWindow (content rect = origin 100,100 size 800x600)", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "screenX", { value: 100, configurable: true });
+    Object.defineProperty(window, "screenY", { value: 100, configurable: true });
+    Object.defineProperty(window, "innerWidth", { value: 800, configurable: true });
+    Object.defineProperty(window, "innerHeight", { value: 600, configurable: true });
+  });
+
+  it("a pointer inside the rect → false", () => {
+    expect(isOutsideCurrentWindow(400, 400)).toBe(false);
+  });
+
+  it("left of / above the origin → true", () => {
+    expect(isOutsideCurrentWindow(50, 400)).toBe(true);
+    expect(isOutsideCurrentWindow(400, 50)).toBe(true);
+  });
+
+  it("right of / below the rect → true", () => {
+    expect(isOutsideCurrentWindow(950, 400)).toBe(true);
+    expect(isOutsideCurrentWindow(400, 750)).toBe(true);
+  });
+});

--- a/clients/web/src/lib/api/facade/channel.ts
+++ b/clients/web/src/lib/api/facade/channel.ts
@@ -26,6 +26,8 @@ import {
   removeChannelMember as removeChannelMemberConnect,
   listChannelMembers as listChannelMembersConnect,
   listChannelMembersRaw,
+  type ChannelMemberData,
+  type ChannelPodSummary,
 } from "./channelConnect";
 
 export type { MessageContent, MessageMentions } from "@/lib/viewModels/channelMessage";

--- a/clients/web/src/lib/windowing.ts
+++ b/clients/web/src/lib/windowing.ts
@@ -1,0 +1,76 @@
+// Multi-window seam. On desktop (Electron) window operations go through IPC to
+// the main process — the renderer's native window.open is denied by the main
+// setWindowOpenHandler. On web they fall back to a browser popout. Runtime-
+// detected (mirrors lib/shims electron-shell), so no build-time platform branch.
+interface ElectronApi {
+  invoke?: (channel: string, ...args: unknown[]) => Promise<unknown>;
+  // Projected from the main-process capability table (preload). The raw kind string
+  // is deliberately not exposed, so policy can't drift back to `kind === "..."` tests.
+  ephemeralLayout?: boolean;
+  ownsNotificationsSeed?: boolean;
+  onPrimaryChanged?: (cb: () => void) => () => void;
+}
+
+export function electronApi(): ElectronApi | undefined {
+  return (globalThis as { window?: { electronAPI?: ElectronApi } }).window?.electronAPI;
+}
+
+function openBrowserPopout(path: string, name: string): void {
+  window.open(path, name, "width=1000,height=720,menubar=no,toolbar=no,location=no,status=no");
+}
+
+function warnOpenFailed(target: string, e: unknown): void {
+  console.warn(`[windowing] open ${target} failed:`, e);
+}
+
+export function openTerminalWindow(podKey: string): void {
+  const api = electronApi();
+  if (api?.invoke) {
+    api.invoke("window:openTerminal", podKey).catch((e) => warnOpenFailed("terminal", e));
+    return;
+  }
+  openBrowserPopout(`/popout/terminal/${podKey}`, `terminal-${podKey}`);
+}
+
+export function openChannelWindow(channelId: number): void {
+  if (!Number.isFinite(channelId) || channelId <= 0) return;
+  const api = electronApi();
+  if (api?.invoke) {
+    api.invoke("window:open", "channel", { id: String(channelId) }).catch((e) =>
+      warnOpenFailed("channel", e),
+    );
+    return;
+  }
+  openBrowserPopout(`/popout/channel/${channelId}`, `channel-${channelId}`);
+}
+
+// Notification ownership — only ONE window fires the JS-layer browser
+// notifications in DashboardShell, else multi-window duplicates every OS toast.
+// Resolved against the main process's LIVE primary designation (not the static
+// windowKind) so it follows primary re-election when the primary closes. Web
+// (no electronAPI) is the sole tab → always the owner.
+export function queryIsPrimaryWindow(): Promise<boolean> {
+  const api = electronApi();
+  if (!api?.invoke) return Promise.resolve(true);
+  return api.invoke("window:isPrimary").then((p) => Boolean(p)).catch((e: unknown) => {
+    console.warn("[windowing] queryIsPrimaryWindow failed:", e);
+    return false;
+  });
+}
+
+// Subscribe to main-process primary re-election; returns an unsubscribe fn.
+// No-op on web.
+export function onPrimaryWindowChanged(cb: () => void): () => void {
+  return electronApi()?.onPrimaryChanged?.(cb) ?? (() => {});
+}
+
+// True when a screen-space pointer sits outside the current window's content
+// rect. Tab tear-off uses it to decide whether a dragged pane should spawn its
+// own window. screenX/screenY (window content origin) is paired with
+// inner{Width,Height} (content size) so both sides share the content frame —
+// outer dims would overshoot the right/bottom edge by the window chrome.
+// Compared in CSS px; good enough for "dragged clearly out of the window".
+export function isOutsideCurrentWindow(screenX: number, screenY: number): boolean {
+  const { screenX: wx, screenY: wy, innerWidth: ww, innerHeight: wh } = window;
+  return screenX < wx || screenX > wx + ww || screenY < wy || screenY > wy + wh;
+}

--- a/clients/web/src/messages/de/app.json
+++ b/clients/web/src/messages/de/app.json
@@ -76,6 +76,7 @@
     "ticket": "Ticket",
     "contextMenu": {
       "openTerminal": "Terminal öffnen",
+      "openInNewWindow": "In neuem Fenster öffnen",
       "viewTicket": "Ticket {slug} anzeigen",
       "rename": "Umbenennen",
       "terminatePod": "Pod beenden",
@@ -258,6 +259,7 @@
     "contextMenu": {
       "rename": "Umbenennen",
       "terminate": "Beenden",
+      "openInNewWindow": "In neuem Fenster öffnen",
       "enablePerpetual": "Dauerhaft aktivieren",
       "disablePerpetual": "Dauerhaft deaktivieren"
     },

--- a/clients/web/src/messages/de/channels.json
+++ b/clients/web/src/messages/de/channels.json
@@ -1,5 +1,8 @@
 {
   "channels": {
+    "contextMenu": {
+      "openInNewWindow": "In neuem Fenster öffnen"
+    },
     "emptyState": "Wähle einen Kanal, um zu chatten",
     "emptyStateHint": "Wähle einen Kanal aus der Seitenleiste, um Nachrichten anzuzeigen und mit deinem Team zusammenzuarbeiten",
     "sidebar": {

--- a/clients/web/src/messages/en/app.json
+++ b/clients/web/src/messages/en/app.json
@@ -111,6 +111,7 @@
     "ticket": "Ticket",
     "contextMenu": {
       "openTerminal": "Open Terminal",
+      "openInNewWindow": "Open in New Window",
       "viewTicket": "View Ticket {slug}",
       "rename": "Rename",
       "terminatePod": "Terminate Pod",
@@ -363,6 +364,7 @@
       "rename": "Rename",
       "share": "Share",
       "terminate": "Terminate",
+      "openInNewWindow": "Open in New Window",
       "enablePerpetual": "Enable Perpetual",
       "disablePerpetual": "Disable Perpetual"
     },

--- a/clients/web/src/messages/en/channels.json
+++ b/clients/web/src/messages/en/channels.json
@@ -1,5 +1,8 @@
 {
   "channels": {
+    "contextMenu": {
+      "openInNewWindow": "Open in New Window"
+    },
     "emptyState": "Select a channel to start chatting",
     "emptyStateHint": "Choose a channel from the sidebar to view messages and collaborate with your team",
     "archivedBanner": "This channel is archived — sending messages is disabled",

--- a/clients/web/src/messages/es/app.json
+++ b/clients/web/src/messages/es/app.json
@@ -76,6 +76,7 @@
     "ticket": "Ticket",
     "contextMenu": {
       "openTerminal": "Abrir Terminal",
+      "openInNewWindow": "Abrir en una ventana nueva",
       "viewTicket": "Ver Ticket {slug}",
       "rename": "Renombrar",
       "terminatePod": "Terminar Pod",
@@ -258,6 +259,7 @@
     "contextMenu": {
       "rename": "Renombrar",
       "terminate": "Terminar",
+      "openInNewWindow": "Abrir en una ventana nueva",
       "enablePerpetual": "Activar modo perpetuo",
       "disablePerpetual": "Desactivar modo perpetuo"
     },

--- a/clients/web/src/messages/es/channels.json
+++ b/clients/web/src/messages/es/channels.json
@@ -1,5 +1,8 @@
 {
   "channels": {
+    "contextMenu": {
+      "openInNewWindow": "Abrir en una ventana nueva"
+    },
     "emptyState": "Selecciona un canal para empezar a chatear",
     "emptyStateHint": "Elige un canal de la barra lateral para ver mensajes y colaborar con tu equipo",
     "sidebar": {

--- a/clients/web/src/messages/fr/app.json
+++ b/clients/web/src/messages/fr/app.json
@@ -76,6 +76,7 @@
     "ticket": "Ticket",
     "contextMenu": {
       "openTerminal": "Ouvrir le Terminal",
+      "openInNewWindow": "Ouvrir dans une nouvelle fenêtre",
       "viewTicket": "Voir le Ticket {slug}",
       "rename": "Renommer",
       "terminatePod": "Arrêter le Pod",
@@ -258,6 +259,7 @@
     "contextMenu": {
       "rename": "Renommer",
       "terminate": "Terminer",
+      "openInNewWindow": "Ouvrir dans une nouvelle fenêtre",
       "enablePerpetual": "Activer le mode perpétuel",
       "disablePerpetual": "Désactiver le mode perpétuel"
     },

--- a/clients/web/src/messages/fr/channels.json
+++ b/clients/web/src/messages/fr/channels.json
@@ -1,5 +1,8 @@
 {
   "channels": {
+    "contextMenu": {
+      "openInNewWindow": "Ouvrir dans une nouvelle fenêtre"
+    },
     "emptyState": "Sélectionnez un canal pour commencer à discuter",
     "emptyStateHint": "Choisissez un canal dans la barre latérale pour voir les messages et collaborer avec votre équipe",
     "sidebar": {

--- a/clients/web/src/messages/ja/app.json
+++ b/clients/web/src/messages/ja/app.json
@@ -76,6 +76,7 @@
     "ticket": "チケット",
     "contextMenu": {
       "openTerminal": "ターミナルを開く",
+      "openInNewWindow": "新しいウィンドウで開く",
       "viewTicket": "チケット {slug} を表示",
       "rename": "名前を変更",
       "terminatePod": "Pod を終了",
@@ -258,6 +259,7 @@
     "contextMenu": {
       "rename": "名前を変更",
       "terminate": "終了",
+      "openInNewWindow": "新しいウィンドウで開く",
       "enablePerpetual": "永続モードを有効にする",
       "disablePerpetual": "永続モードを無効にする"
     },

--- a/clients/web/src/messages/ja/channels.json
+++ b/clients/web/src/messages/ja/channels.json
@@ -1,5 +1,8 @@
 {
   "channels": {
+    "contextMenu": {
+      "openInNewWindow": "新しいウィンドウで開く"
+    },
     "emptyState": "チャンネルを選択してチャットを開始",
     "emptyStateHint": "サイドバーからチャンネルを選択して、メッセージを表示しチームと協力しましょう",
     "sidebar": {

--- a/clients/web/src/messages/ko/app.json
+++ b/clients/web/src/messages/ko/app.json
@@ -76,6 +76,7 @@
     "ticket": "티켓",
     "contextMenu": {
       "openTerminal": "터미널 열기",
+      "openInNewWindow": "새 창에서 열기",
       "viewTicket": "티켓 {slug} 보기",
       "rename": "이름 변경",
       "terminatePod": "Pod 종료",
@@ -258,6 +259,7 @@
     "contextMenu": {
       "rename": "이름 변경",
       "terminate": "종료",
+      "openInNewWindow": "새 창에서 열기",
       "enablePerpetual": "영구 모드 활성화",
       "disablePerpetual": "영구 모드 비활성화"
     },

--- a/clients/web/src/messages/ko/channels.json
+++ b/clients/web/src/messages/ko/channels.json
@@ -1,5 +1,8 @@
 {
   "channels": {
+    "contextMenu": {
+      "openInNewWindow": "새 창에서 열기"
+    },
     "emptyState": "채널을 선택하여 채팅 시작",
     "emptyStateHint": "사이드바에서 채널을 선택하여 메시지를 확인하고 팀과 협업하세요",
     "sidebar": {

--- a/clients/web/src/messages/pt/app.json
+++ b/clients/web/src/messages/pt/app.json
@@ -76,6 +76,7 @@
     "ticket": "Ticket",
     "contextMenu": {
       "openTerminal": "Abrir Terminal",
+      "openInNewWindow": "Abrir em nova janela",
       "viewTicket": "Ver Ticket {slug}",
       "rename": "Renomear",
       "terminatePod": "Encerrar Pod",
@@ -258,6 +259,7 @@
     "contextMenu": {
       "rename": "Renomear",
       "terminate": "Encerrar",
+      "openInNewWindow": "Abrir em nova janela",
       "enablePerpetual": "Ativar modo perpétuo",
       "disablePerpetual": "Desativar modo perpétuo"
     },

--- a/clients/web/src/messages/pt/channels.json
+++ b/clients/web/src/messages/pt/channels.json
@@ -1,5 +1,8 @@
 {
   "channels": {
+    "contextMenu": {
+      "openInNewWindow": "Abrir em nova janela"
+    },
     "emptyState": "Selecione um canal para começar a conversar",
     "emptyStateHint": "Escolha um canal na barra lateral para ver mensagens e colaborar com sua equipe",
     "sidebar": {

--- a/clients/web/src/messages/zh/app.json
+++ b/clients/web/src/messages/zh/app.json
@@ -111,6 +111,7 @@
     "ticket": "任务",
     "contextMenu": {
       "openTerminal": "打开终端",
+      "openInNewWindow": "在新窗口打开",
       "viewTicket": "查看任务 {slug}",
       "rename": "重命名",
       "terminatePod": "终止 Pod",
@@ -363,6 +364,7 @@
       "rename": "重命名",
       "share": "共享",
       "terminate": "终止",
+      "openInNewWindow": "在新窗口打开",
       "enablePerpetual": "启用永续模式",
       "disablePerpetual": "禁用永续模式"
     },

--- a/clients/web/src/messages/zh/channels.json
+++ b/clients/web/src/messages/zh/channels.json
@@ -1,5 +1,8 @@
 {
   "channels": {
+    "contextMenu": {
+      "openInNewWindow": "在新窗口打开"
+    },
     "emptyState": "选择一个频道开始聊天",
     "emptyStateHint": "从侧边栏选择一个频道，查看消息并与团队协作",
     "archivedBanner": "此频道已归档，无法发送消息",

--- a/clients/web/src/stores/__tests__/persistStorage.test.ts
+++ b/clients/web/src/stores/__tests__/persistStorage.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { resolvePersistStorage } from "../persistStorage";
+
+type WinWithApi = { electronAPI?: { ephemeralLayout?: boolean } };
+const setApi = (api: WinWithApi["electronAPI"] | undefined) => {
+  (window as unknown as WinWithApi).electronAPI = api;
+};
+
+afterEach(() => setApi(undefined));
+
+describe("resolvePersistStorage", () => {
+  it("web (no electronAPI) → localStorage", () => {
+    setApi(undefined);
+    expect(resolvePersistStorage()).toBe(window.localStorage);
+  });
+
+  it("primary window (ephemeralLayout false) → localStorage", () => {
+    setApi({ ephemeralLayout: false });
+    expect(resolvePersistStorage()).toBe(window.localStorage);
+  });
+
+  it("non-primary window (ephemeralLayout true) → sessionStorage", () => {
+    setApi({ ephemeralLayout: true });
+    expect(resolvePersistStorage()).toBe(window.sessionStorage);
+  });
+});

--- a/clients/web/src/stores/channel.ts
+++ b/clients/web/src/stores/channel.ts
@@ -1,4 +1,5 @@
 export { useChannelStore, useChannels, useCurrentChannel, getLastMessage, type Channel, type ChannelLastMessage } from "./channelStore";
+export { readChannel } from "./channelSelectors";
 export {
   useChannelMessageStore,
   EMPTY_CACHE,

--- a/clients/web/src/stores/ide.ts
+++ b/clients/web/src/stores/ide.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { persist, createJSONStorage } from "zustand/middleware";
+import { resolvePersistStorage } from "./persistStorage";
 
 export type ActivityType =
   | "workspace"
@@ -77,6 +78,7 @@ export const useIDEStore = create<IDEState>()(
     }),
     {
       name: "agentsmesh-ide",
+      storage: createJSONStorage(resolvePersistStorage),
       partialize: (state) => ({
         activeActivity: state.activeActivity,
         sidebarOpen: state.sidebarOpen,

--- a/clients/web/src/stores/persistStorage.ts
+++ b/clients/web/src/stores/persistStorage.ts
@@ -1,0 +1,8 @@
+// Per-window layout storage: non-primary windows use sessionStorage (ephemeralLayout
+// trait) to avoid colliding on the shared file:// localStorage origin; web + primary
+// keep localStorage.
+export function resolvePersistStorage(): Storage {
+  const win = (globalThis as { window?: Window & { electronAPI?: { ephemeralLayout?: boolean } } }).window;
+  if (!win) throw new Error("Storage not available (SSR)"); // createJSONStorage catches → persist skips
+  return win.electronAPI?.ephemeralLayout ? win.sessionStorage : win.localStorage;
+}

--- a/clients/web/src/stores/workspace.ts
+++ b/clients/web/src/stores/workspace.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { persist, createJSONStorage } from "zustand/middleware";
+import { resolvePersistStorage } from "./persistStorage";
 import type { WorkspacePane, SplitTreeLeaf, SplitTreeSplit, SplitTreeNode, WorkspaceState } from "./workspaceTypes";
 import {
   generatePaneId, generateNodeId,
@@ -142,6 +143,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
     {
       name: "agentsmesh-workspace",
       version: 4,
+      storage: createJSONStorage(resolvePersistStorage),
       partialize: (state) => ({
         panes: state.panes,
         activePane: state.activePane,

--- a/clients/web/src/test/setup.ts
+++ b/clients/web/src/test/setup.ts
@@ -194,7 +194,7 @@ vi.mock('@/lib/wasm-core', () => {
     const r = p.runner as PodObj | undefined
     const cb = p.created_by as PodObj | undefined
     return create(PodSchema, {
-      id: p.id != null ? BigInt(p.id as number) : 0n, podKey: (p.pod_key as string) ?? '',
+      id: p.id != null ? BigInt(p.id as number) : BigInt(0), podKey: (p.pod_key as string) ?? '',
       status: (p.status as string) ?? '', agentStatus: (p.agent_status as string) ?? '',
       createdAt: (p.created_at as string) ?? '',
       runner: r ? create(PodRunnerInfoSchema, { id: r.id != null ? BigInt(r.id as number) : undefined, nodeId: r.node_id as string, status: r.status as string }) : undefined,
@@ -230,7 +230,7 @@ vi.mock('@/lib/wasm-core', () => {
     apply_appended_pods: fn((bytes: Uint8Array) => {
       try {
         const resp = fromBinary(ListPodsResponseSchema, bytes)
-        const existing = JSON.parse(h.pod.pods) as { pod_key: string }[]
+        const existing = JSON.parse(h.pod.pods) as PodObj[]
         const seen = new Set(existing.map((p) => p.pod_key))
         for (const p of resp.items) {
           const c = protoPodToCacheMin(p)

--- a/packages/electron-adapter/src/realtime.test.ts
+++ b/packages/electron-adapter/src/realtime.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { ElectronEventsManager } from "./realtime";
+
+type Handler = (s: string) => void;
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+let stateHandler: Handler | undefined;
+
+function stubApi(getStateValue: unknown = "disconnected") {
+  stateHandler = undefined;
+  const invoke = vi.fn((channel: string) =>
+    channel === "realtime:getState" ? Promise.resolve(getStateValue) : Promise.resolve(undefined),
+  );
+  (globalThis as { window?: unknown }).window = {
+    electronAPI: {
+      invoke,
+      onRealtimeEvent: () => () => {},
+      onRealtimeState: (h: Handler) => {
+        stateHandler = h;
+        return () => {};
+      },
+    },
+  };
+  return invoke;
+}
+
+afterEach(() => {
+  delete (globalThis as { window?: unknown }).window;
+  vi.restoreAllMocks();
+});
+
+describe("ElectronEventsManager · onRealtimeState guard (#4)", () => {
+  it("ignores empty/non-string frames so they don't clobber a good badge", async () => {
+    stubApi();
+    const mgr = new ElectronEventsManager();
+    const seen: string[] = [];
+    await mgr.on_connection_state_change((s) => seen.push(s));
+    await flush(); // drain the initial 'disconnected' replay + getState seed
+    seen.length = 0;
+
+    stateHandler!("connected");
+    expect(seen).toEqual(["connected"]);
+
+    stateHandler!(""); // empty frame ignored
+    expect(seen).toEqual(["connected"]);
+  });
+});
+
+describe("ElectronEventsManager · getState seed (#3)", () => {
+  it("seeds a window opened after the stream already connected", async () => {
+    stubApi("connected");
+    const mgr = new ElectronEventsManager();
+    const seen: string[] = [];
+    await mgr.on_connection_state_change((s) => seen.push(s));
+    await flush();
+    expect(seen).toContain("connected");
+  });
+
+  it("does NOT regress state once a real broadcast already landed", async () => {
+    stubApi("connecting"); // getState would resolve a now-stale value
+    const mgr = new ElectronEventsManager();
+    const seen: string[] = [];
+    await mgr.on_connection_state_change((s) => seen.push(s));
+
+    stateHandler!("connected"); // authoritative broadcast lands first
+    await flush(); // getState seed resolves now
+
+    expect(seen).toContain("connected");
+    expect(seen).not.toContain("connecting");
+  });
+});

--- a/packages/electron-adapter/src/realtime.ts
+++ b/packages/electron-adapter/src/realtime.ts
@@ -29,6 +29,7 @@ export class ElectronEventsManager {
   private nextId = 1;
   private unsubFns: Array<() => void> = [];
   private currentState: string = "disconnected";
+  private stateReceived = false;
 
   constructor() {
     const api = (globalThis as { window?: { electronAPI?: RealtimeBridgeApi } }).window
@@ -48,10 +49,24 @@ export class ElectronEventsManager {
     );
     this.unsubFns.push(
       api.onRealtimeState((state: string) => {
+        // Ignore empty/non-string frames (transient '' during rebind) — must not clobber a good badge.
+        if (typeof state !== "string" || state.length === 0) return;
+        this.stateReceived = true;
         this.currentState = state;
         for (const cb of this.stateCallbacks.values()) cb(state);
       }),
     );
+    // Seed state for a window opened after the stream already connected (main only
+    // broadcasts on transitions). Skip once a real broadcast landed — it's authoritative.
+    void invoke("realtime:getState")
+      .then((s) => {
+        if (this.stateReceived || typeof s !== "string" || s === this.currentState) return;
+        this.currentState = s;
+        for (const cb of this.stateCallbacks.values()) cb(s);
+      })
+      .catch(() => {
+        // Cold-start race: handler not ready; the 'disconnected' default stands.
+      });
   }
 
   async subscribe_all(cb: EventCallback): Promise<number> {


### PR DESCRIPTION
## What

Replaces the desktop `mainWindow` singleton with a `WindowRegistry` and adds a channel-popout window, unlocking real multi-window support (New Window, terminal popout, channel popout) with correct primary election, per-window persistence, and dynamic notification-owner handoff.

## Why

The old `mainWindow` singleton scattered `kind === "..."` policy checks across IPC / realtime / relay, so each new window kind risked silently breaking primary election, relay teardown, or notification ownership. This introduces a **window-kind capability table** as the single source of truth for per-kind policy.

## Key changes

### Main-process architecture
- **`WindowRegistry`** replaces `mainWindow`: derived `primaryId` election (`recomputePrimary`), per-`webContents` IPC multicast, ref-counted relay/realtime subscriptions.
- **`shared/window-kind.ts` capability table** — `primaryEligible` / `reloadOnConfigEdit` / `ephemeralLayout` / `seedsNotificationOwner`. Adding a kind is one row, not N scattered conditionals (OCP / protected-variations).
- **`index.ts` split** into focused modules: `app_state_handlers`, `cold_start`, `connect_call`, `create_window`, `legacy_api_aliases`, `menu`, `realtime_snapshots`, `window_ipc`, `window_registry` (200-line file limit).

### Correctness fixes (from max-effort review)
- **Boot-order**: `connectCall` + 12 legacy aliases registered *after* `bindAppStateHandlers` (were wiped at boot, dead on arrival).
- **Realtime-after-switch**: `rebindAppState` is now `async` and awaits `setupRealtimeBridge`, fixing dead realtime after a server switch.
- **Relay listener desync**: relay pool uses a single-value listener map (one listener per pod, replace-not-append) — fixes status/ACP desync on a resubscribe race.
- **Server switch**: chromeless popouts (terminal/channel) **close** on URL change instead of reloading into a permanently-wedged "Connecting…" (their pod is on the old backend).
- **Primary election**: a chromeless popout is never primary; designation transfers to a surviving full window when the incumbent closes.

### Web
- `windowing.ts` helpers (exported `electronApi`, coordinate-frame fix, `channelId<=0` guard).
- `ChannelContextMenu` keyboard a11y via `forwardRef` (Shift+F10 no longer lost).
- Per-window persistence: non-primary windows use `sessionStorage` to avoid stomping the shared `file://` localStorage key.
- i18n across 8 locales.

### CI
- `bazel.yml` web job now runs `:src_typecheck_test` (the real type gate) instead of `:src` (transpile-only false-green).

## Tests
- **38 new unit/integration tests**: `window-kind` (6), `window_registry` (13), `windowing` (11), `persistStorage` (3), electron-adapter `realtime` (3), relay pool listener-replace (2 Rust).
- **4 e2e specs** under `e2e/tests/window/`: popout-channel, popout-terminal, primary-election (#2 channel popout never primary, #5 primary transfers via New Window), server-switch (popout closes on switch).
- All unit + relay + window-subset e2e green locally.