### PR TITLE
feat(agents): integrate GitHub Copilot CLI

### DIFF
--- a/backend/migrations/000162_add_copilot_agent.down.sql
+++ b/backend/migrations/000162_add_copilot_agent.down.sql
@@ -1,0 +1,18 @@
+-- 000162_add_copilot_agent.down.sql
+-- Rollback path: clear FK-referencing rows before removing the agents row,
+-- wrapped in a transaction for atomicity (matches the BEGIN/COMMIT convention
+-- in 000157/000156/000149/000130 down migrations).
+--
+-- organization_agents and organization_agent_configs carry NO ACTION foreign
+-- keys onto agents(slug) (migration 000093:23,31), so deleting copilot-cli from
+-- agents while any org enabled it would fail - they MUST be cleared first.
+-- user_agent_configs carries agent_slug with an index but no FK (000090), so
+-- it's cleared only to avoid orphan slug references, not for FK safety.
+BEGIN;
+
+DELETE FROM organization_agent_configs WHERE agent_slug = 'copilot-cli';
+DELETE FROM organization_agents WHERE agent_slug = 'copilot-cli';
+DELETE FROM user_agent_configs WHERE agent_slug = 'copilot-cli';
+DELETE FROM agents WHERE slug = 'copilot-cli';
+
+COMMIT;

--- a/backend/migrations/000162_add_copilot_agent.up.sql
+++ b/backend/migrations/000162_add_copilot_agent.up.sql
@@ -1,0 +1,42 @@
+-- 000162_add_copilot_agent.up.sql
+-- Register GitHub Copilot CLI as a builtin agent.
+--
+-- The binary on disk is `copilot` (installed via Homebrew cask `copilot-cli`
+-- or `npm i -g @github/copilot`). The DB `slug` keeps the `-cli` suffix to
+-- match the claude-code / codex-cli / gemini-cli / cursor-cli naming
+-- convention, but the AgentFile AGENT/EXECUTABLE fields MUST be the actual
+-- binary name `copilot` (agentfile/eval/eval_decl.go wires AGENT directly into
+-- LaunchCommand, which the runner exec()s). Using AGENT=copilot-cli would make
+-- every pod fail with ENOENT (see migration 000157 for the same reasoning).
+--
+-- Copilot is a native ACP agent: `copilot --acp` starts an Agent Client
+-- Protocol JSON-RPC 2.0 server over stdio (verified: initialize returns
+-- agentCapabilities incl. loadSession). It therefore slots into the same ACP
+-- driver as gemini-cli / opencode / loopal and needs no custom transport. The
+-- MODE acp args are `--acp`, mirroring loopal (000122).
+--
+-- Auto-approve: the brief-verified `--allow-all-tools` (env COPILOT_ALLOW_ALL)
+-- and `--no-ask-user` flags keep a non-interactive PTY pod from blocking on a
+-- permission/ask_user prompt. They are gated to `mode != "acp"` because in ACP
+-- mode tool permissions are negotiated over the protocol (matching codex-cli,
+-- which gates `--ask-for-approval` the same way).
+--
+-- Model passthrough: `CONFIG model STRING` feeds `--model <model>` (verified
+-- global flag; `auto` lets Copilot pick). Applied in both modes.
+--
+-- COPILOT_GITHUB_TOKEN is declared as an OPTIONAL secret: Copilot authenticates
+-- via `copilot login` OAuth (token in HOME, inherited by the pod) by default,
+-- but also honors a GitHub token env var for headless auth. The ENV declaration
+-- is pure schema metadata (agentfile/eval/eval_decl.go skips
+-- `ENV X SECRET OPTIONAL` at eval time); it lets the frontend render a curated
+-- credential field, mirroring cursor-cli's CURSOR_API_KEY.
+--
+-- MCP is intentionally NOT declared (no `MCP ON`): Copilot reads MCP servers
+-- from ~/.copilot/mcp-config.json (HOME), not from a file under the sandbox
+-- work_dir, so declaring MCP would set MCPEnabled=true without any config
+-- landing where Copilot looks for it. Deferred to a follow-up (same first-pass
+-- stance as cursor-cli in 000157).
+
+INSERT INTO agents (slug, name, launch_command, executable, is_builtin, is_active, supported_modes, agentfile_source)
+VALUES ('copilot-cli', 'GitHub Copilot CLI', 'copilot', 'copilot', true, true, 'pty,acp',
+  E'# === Identity ===\nAGENT copilot\nEXECUTABLE copilot\n\n# === Mode ===\nMODE pty\nMODE acp "--acp"\n\n# === Configuration ===\nCONFIG model STRING = ""\n\n# === Environment ===\nENV COPILOT_GITHUB_TOKEN SECRET OPTIONAL\n\n# === Prompt ===\nPROMPT_POSITION prepend\n\n# === Build Logic ===\narg "--model" config.model when config.model != ""\narg "--allow-all-tools" when mode != "acp"\narg "--no-ask-user" when mode != "acp"\n');

