### PR TITLE
ci(deploy): git pull on relay hosts before deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -200,7 +200,7 @@ jobs:
     runs-on: [self-hosted, deploy]
     steps:
       - run: |
-          ssh aliyun-us-west-relay-001 "cd /opt/agentsmesh/relay && ./deploy.sh uswest-relay-01 --pull"
+          ssh aliyun-us-west-relay-001 "cd /opt/agentsmesh && git pull --rebase --autostash origin main && cd relay && ./deploy.sh uswest-relay-01 --pull"
 
   deploy-uswest-relay-beijing-02:
     name: Deploy US West Relay Beijing 02
@@ -209,7 +209,7 @@ jobs:
     runs-on: [self-hosted, deploy]
     steps:
       - run: |
-          ssh aliyun-agentsmesh-us-relay-beijing-002 "cd /opt/agentsmesh/relay && ./deploy.sh uswest-relay-beijing-02 --pull"
+          ssh aliyun-agentsmesh-us-relay-beijing-002 "cd /opt/agentsmesh && git pull --rebase --autostash origin main && cd relay && ./deploy.sh uswest-relay-beijing-02 --pull"
 
   migrate-uswest:
     name: Migrate US West
@@ -251,7 +251,7 @@ jobs:
     runs-on: [self-hosted, deploy]
     steps:
       - run: |
-          ssh aliyun-cn-relay-01 "cd /opt/agentsmesh/relay && ./deploy.sh cn-relay-01 --pull"
+          ssh aliyun-cn-relay-01 "cd /opt/agentsmesh && git pull --rebase --autostash origin main && cd relay && ./deploy.sh cn-relay-01 --pull"
 
   migrate-cn:
     name: Migrate CN


### PR DESCRIPTION
## Problem

The three relay deploy jobs (`deploy-uswest-relay-01`, `deploy-uswest-relay-beijing-02`, `deploy-cn-relay-01`) run:

```
ssh <host> "cd /opt/agentsmesh/relay && ./deploy.sh <env> --pull"
```

`--pull` is a **docker image** pull only — the job never `git pull`s the deploy repo on the host. So any change to the relay compose (`relay/docker-compose.yml` and the per-host overrides) never reaches the relay hosts; they keep deploying whatever local yaml they were last set up with. Verified on `aliyun-cn-relay-01`: its `/opt/agentsmesh` HEAD is stuck at an old commit and its relay compose lacks the just-committed `init: true` line.

The **backend** jobs already do the right thing (`cd /opt/agentsmesh && git pull --rebase --autostash origin main && ./deploy.sh …`), and the line ~182 comment even documents why. The relay jobs were just never updated to match.

## Fix

Prefix each relay job's SSH command with the same `git pull --rebase --autostash origin main` before `./deploy.sh`, so relay compose changes actually propagate on the next deploy:

```
ssh <host> "cd /opt/agentsmesh && git pull --rebase --autostash origin main && cd relay && ./deploy.sh <env> --pull"
```

`--autostash` tolerates any local drift on the host; `--rebase` keeps it linear — identical to the backend jobs.

## Why now

A relay healthcheck zombie-reaper fix (`init: true` on the relay service, deploy repo commit `e2f555f`) was just committed to fix a fork-exhaustion incident on `cn-relay-01` (984 leaked `ssl_client` zombies from the BusyBox-wget HTTPS healthcheck under a no-init PID 1). Without this workflow change that fix would silently never reach the relay hosts.

Verified: `/opt/agentsmesh` on the relay host is a proper git checkout with a working deploy key (`git fetch` succeeds), so the added `git pull` is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
