### PR TITLE
fix(desktop): restore window dragging from titlebar headers (macOS immersive)

### DIFF
--- a/clients/desktop/src/renderer/globals.css
+++ b/clients/desktop/src/renderer/globals.css
@@ -207,6 +207,28 @@ body:has(.app-shell) {
 .app-no-drag {
   -webkit-app-region: no-drag;
 }
+/* -webkit-app-region is per-element (no inheritance); carve interactive descendants
+   back to no-drag so a draggable header keeps its buttons clickable. [draggable="true"]
+   opts out too — HTML5 tab tear-off is mutually exclusive with native app-region drag. */
+.app-drag button,
+.app-drag a,
+.app-drag input,
+.app-drag textarea,
+.app-drag select,
+.app-drag label,
+.app-drag [role="button"],
+.app-drag [role="textbox"],
+.app-drag [contenteditable="true"],
+.app-drag [draggable="true"] {
+  -webkit-app-region: no-drag;
+}
+/* A popout's titlebar header has no activity bar to its left, so it sits under the macOS
+   traffic lights — inset it clear. Route-scoped (not window-kind): no-activity-bar marks the
+   popout page root, so navigating into the full IDE shell drops the inset (the root unmounts).
+   78px = trafficLightPosition.x 14 + 3 lights (create_window.ts). */
+.platform-mac .no-activity-bar .app-drag {
+  padding-left: 78px;
+}
 
 /* Typography prose — map to theme CSS variables */
 .prose {

--- a/clients/desktop/src/renderer/pages/dashboard/mesh/MeshPage.tsx
+++ b/clients/desktop/src/renderer/pages/dashboard/mesh/MeshPage.tsx
@@ -32,7 +32,7 @@ export function MeshPage() {
 
   return (
     <div className="flex h-full w-full min-w-0 flex-col overflow-hidden">
-      <header className="flex items-center justify-between border-b border-border px-6 py-3.5">
+      <header className="app-drag flex items-center justify-between border-b border-border px-6 py-3.5">
         <h1 className="text-[18px] font-semibold text-foreground">{t("mesh.page.title")}</h1>
 
         <div className="flex items-center gap-2">

--- a/clients/desktop/src/renderer/pages/popout/channel/PopoutChannelPage.tsx
+++ b/clients/desktop/src/renderer/pages/popout/channel/PopoutChannelPage.tsx
@@ -24,7 +24,7 @@ export function PopoutChannelPage() {
 
   return (
     <RealtimeProvider>
-      <div className="h-screen w-screen bg-background">
+      <div className="no-activity-bar h-screen w-screen bg-background">
         <ChannelChatPanel channelId={channelId} />
       </div>
     </RealtimeProvider>

--- a/clients/desktop/src/renderer/pages/popout/terminal/PopoutTerminalPage.tsx
+++ b/clients/desktop/src/renderer/pages/popout/terminal/PopoutTerminalPage.tsx
@@ -21,7 +21,7 @@ export function PopoutTerminalPage() {
 
   return (
     <RealtimeProvider>
-      <div className="h-screen w-screen bg-terminal-bg">
+      <div className="no-activity-bar h-screen w-screen bg-terminal-bg">
         <TerminalPane
           paneId={`popout-${podKey}`}
           podKey={podKey}

--- a/clients/web/src/components/blocks/BlocksDocHeader.tsx
+++ b/clients/web/src/components/blocks/BlocksDocHeader.tsx
@@ -29,7 +29,7 @@ export function BlocksDocHeader({
     </>
   );
   return (
-    <div className="flex flex-col gap-1.5 border-b border-border px-12 pb-3 pt-4">
+    <div className="app-drag flex flex-col gap-1.5 border-b border-border px-12 pb-3 pt-4">
       <div className="flex items-center gap-2 text-[12px] text-muted-foreground">
         <span>Pages</span>
         <span className="text-border">›</span>

--- a/clients/web/src/components/channel/ChannelChatPanel.tsx
+++ b/clients/web/src/components/channel/ChannelChatPanel.tsx
@@ -29,7 +29,7 @@ export function ChannelChatPanel({ channelId }: ChannelChatPanelProps) {
   if (chat.channelLoading && !chat.currentChannel) {
     return (
       <div className="flex flex-col h-full bg-background">
-        <div className="flex-shrink-0 border-b border-border px-4 py-3">
+        <div className="app-drag flex-shrink-0 border-b border-border px-4 py-3">
           <div className="h-8 w-32 bg-muted animate-pulse rounded" />
         </div>
         <div className="flex-1 flex items-center justify-center">

--- a/clients/web/src/components/channel/ChannelHeader.tsx
+++ b/clients/web/src/components/channel/ChannelHeader.tsx
@@ -64,7 +64,7 @@ export function ChannelHeader({
   }
 
   return (
-    <div className="flex flex-shrink-0 items-center justify-between border-b border-border px-6 py-3">
+    <div className="app-drag flex flex-shrink-0 items-center justify-between border-b border-border px-6 py-3">
       <div className="flex min-w-0 items-center gap-2.5">
         <Icon
           className={cn(

--- a/clients/web/src/components/ide/SideBar.tsx
+++ b/clients/web/src/components/ide/SideBar.tsx
@@ -86,7 +86,7 @@ export function SideBar({ className, children, headerAction }: SideBarProps) {
       style={{ width: sidebarWidth }}
     >
       {activeActivity !== "settings" && (
-        <div className="flex h-12 items-center justify-between gap-2 border-b border-border/60 px-3">
+        <div className="app-drag flex h-12 items-center justify-between gap-2 border-b border-border/60 px-3">
           <div className="flex min-w-0 items-center gap-1.5">
             <Button
               variant="ghost"

--- a/clients/web/src/components/tickets/TicketsPageHeader.tsx
+++ b/clients/web/src/components/tickets/TicketsPageHeader.tsx
@@ -34,7 +34,7 @@ export function TicketsPageHeader({ onCreateClick, onExportClick, rightExtra }: 
   );
 
   return (
-    <header className="flex items-center justify-between gap-4 border-b border-border px-6 py-3">
+    <header className="app-drag flex items-center justify-between gap-4 border-b border-border px-6 py-3">
       <div className="flex items-center gap-3">
         <h1 className="text-lg font-semibold tracking-tight text-foreground">{t("tickets.title")}</h1>
       </div>

--- a/clients/web/src/components/workspace/TerminalPaneHeader.tsx
+++ b/clients/web/src/components/workspace/TerminalPaneHeader.tsx
@@ -80,7 +80,7 @@ export function TerminalPaneHeader({
   })();
 
   return (
-    <div className="h-8 flex items-center justify-between px-2 bg-terminal-bg-secondary border-b border-terminal-border">
+    <div className={cn("h-8 flex items-center justify-between px-2 bg-terminal-bg-secondary border-b border-terminal-border", !canTearOff && "app-drag")}>
       <div
         className="flex items-center gap-2 min-w-0"
         draggable={canTearOff}


### PR DESCRIPTION
## Problem

v0.44.2 regression: on macOS (`titleBarStyle: "hiddenInset"`), **neither the main window nor any popout window can be dragged by its top edge**. #449 shrank the only `-webkit-app-region: drag` region into the 136px ActivityBar to remove a gray titlebar band — but that left the main window's content headers and all popout windows (which have no ActivityBar) with no drag region at all.

## Fix

Immersive-titlebar drag belongs on the header bars that already sit at the window top — not a separate band. Each window-top header becomes its own drag region:

- **Global no-drag carve-out** (`globals.css`): `.app-drag button, a, input, [role=button], [draggable=true], …{ -webkit-app-region: no-drag }` so a draggable header keeps its buttons clickable, and HTML5 tab tear-off (mutually exclusive with app-region drag) is auto-preserved.
- **`app-drag` on the 5 window-top headers**: SideBar, ChannelHeader, TicketsPageHeader, BlocksDocHeader, MeshPage — plus the channel loading skeleton.
- **TerminalPaneHeader** bar drags only in the popout (`!canTearOff`); main-window split panes keep HTML5 tab tear-off and never drag the window (app-region drag is position-independent, so an unconditional `app-drag` would let a bottom-row pane lurch the whole window).
- **Traffic-light inset**, route-scoped: a `no-activity-bar` class on the popout page roots insets their titlebar 78px clear of the macOS traffic lights, and **drops when a popout navigates into the full IDE shell** (the root unmounts). This replaces an earlier static window-kind class that corrupted the ActivityBar when a channel popout followed an in-app ticket/repo link.

## Review

Converged over **3 rounds of max-effort code review + 1 arch check**, which caught and fixed: a broken `pointer-events-none` overlay strip (app-region ignores pointer-events), the unconditional TerminalPaneHeader drag, the static-window-class navigation corruption, and a dead-code MobileShell path (unreachable: `minWidth 900` > mobile breakpoint `768`).

## Verification

- ✅ `bazel test //clients/web:src_typecheck_test`
- ✅ `bazel build //clients/desktop:out`
- Manual macOS matrix (drag each header / both popouts / popout button clicks / terminal tab tear-off) — pending reviewer spot-check.

10 files, web-shared header components are no-ops on web (`--titlebar-drag-height: 0`, app-region inert in browsers).