--- a/backend/migrations/embed_test.go
+++ b/backend/migrations/embed_test.go
@@ -100,3 +100,59 @@ func TestMigration000157CursorCLIAgent(t *testing.T) {
 		t.Error("down migration must NOT DELETE FROM user_agent_credential_profiles — dropped in 000146")
 	}
 }
+
+// TestMigration000162CopilotCLIAgent locks the same failure modes for the
+// copilot-cli builtin migration that 000157 locks for cursor-cli:
+//   - AgentFile AGENT/EXECUTABLE MUST be the actual binary `copilot`, NOT the
+//     DB slug `copilot-cli`. eval_decl.go writes AGENT into LaunchCommand which
+//     the runner exec()s; using the slug makes every pod fail with ENOENT.
+//   - Copilot is a native ACP agent, so the AgentFile MUST declare
+//     `MODE acp "--acp"` (mirrors loopal 000122).
+//   - Down migration MUST clear referencing rows first or it fails on the
+//     organization_agents FK (000093 declares NO ACTION).
+func TestMigration000162CopilotCLIAgent(t *testing.T) {
+	up, err := FS.ReadFile("000162_add_copilot_agent.up.sql")
+	if err != nil {
+		t.Fatalf("read up migration: %v", err)
+	}
+	upStr := string(up)
+
+	if !strings.Contains(upStr, "AGENT copilot\\n") {
+		t.Error("AgentFile AGENT must declare the binary name `copilot` (not the slug)")
+	}
+	if strings.Contains(upStr, "AGENT copilot-cli") {
+		t.Error("AGENT must NOT be the DB slug `copilot-cli`: that value becomes LaunchCommand and is exec'd; the binary is `copilot`")
+	}
+	if !strings.Contains(upStr, "EXECUTABLE copilot") {
+		t.Error("EXECUTABLE must be `copilot`")
+	}
+	if !strings.Contains(upStr, `MODE acp "--acp"`) {
+		t.Error("AgentFile must declare `MODE acp \"--acp\"`: Copilot is a native ACP agent")
+	}
+	if !strings.Contains(upStr, "'copilot-cli'") {
+		t.Error("DB slug column must be 'copilot-cli' (matches claude-code / codex-cli / gemini-cli / cursor-cli convention)")
+	}
+	if !strings.Contains(upStr, "'copilot'") {
+		t.Error("launch_command / executable columns must be 'copilot'")
+	}
+	if !strings.Contains(upStr, "ENV COPILOT_GITHUB_TOKEN SECRET OPTIONAL") {
+		t.Error("AgentFile must declare COPILOT_GITHUB_TOKEN as an optional secret so the credential UI can render a curated field")
+	}
+
+	down, err := FS.ReadFile("000162_add_copilot_agent.down.sql")
+	if err != nil {
+		t.Fatalf("read down migration: %v", err)
+	}
+	downStr := string(down)
+
+	// Both NO-ACTION-FK tables (000093) must be deleted BEFORE agents.
+	orgConfigsIdx := strings.Index(downStr, "DELETE FROM organization_agent_configs")
+	orgAgentsIdx := strings.Index(downStr, "DELETE FROM organization_agents WHERE")
+	agentsIdx := strings.Index(downStr, "DELETE FROM agents WHERE slug")
+	if orgConfigsIdx < 0 || orgAgentsIdx < 0 || agentsIdx < 0 {
+		t.Fatal("down migration must DELETE from organization_agent_configs, organization_agents, AND agents")
+	}
+	if orgConfigsIdx > agentsIdx || orgAgentsIdx > agentsIdx {
+		t.Error("down migration must clear organization_agent_configs/organization_agents BEFORE agents (FK NO ACTION blocks otherwise)")
+	}
+}

