### PR TITLE
fix(ci): support pinned curl in GitLab sync

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,8 @@ sync:github:
         "$CI_REPOSITORY_URL" \
         "$github_sha:refs/heads/main"
 
-      curl --fail-with-body --silent --show-error \
+      # The pinned Bazel builder ships curl without --fail-with-body.
+      curl --fail --silent --show-error \
         --request POST \
         --form "token=$CI_JOB_TOKEN" \
         --form "ref=main" \


### PR DESCRIPTION
## Summary

- replace `curl --fail-with-body` with portable `--fail --silent --show-error` in the GitLab mirror trigger
- document the pinned Bazel builder compatibility constraint

## Root cause

The mirror push itself succeeded, but Pipeline `9229` / Job `76817` failed immediately afterward because the pinned builder image ships a curl version that does not recognize `--fail-with-body`. That prevented the sync job from triggering the normal build pipeline whenever GitHub actually advanced.

## Validation

- GitLab CI YAML parsed with Ruby/Psych
- extracted `sync:github` script passes `bash -n`
- extracted script passes ShellCheck
- `git diff --check`