### PR TITLE
ci: trust the GitLab sync workspace

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,7 @@ sync:github:
   script:
     - |
       set -euo pipefail
+      git config --global --add safe.directory "$CI_PROJECT_DIR"
       git fetch --no-tags --force \
         https://github.com/AgentsMesh/AgentsMesh.git \
         main:refs/remotes/github/main


### PR DESCRIPTION
## Summary

- mark the GitLab Runner checkout as a trusted Git working directory before the scheduled mirror job fetches GitHub
- keep the trust exception scoped to `CI_PROJECT_DIR`

## Root cause

The pinned builder image runs as uid 1000 while GitLab Runner mounts the checkout with different ownership. Git refuses all repository operations with `detected dubious ownership` before the mirror comparison can run.

## Validation

- reproduced the ownership failure in the pinned builder image
- verified the scoped safe-directory command fixes it
- GitLab CI lint
- extracted sync script `bash -n`

The mirror schedule is temporarily inactive until this fix is merged and verified.