--- a/clients/web/src/components/landing/AgentLogos.tsx
+++ b/clients/web/src/components/landing/AgentLogos.tsx
@@ -61,6 +61,17 @@ const agentConfigs = [
     ),
   },
   {
+    name: "GitHub Copilot CLI",
+    descriptionKey: "landing.agentLogos.descriptions.github",
+    icon: (
+      <svg viewBox="0 0 24 24" className="w-8 h-8" fill="currentColor">
+        <rect x="3" y="7" width="18" height="12" rx="6" stroke="currentColor" strokeWidth="2" fill="none" />
+        <circle cx="9" cy="13" r="1.5" fill="currentColor" />
+        <circle cx="15" cy="13" r="1.5" fill="currentColor" />
+      </svg>
+    ),
+  },
+  {
     name: "Loopal",
     descriptionKey: "landing.agentLogos.descriptions.selfBuilt",
     icon: (

--- a/clients/web/src/messages/de/landing.json
+++ b/clients/web/src/messages/de/landing.json
@@ -39,6 +39,7 @@
         "community": "Community",
         "yourOwn": "Eigene",
         "anysphere": "Anysphere",
+        "github": "GitHub",
         "selfBuilt": "Selbst entwickelt"
       }
     },

--- a/clients/web/src/messages/en/landing.json
+++ b/clients/web/src/messages/en/landing.json
@@ -39,7 +39,8 @@
         "community": "Community",
         "selfBuilt": "Self-Built",
         "yourOwn": "Your Own",
-        "anysphere": "Anysphere"
+        "anysphere": "Anysphere",
+        "github": "GitHub"
       }
     },
     "paradigmShift": {

--- a/clients/web/src/messages/es/landing.json
+++ b/clients/web/src/messages/es/landing.json
@@ -39,6 +39,7 @@
         "community": "Comunidad",
         "yourOwn": "Personalizado",
         "anysphere": "Anysphere",
+        "github": "GitHub",
         "selfBuilt": "Propio"
       }
     },

--- a/clients/web/src/messages/fr/landing.json
+++ b/clients/web/src/messages/fr/landing.json
@@ -39,6 +39,7 @@
         "community": "Communauté",
         "yourOwn": "Le Vôtre",
         "anysphere": "Anysphere",
+        "github": "GitHub",
         "selfBuilt": "Personnalisé"
       }
     },

--- a/clients/web/src/messages/ja/landing.json
+++ b/clients/web/src/messages/ja/landing.json
@@ -39,6 +39,7 @@
         "community": "コミュニティ",
         "yourOwn": "カスタム",
         "anysphere": "Anysphere",
+        "github": "GitHub",
         "selfBuilt": "自社構築"
       }
     },

--- a/clients/web/src/messages/ko/landing.json
+++ b/clients/web/src/messages/ko/landing.json
@@ -39,6 +39,7 @@
         "community": "커뮤니티",
         "yourOwn": "커스텀",
         "anysphere": "Anysphere",
+        "github": "GitHub",
         "selfBuilt": "자체 구축"
       }
     },

--- a/clients/web/src/messages/pt/landing.json
+++ b/clients/web/src/messages/pt/landing.json
@@ -39,6 +39,7 @@
         "community": "Comunidade",
         "yourOwn": "O Seu Proprio",
         "anysphere": "Anysphere",
+        "github": "GitHub",
         "selfBuilt": "Próprio"
       }
     },

