### PR TITLE
fix(deploy): route Connect RPC in private templates

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -45,6 +45,8 @@ jobs:
       - run: bazel run //:buildifier_check
       - name: Identifier contract lint
         run: bash tools/identifier-lint/lint.sh
+      - name: Self-hosted Traefik route contract
+        run: bash deploy/traefik_connect_routes_test.sh
       - name: Verify desktop-only crate isolation
         run: |
           set -euo pipefail

--- a/deploy/onpremise/traefik/dynamic/routes.yml
+++ b/deploy/onpremise/traefik/dynamic/routes.yml
@@ -13,7 +13,7 @@ http:
     # Backend API
     # =========================================================================
     api:
-      rule: "PathPrefix(`/api`) || PathPrefix(`/health`)"
+      rule: "PathPrefix(`/api`) || PathPrefix(`/health`) || PathPrefix(`/proto.`)"
       entryPoints:
         - web
       service: backend

--- a/deploy/selfhost/traefik/dynamic/routes.yml
+++ b/deploy/selfhost/traefik/dynamic/routes.yml
@@ -6,7 +6,7 @@ http:
   routers:
     # Backend API
     api:
-      rule: "PathPrefix(`/api`) || PathPrefix(`/health`)"
+      rule: "PathPrefix(`/api`) || PathPrefix(`/health`) || PathPrefix(`/proto.`)"
       entryPoints:
         - web
       service: backend

--- a/deploy/traefik_connect_routes_test.sh
+++ b/deploy/traefik_connect_routes_test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+configs=(
+  "deploy/selfhost/traefik/dynamic/routes.yml"
+  "deploy/onpremise/traefik/dynamic/routes.yml"
+)
+
+cd "$repo_root"
+ruby -ryaml - "${configs[@]}" <<'RUBY'
+EXPECTED_RULE = 'PathPrefix(`/api`) || PathPrefix(`/health`) || PathPrefix(`/proto.`)'
+
+def value_at(document, *keys)
+  keys.reduce(document) do |value, key|
+    value.is_a?(Hash) ? value[key] : nil
+  end
+end
+
+def assert_equal(path, field, actual, expected)
+  return if actual == expected
+
+  abort "#{path}: #{field}: expected #{expected.inspect}, got #{actual.inspect}"
+end
+
+ARGV.each do |path|
+  begin
+    document = YAML.safe_load_file(path, aliases: false)
+  rescue Psych::Exception => error
+    abort "#{path}: yaml: #{error.message}"
+  end
+
+  api_rule = value_at(document, "http", "routers", "api", "rule")
+  api_service = value_at(document, "http", "routers", "api", "service")
+  api_priority = value_at(document, "http", "routers", "api", "priority")
+  web_priority = value_at(document, "http", "routers", "web", "priority")
+
+  assert_equal(path, "http.routers.api.rule", api_rule, EXPECTED_RULE)
+  assert_equal(path, "http.routers.api.service", api_service, "backend")
+  assert_equal(path, "http.routers.api.priority", api_priority, 100)
+
+  unless web_priority.is_a?(Numeric) && web_priority < api_priority
+    abort "#{path}: http.routers.web.priority: expected a number lower than #{api_priority.inspect}, got #{web_priority.inspect}"
+  end
+
+  puts "validated #{path}"
+end
+RUBY


### PR DESCRIPTION
## Summary

- route `/proto.*` Connect-RPC requests to the backend in selfhost and on-premise Traefik templates
- add a structured YAML contract test for both private deployment templates
- run the contract test in the existing Smoke workflow

## Root cause

Desktop authentication uses `/proto.auth.v1.AuthService/Login` and SSO discovery uses `/proto.sso.v1.SSOService/Discover`. The private deployment templates only routed `/api` and `/health` to Backend, so `/proto.*` fell through to the Next.js catch-all and returned an HTML 404.

## Validation

- `bash -n deploy/traefik_connect_routes_test.sh`
- `shellcheck deploy/traefik_connect_routes_test.sh`
- `bash deploy/traefik_connect_routes_test.sh`
- `git diff --check`
- YAML parsed with Ruby/Psych