--- a/clients/web/src/messages/zh/landing.json
+++ b/clients/web/src/messages/zh/landing.json
@@ -39,7 +39,8 @@
         "community": "社区",
         "selfBuilt": "自研",
         "yourOwn": "自定义",
-        "anysphere": "Anysphere"
+        "anysphere": "Anysphere",
+        "github": "GitHub"
       }
     },
     "paradigmShift": {

--- a/runner/internal/agents/copilot/BUILD.bazel
+++ b/runner/internal/agents/copilot/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "copilot",
+    srcs = ["register.go"],
+    importpath = "github.com/anthropics/agentsmesh/runner/internal/agents/copilot",
+    visibility = ["//runner:__subpackages__"],
+    deps = [
+        "//runner/internal/agentkit",
+        "//runner/internal/tokenusage",
+    ],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":copilot",
+    visibility = ["//runner:__subpackages__"],
+)
+
+go_test(
+    name = "copilot_test",
+    srcs = ["register_test.go"],
+    embed = [":copilot"],
+    deps = [
+        "//runner/internal/agentkit",
+        "//runner/internal/tokenusage",
+        "@com_github_stretchr_testify//assert",
+    ],
+)

--- a/runner/internal/agents/copilot/register.go
+++ b/runner/internal/agents/copilot/register.go
@@ -1,0 +1,21 @@
+package copilot
+
+import (
+	"github.com/anthropics/agentsmesh/runner/internal/agentkit"
+	"github.com/anthropics/agentsmesh/runner/internal/tokenusage"
+)
+
+func init() {
+	// GitHub Copilot CLI speaks standard ACP JSON-RPC 2.0 over `copilot --acp`
+	// (verified: initialize -> agentCapabilities incl. loadSession), so the
+	// default ACP transport applies and no acp.RegisterAgent is needed - same
+	// as gemini / opencode.
+	//
+	// Copilot exposes no documented on-disk session format we can parse for
+	// token usage, so opt out of the cross-agent fixture contract rather than
+	// ship a no-op parser (per agents/doc.go). Cover BOTH the DB slug
+	// ("copilot-cli") and the runtime launch_command key ("copilot") that
+	// tokenusage.Collect uses (pod.Agent == LaunchCommand), mirroring cursor.
+	tokenusage.RegisterParserOptOut([]string{"copilot-cli", "copilot"})
+	agentkit.RegisterProcessNames("copilot")
+}

--- a/runner/internal/agents/copilot/register_test.go
+++ b/runner/internal/agents/copilot/register_test.go
@@ -1,0 +1,20 @@
+package copilot
+
+import (
+	"testing"
+
+	"github.com/anthropics/agentsmesh/runner/internal/agentkit"
+	"github.com/anthropics/agentsmesh/runner/internal/tokenusage"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCopilotRegistered(t *testing.T) {
+	// Opt-out covers BOTH the DB slug and the runtime launch_command key.
+	assert.True(t, tokenusage.IsParserOptOut("copilot-cli"), "slug copilot-cli should be opt-out from token-usage fixture contract")
+	assert.True(t, tokenusage.IsParserOptOut("copilot"), "launch_command copilot (the runtime token-collection key) should be opt-out")
+	assert.Nil(t, tokenusage.GetParser("copilot-cli"), "opt-out agents must not register a parser (slug key)")
+	assert.Nil(t, tokenusage.GetParser("copilot"), "opt-out agents must not register a parser (runtime launch_command key)")
+
+	assert.True(t, agentkit.IsAgentProcess("copilot"), "process name copilot must be registered")
+	assert.False(t, agentkit.IsAgentProcess("copilot-cli"), "the DB slug must NOT be registered as a process name (the binary is copilot)")
+}

--- a/runner/internal/runner/BUILD.bazel
+++ b/runner/internal/runner/BUILD.bazel
@@ -72,6 +72,7 @@ go_library(
         "//runner/internal/agents/aider",
         "//runner/internal/agents/claude",
         "//runner/internal/agents/codex",
+        "//runner/internal/agents/copilot",
         "//runner/internal/agents/cursor",
         "//runner/internal/agents/gemini",
         "//runner/internal/agents/loopal",

--- a/runner/internal/runner/agents_import.go
+++ b/runner/internal/runner/agents_import.go
@@ -4,6 +4,7 @@ import (
 	_ "github.com/anthropics/agentsmesh/runner/internal/agents/aider"
 	_ "github.com/anthropics/agentsmesh/runner/internal/agents/claude"
 	_ "github.com/anthropics/agentsmesh/runner/internal/agents/codex"
+	_ "github.com/anthropics/agentsmesh/runner/internal/agents/copilot"
 	_ "github.com/anthropics/agentsmesh/runner/internal/agents/cursor"
 	_ "github.com/anthropics/agentsmesh/runner/internal/agents/gemini"
 	_ "github.com/anthropics/agentsmesh/runner/internal/agents/loopal"


### PR DESCRIPTION
## Summary

- What changed? Adds GitHub Copilot CLI as a first-class builtin agent, selectable exactly like Claude Code / Codex / Gemini / Aider / OpenCode / Cursor. Copilot is a native ACP agent (`copilot --acp`), so it slots into the same ACP driver as Gemini/OpenCode/Loopal with no custom transport.
- Why was this change needed? Copilot CLI is a widely used coding agent and was the main mainstream CLI not yet wired into the mesh.

## Changes

- backend: migration `000162_add_copilot_agent` seeds the `copilot-cli` builtin (binary `copilot`, modes `pty,acp`). The AgentFile uses `MODE acp "--acp"` (mirrors loopal), passes `--model` through a `STRING` config, and gates `--allow-all-tools`/`--no-ask-user` to pty mode so a non-interactive pod never blocks on a permission or ask_user prompt. ACP mode defers tool permissions to the framework's existing negotiation. MCP is intentionally deferred (Copilot reads `~/.copilot/mcp-config.json` in HOME, not the sandbox work_dir), matching cursor-cli's first-pass stance.
- runner: `internal/agents/copilot/register.go` registers the `copilot` process name and opts out of token-usage fixture parsing (no documented on-disk session format), mirroring cursor. Standard ACP JSON-RPC, so no custom transport. Wired via the blank import in `agents_import.go`.
- tests: `copilot/register_test.go` plus a static SQL audit `TestMigration000162CopilotCLIAgent` mirroring the cursor-cli locks.
- web: Copilot added to the landing AgentLogos showcase, with a `github` description key across all eight locales.

## Validation

- [x] Backend tests (`bazel test //backend/...`): verified the proto-independent subset locally via `go test ./backend/migrations/` (pass); the full bazel suite runs in CI.
- [x] Web checks: all eight `landing.json` files validated as JSON with parallel keys; the AgentLogos change matches the existing entry shape.
- [x] Runner checks (`bazel test //runner/...`): verified `go test ./runner/internal/agents/copilot/` (pass); the full bazel suite runs in CI.
- [x] Manual validation performed: against the real Copilot CLI v1.0.65 on this machine, `copilot --acp` returns a valid ACP initialize (`loadSession:true`, `sessionCapabilities.list`) and `copilot -p "..." -s --allow-all-tools --no-ask-user --model auto` returns clean output (exit 0).

Environment note: bazel and buf are not installed on this machine and the Go proto bindings are bazel-generated (not checked in), so the full bazel suites were not run locally; the proto-independent packages were built and tested directly.

## Documentation

- [x] Docs updated (inline migration and register.go rationale comments)
- [ ] No docs changes needed

## Risk and Rollback

- Risk level: Low. Additive only: one new builtin agent row, one new runner package (blank-imported), one landing-page entry. No existing agent, schema, or runtime path is modified.
- Rollback plan: `migrate down 1` runs `000162_..._down.sql` (clears FK-referencing rows then the agents row in a transaction); revert the commit to drop the runner package and web entry.

Per CONTRIBUTING.md, this contribution is offered under the repository's Business Source License 1.1.
