### PR TITLE
fix(channel): robust entry scroll & unread-divider positioning

### DIFF
--- a/clients/web/src/components/channel/ChannelChatPanel.tsx
+++ b/clients/web/src/components/channel/ChannelChatPanel.tsx
@@ -70,6 +70,7 @@ export function ChannelChatPanel({ channelId }: ChannelChatPanelProps) {
                 currentUserId={chat.currentUserId}
                 channelId={channelId}
                 firstUnreadId={chat.firstUnreadId}
+                entryAnchorResolved={chat.entryAnchorResolved}
                 roleByUserId={chat.roleByUserId}
                 onEditMessage={chat.handleEditMessage}
                 onDeleteMessage={chat.handleDeleteMessage}

--- a/clients/web/src/components/channel/MessageList.tsx
+++ b/clients/web/src/components/channel/MessageList.tsx
@@ -22,6 +22,9 @@ interface MessageListProps {
   currentUserId?: number;
   channelId?: number;
   firstUnreadId?: number | null;
+  // Whether the unread cursor is resolved. Entry positioning waits for this so
+  // an unknown cursor doesn't scroll to the bottom and then jump to the divider.
+  entryAnchorResolved?: boolean;
   roleByUserId?: Map<number, string>;
   onEditMessage?: (messageId: number, payload: MessageEditPayload) => Promise<void>;
   onDeleteMessage?: (messageId: number) => Promise<void>;
@@ -29,15 +32,15 @@ interface MessageListProps {
 
 export function MessageList({
   messages, loading, loadingMore, hasMore, error,
-  onLoadMore, onRetry, currentUserId, channelId, firstUnreadId, roleByUserId,
+  onLoadMore, onRetry, currentUserId, channelId, firstUnreadId, entryAnchorResolved = true, roleByUserId,
   onEditMessage, onDeleteMessage,
 }: MessageListProps) {
   const t = useTranslations("channels.messages");
   const allPods = usePods();
   const {
-    containerRef, bottomRef, isAtBottom, newMessageCount, mentionBelowId,
+    containerRef, contentRef, bottomRef, isAtBottom, newMessageCount, mentionBelowId,
     handleScroll, scrollToBottom, scrollToMessage,
-  } = useMessageListScroll({ messages, loading, loadingMore, channelId, firstUnreadId, currentUserId });
+  } = useMessageListScroll({ messages, loading, loadingMore, channelId, firstUnreadId, entryAnchorResolved, currentUserId });
 
   const sentinelRef = useRef<HTMLDivElement>(null);
   const onLoadMoreRef = useRef(onLoadMore);
@@ -91,57 +94,59 @@ export function MessageList({
         onScroll={handleScroll}
         data-testid="channel-message-list"
       >
-        {hasMore && <div ref={sentinelRef} className="h-1" />}
-        {loadingMore && (
-          <div className="flex justify-center py-3">
-            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-          </div>
-        )}
-
-        {dateGroups.map((dateGroup) => (
-          <div key={dateGroup.date}>
-            <div className="flex justify-center py-2">
-              <span className="text-[11px] text-muted-foreground">— {dateGroup.date} —</span>
+        <div ref={contentRef} className="flex min-h-full flex-col">
+          {hasMore && <div ref={sentinelRef} className="h-1" />}
+          {loadingMore && (
+            <div className="flex justify-center py-3">
+              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
             </div>
-            {dateGroup.messages.map((message) => (
-              <Fragment key={message.id}>
-                {firstUnreadId === message.id && <UnreadDivider />}
-                <MessageRow
-                  message={message}
-                  allPods={allPods}
-                  currentUserId={currentUserId}
-                  channelId={channelId}
-                  isFirstInGroup={groupFlags.get(message.id) ?? true}
-                  role={message.user ? roleByUserId?.get(message.user.id) : undefined}
-                  onEditMessage={onEditMessage}
-                  onDeleteMessage={onDeleteMessage}
-                />
-              </Fragment>
-            ))}
-          </div>
-        ))}
+          )}
 
-        {error && !loading && messages.length === 0 && (
-          <div className="flex h-full flex-col items-center justify-center text-muted-foreground">
-            <MessageSquare className="mb-4 h-12 w-12 opacity-30" />
-            <p className="text-sm text-destructive">{error}</p>
-            {onRetry && (
-              <button className="mt-2 text-xs text-primary hover:underline" onClick={onRetry}>
-                {t("loadOlder")}
-              </button>
-            )}
-          </div>
-        )}
+          {dateGroups.map((dateGroup) => (
+            <div key={dateGroup.date}>
+              <div className="flex justify-center py-2">
+                <span className="text-[11px] text-muted-foreground">— {dateGroup.date} —</span>
+              </div>
+              {dateGroup.messages.map((message) => (
+                <Fragment key={message.id}>
+                  {firstUnreadId === message.id && <UnreadDivider />}
+                  <MessageRow
+                    message={message}
+                    allPods={allPods}
+                    currentUserId={currentUserId}
+                    channelId={channelId}
+                    isFirstInGroup={groupFlags.get(message.id) ?? true}
+                    role={message.user ? roleByUserId?.get(message.user.id) : undefined}
+                    onEditMessage={onEditMessage}
+                    onDeleteMessage={onDeleteMessage}
+                  />
+                </Fragment>
+              ))}
+            </div>
+          ))}
 
-        {messages.length === 0 && !loading && !error && (
-          <div className="flex h-full flex-col items-center justify-center text-muted-foreground">
-            <MessageSquare className="mb-4 h-12 w-12 opacity-30" />
-            <p className="text-sm">{t("noMessages")}</p>
-            <p className="mt-1 text-xs">{t("startConversation")}</p>
-          </div>
-        )}
+          {error && !loading && messages.length === 0 && (
+            <div className="flex h-full flex-col items-center justify-center text-muted-foreground">
+              <MessageSquare className="mb-4 h-12 w-12 opacity-30" />
+              <p className="text-sm text-destructive">{error}</p>
+              {onRetry && (
+                <button className="mt-2 text-xs text-primary hover:underline" onClick={onRetry}>
+                  {t("loadOlder")}
+                </button>
+              )}
+            </div>
+          )}
 
-        <div ref={bottomRef} />
+          {messages.length === 0 && !loading && !error && (
+            <div className="flex h-full flex-col items-center justify-center text-muted-foreground">
+              <MessageSquare className="mb-4 h-12 w-12 opacity-30" />
+              <p className="text-sm">{t("noMessages")}</p>
+              <p className="mt-1 text-xs">{t("startConversation")}</p>
+            </div>
+          )}
+
+          <div ref={bottomRef} />
+        </div>
       </div>
 
       {mentionBelowId != null && messages.some((m) => m.id === mentionBelowId) && (

--- a/clients/web/src/components/channel/MobileChannelChat.tsx
+++ b/clients/web/src/components/channel/MobileChannelChat.tsx
@@ -108,6 +108,7 @@ export function MobileChannelChat({ channelId, onClose }: MobileChannelChatProps
             currentUserId={chat.currentUserId}
             channelId={channelId}
             firstUnreadId={chat.firstUnreadId}
+            entryAnchorResolved={chat.entryAnchorResolved}
             roleByUserId={chat.roleByUserId}
             onEditMessage={chat.handleEditMessage}
             onDeleteMessage={chat.handleDeleteMessage}

--- a/clients/web/src/components/channel/__tests__/MessageList.scroll.test.tsx
+++ b/clients/web/src/components/channel/__tests__/MessageList.scroll.test.tsx
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { MessageList } from "../MessageList";
+import type { TransformedMessage } from "../types";
+
+vi.mock("next-intl", () => ({ useTranslations: () => (key: string) => key }));
+vi.mock("@/stores/pod", () => ({ usePods: () => [] }));
+
+let resizeCallback: ResizeObserverCallback | null = null;
+
+class TestResizeObserver {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+  constructor(callback: ResizeObserverCallback) {
+    resizeCallback = callback;
+  }
+}
+
+function msg(id: number): TransformedMessage {
+  return {
+    id,
+    body: `message ${id}`,
+    messageType: "text",
+    createdAt: "2026-01-01T12:00:00Z",
+    user: { id: 7, username: "dev" },
+  };
+}
+
+function renderList(props: Partial<React.ComponentProps<typeof MessageList>> = {}) {
+  return render(
+    <MessageList
+      messages={[msg(10), msg(11), msg(12)]}
+      loading={false}
+      channelId={1}
+      {...props}
+    />,
+  );
+}
+
+let rafCallbacks: FrameRequestCallback[] = [];
+function flushRaf() {
+  const pending = rafCallbacks;
+  rafCallbacks = [];
+  pending.forEach((cb) => cb(performance.now()));
+}
+
+describe("MessageList entry scroll", () => {
+  const originalRAF = global.requestAnimationFrame;
+  const originalCAF = global.cancelAnimationFrame;
+  const originalRO = global.ResizeObserver;
+  const originalScrollIntoView = Element.prototype.scrollIntoView;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resizeCallback = null;
+    rafCallbacks = [];
+    global.ResizeObserver = TestResizeObserver as unknown as typeof ResizeObserver;
+    global.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      rafCallbacks.push(cb);
+      return rafCallbacks.length;
+    }) as typeof requestAnimationFrame;
+    global.cancelAnimationFrame = (() => {}) as typeof cancelAnimationFrame;
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    // Restore every global clobbered above. The fake requestAnimationFrame never
+    // invokes its callback, so leaking it into later test files in the same
+    // worker thread hangs their animations/userEvent flows (5s timeouts).
+    global.requestAnimationFrame = originalRAF;
+    global.cancelAnimationFrame = originalCAF;
+    global.ResizeObserver = originalRO;
+    Element.prototype.scrollIntoView = originalScrollIntoView;
+  });
+
+  it("scrolls to bottom on read-channel entry", () => {
+    renderList();
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({ behavior: "instant" });
+  });
+
+  it("scrolls the unread divider on unread entry", () => {
+    renderList({ firstUnreadId: 11 });
+
+    // getByRole("separator") is the UnreadDivider (the [data-unread-anchor]
+    // element); asserting on its own scrollIntoView proves the divider — not
+    // some other element — is what entry positioning scrolled to.
+    const divider = screen.getByRole("separator");
+    expect(divider.scrollIntoView).toHaveBeenCalledWith({ block: "start", behavior: "instant" });
+  });
+
+  it("waits for the anchor to resolve before the first scroll (no bottom→divider jump)", () => {
+    // Unknown cursor: entryAnchorResolved false, firstUnreadId not yet known.
+    const { rerender } = renderList({ firstUnreadId: null, entryAnchorResolved: false });
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+
+    // Cursor resolves to an unread divider — now (and only now) it anchors,
+    // straight to the divider rather than bottom-then-jump.
+    rerender(
+      <MessageList messages={[msg(10), msg(11), msg(12)]} loading={false} channelId={1} firstUnreadId={11} entryAnchorResolved />,
+    );
+    const divider = screen.getByRole("separator");
+    expect(divider.scrollIntoView).toHaveBeenCalledWith({ block: "start", behavior: "instant" });
+  });
+
+  it("re-anchors when a fresh same-length message window arrives", () => {
+    const { rerender } = renderList({ messages: [msg(1), msg(2), msg(3)] });
+    vi.mocked(Element.prototype.scrollIntoView).mockClear();
+
+    rerender(<MessageList messages={[msg(4), msg(5), msg(6)]} loading={false} channelId={1} />);
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({ behavior: "instant" });
+  });
+
+  it("keeps bottom alignment when content resizes before user intent", () => {
+    renderList();
+    vi.mocked(Element.prototype.scrollIntoView).mockClear();
+
+    act(() => {
+      resizeCallback?.([], {} as ResizeObserver);
+      flushRaf();
+    });
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({ behavior: "instant" });
+  });
+
+  it("does not re-anchor after the user scrolls (native scrollbar / any source)", () => {
+    renderList();
+    vi.mocked(Element.prototype.scrollIntoView).mockClear();
+
+    // A scroll to a position we did not programmatically request = user intent,
+    // regardless of gesture (native scrollbar, find-in-page, keyboard).
+    const list = screen.getByTestId("channel-message-list");
+    Object.defineProperty(list, "scrollTop", { value: 999, configurable: true });
+    fireEvent.scroll(list);
+    act(() => {
+      resizeCallback?.([], {} as ResizeObserver);
+      flushRaf();
+    });
+
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it("preserves the previous first message after loading older messages", () => {
+    const { rerender } = renderList({ messages: [msg(10), msg(11), msg(12)], loadingMore: false });
+
+    rerender(<MessageList messages={[msg(10), msg(11), msg(12)]} loading={false} loadingMore channelId={1} />);
+    vi.mocked(Element.prototype.scrollIntoView).mockClear();
+    rerender(<MessageList messages={[msg(7), msg(8), msg(9), msg(10), msg(11), msg(12)]} loading={false} loadingMore={false} channelId={1} />);
+
+    // Load-more restores the viewport to the previously-first message (top),
+    // not the bottom.
+    const previousFirst = document.querySelector('[data-message-id="10"]');
+    expect(previousFirst?.scrollIntoView).toHaveBeenCalledWith({ block: "start" });
+  });
+
+  it("follows a tall new message to the bottom using the pre-append position", () => {
+    const { rerender } = renderList({ messages: [msg(10), msg(11), msg(12)] });
+    const list = screen.getByTestId("channel-message-list");
+    // User sits exactly at the bottom before the new message arrives.
+    Object.defineProperty(list, "scrollHeight", { value: 300, configurable: true });
+    Object.defineProperty(list, "clientHeight", { value: 300, configurable: true });
+    Object.defineProperty(list, "scrollTop", { value: 0, configurable: true });
+    fireEvent.scroll(list);
+    vi.mocked(Element.prototype.scrollIntoView).mockClear();
+
+    // A tall message appends: post-append the raw gap (60px) exceeds the 50px
+    // slack, so a live DOM read would conclude "not at bottom" and strand it —
+    // the follow decision must instead use the position held before the append.
+    Object.defineProperty(list, "scrollHeight", { value: 360, configurable: true });
+    rerender(<MessageList messages={[msg(10), msg(11), msg(12), msg(13)]} loading={false} channelId={1} />);
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+  });
+
+  it("shows the new-message pill instead of following when the user has scrolled up", () => {
+    const { rerender } = renderList({ messages: [msg(10), msg(11), msg(12)] });
+    const list = screen.getByTestId("channel-message-list");
+    Object.defineProperty(list, "scrollHeight", { value: 1000, configurable: true });
+    Object.defineProperty(list, "clientHeight", { value: 300, configurable: true });
+    Object.defineProperty(list, "scrollTop", { value: 100, configurable: true });
+    fireEvent.scroll(list);
+    vi.mocked(Element.prototype.scrollIntoView).mockClear();
+
+    rerender(<MessageList messages={[msg(10), msg(11), msg(12), msg(13)]} loading={false} channelId={1} />);
+
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
+
+  it("does not re-anchor the unread divider when a message streams in after entry", () => {
+    const { rerender } = renderList({ firstUnreadId: 11, messages: [msg(10), msg(11), msg(12)] });
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({ block: "start", behavior: "instant" });
+    vi.mocked(Element.prototype.scrollIntoView).mockClear();
+
+    rerender(
+      <MessageList messages={[msg(10), msg(11), msg(12), msg(13)]} loading={false} channelId={1} firstUnreadId={11} entryAnchorResolved />,
+    );
+
+    // Entry positioning settled on the append; the streamed message must not drag
+    // the viewport back to the divider (block:start is the divider-anchor signature).
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalledWith({ block: "start", behavior: "instant" });
+  });
+
+  it("does not follow a message that streams in before the unread cursor resolves", async () => {
+    // Unknown cursor: entryAnchorResolved false, firstUnreadId not yet known.
+    const { rerender } = renderList({ messages: [msg(10), msg(11), msg(12)], firstUnreadId: null, entryAnchorResolved: false });
+    // Flush the channel-switch seed microtask (setIsAtBottom(false) for an
+    // unknown cursor). In the real app this microtask always runs before the
+    // next macrotask — i.e. before any streamed message can arrive.
+    await act(async () => { await Promise.resolve(); });
+    vi.mocked(Element.prototype.scrollIntoView).mockClear();
+
+    // A message arrives during the fetchUnreadCounts window. It must NOT auto-
+    // follow to the bottom — that would trip userInterrupted and lose the divider.
+    rerender(<MessageList messages={[msg(10), msg(11), msg(12), msg(13)]} loading={false} channelId={1} firstUnreadId={null} entryAnchorResolved={false} />);
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+
+    // Cursor resolves to a divider — entry now anchors straight to it.
+    rerender(<MessageList messages={[msg(10), msg(11), msg(12), msg(13)]} loading={false} channelId={1} firstUnreadId={11} entryAnchorResolved />);
+    const divider = screen.getByRole("separator");
+    expect(divider.scrollIntoView).toHaveBeenCalledWith({ block: "start", behavior: "instant" });
+  });
+
+  it("does not re-anchor entry positioning after a load-more prepend", () => {
+    const { rerender } = renderList({ messages: [msg(10), msg(11), msg(12)], loadingMore: false });
+    rerender(<MessageList messages={[msg(10), msg(11), msg(12)]} loading={false} loadingMore channelId={1} />);
+    vi.mocked(Element.prototype.scrollIntoView).mockClear();
+
+    // Older page prepends: firstId changes (→ anchorKey) but the tail id is
+    // unchanged. The load-more restore scrolls the previous first message to the
+    // top; entry positioning must NOT also re-anchor to the bottom and fight it.
+    rerender(<MessageList messages={[msg(7), msg(8), msg(9), msg(10), msg(11), msg(12)]} loading={false} loadingMore={false} channelId={1} />);
+
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalledWith({ behavior: "instant" });
+    expect(document.querySelector('[data-message-id="10"]')?.scrollIntoView).toHaveBeenCalledWith({ block: "start" });
+  });
+});

--- a/clients/web/src/components/channel/__tests__/useChannelEntryAnchor.test.tsx
+++ b/clients/web/src/components/channel/__tests__/useChannelEntryAnchor.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import { useChannelEntryAnchor } from "../useChannelEntryAnchor";
 import { getChannelState } from "@/lib/wasm-core";
 import type { TransformedMessage } from "../types";
@@ -12,27 +12,67 @@ const setCursor = (v: number) => vi.mocked(getChannelState().get_last_read_id).m
 describe("useChannelEntryAnchor", () => {
   beforeEach(() => vi.mocked(getChannelState().get_last_read_id).mockReset());
 
-  it("no known cursor (-1) → no divider", () => {
+  it("unknown cursor requests an unread summary before falling back", async () => {
     setCursor(-1);
-    const { result } = renderHook(() => useChannelEntryAnchor(1, msgs(10, 11, 12)));
-    expect(result.current).toBeNull();
+    const { result, rerender } = renderHook(
+      ({ attempted }) => useChannelEntryAnchor(1, msgs(10, 11, 12), attempted),
+      { initialProps: { attempted: false } },
+    );
+    expect(result.current).toEqual({ firstUnreadId: null, resolved: false, needsUnreadSummary: true });
+
+    rerender({ attempted: true });
+
+    await waitFor(() => {
+      expect(result.current).toEqual({ firstUnreadId: null, resolved: true, needsUnreadSummary: false });
+    });
   });
 
-  it("genuine 0 cursor → divider anchors at the first (all-unread) message", () => {
+  it("re-reads a now-known cursor once the summary fetch is attempted", async () => {
+    setCursor(-1);
+    const { result, rerender } = renderHook(
+      ({ attempted }) => useChannelEntryAnchor(1, msgs(10, 11, 12), attempted),
+      { initialProps: { attempted: false } },
+    );
+    expect(result.current.needsUnreadSummary).toBe(true);
+
+    // fetchUnreadCounts wrote the Rust cursor before resolving; flipping
+    // `attempted` re-runs the retry, which reads the now-known cursor.
+    setCursor(11);
+    rerender({ attempted: true });
+
+    await waitFor(() => {
+      expect(result.current).toEqual({ firstUnreadId: 12, resolved: true, needsUnreadSummary: false });
+    });
+  });
+
+  it("genuine 0 cursor anchors at the first message", () => {
     setCursor(0);
     const { result } = renderHook(() => useChannelEntryAnchor(2, msgs(10, 11, 12)));
-    expect(result.current).toBe(10);
+    expect(result.current).toEqual({ firstUnreadId: 10, resolved: true, needsUnreadSummary: false });
   });
 
-  it("cursor at 11 → divider at the first message after it", () => {
+  it("cursor at 11 anchors at the first message after it", () => {
     setCursor(11);
     const { result } = renderHook(() => useChannelEntryAnchor(3, msgs(10, 11, 12)));
-    expect(result.current).toBe(12);
+    expect(result.current).toEqual({ firstUnreadId: 12, resolved: true, needsUnreadSummary: false });
   });
 
-  it("fully read (cursor at latest) → no divider", () => {
+  it("fully read cursor has no divider", () => {
     setCursor(12);
     const { result } = renderHook(() => useChannelEntryAnchor(4, msgs(10, 11, 12)));
-    expect(result.current).toBeNull();
+    expect(result.current).toEqual({ firstUnreadId: null, resolved: true, needsUnreadSummary: false });
+  });
+
+  it("freezes the cursor for the current entry", () => {
+    setCursor(10);
+    const { result, rerender } = renderHook(() => useChannelEntryAnchor(5, msgs(10, 11, 12)));
+    expect(result.current.firstUnreadId).toBe(11);
+
+    // A known cursor is frozen for the entry: a later mark-read advancing it
+    // must not move the divider.
+    setCursor(12);
+    rerender();
+
+    expect(result.current.firstUnreadId).toBe(11);
   });
 });

--- a/clients/web/src/components/channel/entryAnchorScroll.ts
+++ b/clients/web/src/components/channel/entryAnchorScroll.ts
@@ -1,0 +1,56 @@
+export type EntryTarget = "bottom" | "unread";
+
+export interface EntryState {
+  userInterrupted: boolean;
+  settled: boolean;
+  lastAppliedKey: string | null;
+  anchoredLastId: number | null;
+  target: EntryTarget | null;
+  quiesceTimer: ReturnType<typeof setTimeout> | null;
+  resizeFrame: number | null;
+  // scrollTop we expect after our own programmatic scrollIntoView; the next
+  // scroll event matching it is ours, anything else is the user taking over.
+  expectedScrollTop: number | null;
+}
+
+export function createEntryState(): EntryState {
+  return {
+    userInterrupted: false,
+    settled: false,
+    lastAppliedKey: null,
+    anchoredLastId: null,
+    target: null,
+    quiesceTimer: null,
+    resizeFrame: null,
+    expectedScrollTop: null,
+  };
+}
+
+export function clearEntryTimers(state: EntryState) {
+  if (state.quiesceTimer) clearTimeout(state.quiesceTimer);
+  if (state.resizeFrame != null) cancelAnimationFrame(state.resizeFrame);
+  state.quiesceTimer = null;
+  state.resizeFrame = null;
+}
+
+export function scrollToEntryAnchor(
+  container: HTMLDivElement | null,
+  bottom: HTMLDivElement | null,
+  firstUnreadId: number | null | undefined,
+  state: EntryState,
+): EntryTarget | null {
+  const before = container?.scrollTop ?? null;
+  const anchor = firstUnreadId != null ? container?.querySelector("[data-unread-anchor]") : null;
+  if (anchor) {
+    anchor.scrollIntoView({ block: "start", behavior: "instant" as ScrollBehavior });
+  } else if (bottom) {
+    bottom.scrollIntoView({ behavior: "instant" as ScrollBehavior });
+  } else {
+    return null;
+  }
+  // Arm the "this scroll is ours" guard ONLY if the position actually moved: a
+  // no-op scroll fires no scroll event, so a lingering expectedScrollTop would
+  // otherwise swallow a later real user scroll that lands on that same offset.
+  if (container) state.expectedScrollTop = container.scrollTop === before ? null : container.scrollTop;
+  return anchor ? "unread" : "bottom";
+}

--- a/clients/web/src/components/channel/useChannelEntryAnchor.ts
+++ b/clients/web/src/components/channel/useChannelEntryAnchor.ts
@@ -1,39 +1,84 @@
 "use client";
 
-import { useMemo, useRef } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { getChannelState } from "@/lib/wasm-core";
 import type { TransformedMessage } from "./types";
 
-/**
- * Freeze the last-read cursor the first time a channel is opened — before the
- * 300ms markRead advances it — so the "new messages" boundary stays put while
- * the user reads. Returns the id of the first message after that cursor (the
- * divider + scroll anchor), or null when the channel is fully read.
- */
+export interface ChannelEntryAnchor {
+  firstUnreadId: number | null;
+  resolved: boolean;
+  needsUnreadSummary: boolean;
+}
+
+interface EntrySnapshot {
+  channelId: number | null;
+  lastReadId: number | null;
+  unknownResolved: boolean;
+}
+
+function readCursor(channelId: number): number | null {
+  const lastReadId = getChannelState().get_last_read_id(BigInt(channelId));
+  return lastReadId >= 0 ? lastReadId : null;
+}
+
+function makeSnapshot(channelId: number): EntrySnapshot {
+  const cursor = channelId ? readCursor(channelId) : null;
+  return {
+    channelId,
+    lastReadId: cursor,
+    unknownResolved: cursor != null || !channelId,
+  };
+}
+
 export function useChannelEntryAnchor(
   channelId: number,
   messages: TransformedMessage[],
-): number | null {
-  const snapRef = useRef<Map<number, number>>(new Map());
-  // Re-snapshot on each fresh (re-)entry — drop a stale snapshot for this
-  // channel so the divider reflects the CURRENT last-read cursor, not the one
-  // frozen on a prior visit. Stays frozen while we remain in the channel.
-  const enteredRef = useRef<number | null>(null);
-  if (channelId !== enteredRef.current) {
-    snapRef.current.delete(channelId);
-    enteredRef.current = channelId;
-  }
-  if (channelId && !snapRef.current.has(channelId)) {
-    snapRef.current.set(channelId, getChannelState().get_last_read_id(BigInt(channelId)));
-  }
-  const lastReadId = channelId ? snapRef.current.get(channelId) ?? -1 : -1;
+  unreadSummaryAttempted = false,
+): ChannelEntryAnchor {
+  const [snapshot, setSnapshot] = useState<EntrySnapshot>(() => makeSnapshot(channelId));
+
+  useEffect(() => {
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (!cancelled) setSnapshot(makeSnapshot(channelId));
+    });
+    return () => { cancelled = true; };
+  }, [channelId]);
+
+  useEffect(() => {
+    if (!channelId || snapshot.channelId !== channelId || snapshot.lastReadId != null || snapshot.unknownResolved) return;
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (cancelled) return;
+      const cursor = readCursor(channelId);
+      setSnapshot((current) => {
+        if (current.channelId !== channelId || current.lastReadId != null || current.unknownResolved) return current;
+        if (cursor != null) return { channelId, lastReadId: cursor, unknownResolved: true };
+        return unreadSummaryAttempted ? { ...current, unknownResolved: true } : current;
+      });
+    });
+    return () => { cancelled = true; };
+    // Retry re-runs when unreadSummaryAttempted flips after fetchUnreadCounts;
+    // that fetch writes the Rust cursor BEFORE resolving, so we read the fresh
+    // value here without subscribing to the global _unreadTick (which would
+    // re-run this on unread changes for unrelated channels).
+  }, [channelId, snapshot.channelId, snapshot.lastReadId, snapshot.unknownResolved, unreadSummaryAttempted]);
 
   return useMemo(() => {
-    // -1 = no known cursor (channel never reported by a summary fetch) → no
-    // divider. A genuine 0 cursor ("read nothing yet") is kept: every message id
-    // is > 0, so the divider correctly anchors at the first (all-unread) message.
-    if (lastReadId < 0) return null;
-    const first = messages.find((m) => m.id > lastReadId);
-    return first ? first.id : null;
-  }, [messages, lastReadId]);
+    if (!channelId) return { firstUnreadId: null, resolved: true, needsUnreadSummary: false };
+    if (snapshot.channelId !== channelId) return { firstUnreadId: null, resolved: false, needsUnreadSummary: false };
+    if (snapshot.lastReadId == null) {
+      return {
+        firstUnreadId: null,
+        resolved: snapshot.unknownResolved,
+        needsUnreadSummary: !snapshot.unknownResolved,
+      };
+    }
+    const first = messages.find((m) => m.id > snapshot.lastReadId!);
+    return {
+      firstUnreadId: first ? first.id : null,
+      resolved: true,
+      needsUnreadSummary: false,
+    };
+  }, [channelId, messages, snapshot]);
 }

--- a/clients/web/src/components/channel/useMessageEntryPosition.ts
+++ b/clients/web/src/components/channel/useMessageEntryPosition.ts
@@ -1,0 +1,149 @@
+"use client";
+
+import { useEffect, useLayoutEffect, useRef } from "react";
+import type { RefObject } from "react";
+import type { TransformedMessage } from "./types";
+import { clearEntryTimers, createEntryState, scrollToEntryAnchor } from "./entryAnchorScroll";
+
+interface UseMessageEntryPositionOptions {
+  channelId?: number;
+  messages: TransformedMessage[];
+  loading?: boolean;
+  loadingMore?: boolean;
+  firstUnreadId?: number | null;
+  entryAnchorResolved?: boolean;
+  containerRef: RefObject<HTMLDivElement | null>;
+  contentRef: RefObject<HTMLDivElement | null>;
+  bottomRef: RefObject<HTMLDivElement | null>;
+  // Fires when an anchor lands, so the caller can sync at-bottom state to the
+  // real landed position (a divider at scrollTop 0 emits no correcting scroll).
+  onAnchor?: () => void;
+}
+
+// Entry "settles" once content height holds steady this long (a ResizeObserver
+// quiescence signal), so late images re-anchor and fast layouts settle early.
+const REFLOW_QUIESCE_MS = 250;
+
+export function useMessageEntryPosition({
+  channelId,
+  messages,
+  loading,
+  loadingMore,
+  firstUnreadId,
+  entryAnchorResolved = true,
+  containerRef,
+  contentRef,
+  bottomRef,
+  onAnchor,
+}: UseMessageEntryPositionOptions) {
+  const firstId = messages[0]?.id ?? null;
+  const lastId = messages[messages.length - 1]?.id ?? null;
+  // Anchor identity omits the tail id / length on purpose: an appended message
+  // must not re-fire entry positioning (that yanks back to the divider). Only a
+  // window swap (firstId) or moved cursor (firstUnreadId) is a real re-anchor.
+  const anchorKey = `${channelId ?? "none"}:${firstId ?? "none"}:${firstUnreadId ?? "read"}`;
+  const stateRef = useRef(createEntryState());
+
+  // Live inputs the ResizeObserver reads; synced in a layout effect so they are
+  // fresh before the pre-paint observer/RAF fire (a passive effect lags a frame).
+  const liveRef = useRef({ loading, loadingMore, hasMessages: messages.length > 0, firstUnreadId, entryAnchorResolved });
+  useLayoutEffect(() => {
+    liveRef.current = { loading, loadingMore, hasMessages: messages.length > 0, firstUnreadId, entryAnchorResolved };
+  }, [loading, loadingMore, messages.length, firstUnreadId, entryAnchorResolved]);
+
+  useEffect(() => {
+    const state = stateRef.current;
+    clearEntryTimers(state);
+    Object.assign(state, createEntryState());
+    return () => clearEntryTimers(state);
+  }, [channelId]);
+
+  useEffect(() => {
+    if (!loading) return;
+    const state = stateRef.current;
+    clearEntryTimers(state);
+    state.settled = false;
+    state.lastAppliedKey = null;
+  }, [loading]);
+
+  // Intent is derived from real scroll position: any scroll that isn't our own
+  // programmatic re-anchor (native scrollbar, keyboard, momentum) = user takeover.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const onScroll = () => {
+      const state = stateRef.current;
+      if (state.expectedScrollTop != null && Math.abs(container.scrollTop - state.expectedScrollTop) <= 2) {
+        state.expectedScrollTop = null;
+        return;
+      }
+      state.userInterrupted = true;
+      state.settled = true;
+      clearEntryTimers(state);
+    };
+    container.addEventListener("scroll", onScroll, { passive: true });
+    return () => container.removeEventListener("scroll", onScroll);
+  }, [channelId, containerRef]);
+
+  useEffect(() => {
+    const state = stateRef.current;
+    if (!channelId || loading || loadingMore || messages.length === 0 || state.userInterrupted || state.settled) return;
+    // Wait for the unread cursor to resolve before the first anchor, so an unknown
+    // cursor doesn't land at the bottom and then jump to the divider on resolve.
+    if (!entryAnchorResolved) return;
+    if (state.lastAppliedKey === anchorKey) {
+      // Already anchored this window; a grown tail = live traffic started — settle
+      // so the stream flows / shows the pill instead of being dragged back.
+      if (state.anchoredLastId != null && lastId !== state.anchoredLastId) state.settled = true;
+      return;
+    }
+    // A load-more prepend changes firstId (→ anchorKey) but keeps the same tail;
+    // adopt the new key WITHOUT re-anchoring — useMessageListScroll's load-more
+    // restore owns that viewport, and re-anchoring would fight it.
+    if (state.lastAppliedKey !== null && lastId === state.anchoredLastId) {
+      state.lastAppliedKey = anchorKey;
+      return;
+    }
+
+    const target = scrollToEntryAnchor(containerRef.current, bottomRef.current, firstUnreadId, state);
+    if (!target) return;
+    state.lastAppliedKey = anchorKey;
+    state.anchoredLastId = lastId;
+    state.target = target;
+    onAnchor?.();
+  }, [anchorKey, bottomRef, channelId, containerRef, entryAnchorResolved, firstUnreadId, lastId, loading, loadingMore, messages.length, onAnchor]);
+
+  // Re-anchor on content growth (late images/embeds) and mark settled once the
+  // reflow goes quiet — a debounced quiescence signal, reset on every resize.
+  useEffect(() => {
+    const content = contentRef.current;
+    if (!content || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => {
+      const state = stateRef.current;
+      const live = liveRef.current;
+      if (state.userInterrupted || live.loading || live.loadingMore || !live.hasMessages || !live.entryAnchorResolved) return;
+      if (state.quiesceTimer) clearTimeout(state.quiesceTimer);
+      state.quiesceTimer = setTimeout(() => {
+        state.quiesceTimer = null;
+        state.settled = true;
+      }, REFLOW_QUIESCE_MS);
+      if (state.resizeFrame != null) cancelAnimationFrame(state.resizeFrame);
+      state.resizeFrame = requestAnimationFrame(() => {
+        state.resizeFrame = null;
+        if (state.userInterrupted || state.settled) return;
+        const target = scrollToEntryAnchor(containerRef.current, bottomRef.current, liveRef.current.firstUnreadId, state);
+        if (target) {
+          state.target = target;
+          onAnchor?.();
+        }
+      });
+    });
+    observer.observe(content);
+    return () => {
+      observer.disconnect();
+      const state = stateRef.current;
+      if (state.resizeFrame != null) cancelAnimationFrame(state.resizeFrame);
+      state.resizeFrame = null;
+    };
+  }, [bottomRef, channelId, containerRef, contentRef, onAnchor]);
+}

--- a/clients/web/src/components/channel/useMessageListScroll.ts
+++ b/clients/web/src/components/channel/useMessageListScroll.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
 import { prefersReducedMotion } from "@/lib/scroll-behavior";
+import { useMessageEntryPosition } from "./useMessageEntryPosition";
 import type { TransformedMessage } from "./types";
 
 interface UseMessageListScrollOptions {
@@ -10,11 +11,13 @@ interface UseMessageListScrollOptions {
   loadingMore?: boolean;
   channelId?: number;
   firstUnreadId?: number | null;
+  entryAnchorResolved?: boolean;
   currentUserId?: number;
 }
 
 interface UseMessageListScrollReturn {
   containerRef: React.RefObject<HTMLDivElement | null>;
+  contentRef: React.RefObject<HTMLDivElement | null>;
   bottomRef: React.RefObject<HTMLDivElement | null>;
   isAtBottom: boolean;
   newMessageCount: number;
@@ -30,25 +33,38 @@ function mentionsMe(m: TransformedMessage, userId?: number): boolean {
   return userId != null && (m.mentions.users?.includes(userId) ?? false);
 }
 
+function isScrolledToBottom(el: HTMLDivElement | null): boolean {
+  if (!el) return true;
+  return el.scrollHeight - el.scrollTop - el.clientHeight < 50;
+}
+
 export function useMessageListScroll({
   messages,
   loading,
   loadingMore,
   channelId,
   firstUnreadId,
+  entryAnchorResolved = true,
   currentUserId,
 }: UseMessageListScrollOptions): UseMessageListScrollReturn {
   const bottomRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
 
   const [isAtBottom, setIsAtBottom] = useState(true);
   const [newMessageCount, setNewMessageCount] = useState(0);
   const [mentionBelowId, setMentionBelowId] = useState<number | null>(null);
 
+  // The append-effect must decide follow-to-bottom from the position held BEFORE
+  // the new message committed. Appends fire no scroll event, so this ref (synced
+  // from the state that scroll + entry-anchor keep current) holds exactly that
+  // pre-append truth — a live DOM read there would measure the post-append gap
+  // and strand a tall message.
+  const isAtBottomRef = useRef(isAtBottom);
+  useEffect(() => { isAtBottomRef.current = isAtBottom; }, [isAtBottom]);
+
   const handleScroll = useCallback(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 50;
+    const atBottom = isScrolledToBottom(containerRef.current);
     setIsAtBottom(atBottom);
     if (atBottom) {
       setNewMessageCount(0);
@@ -60,15 +76,50 @@ export function useMessageListScroll({
   const wasLoadingMoreRef = useRef(false);
   const initialLoadDone = useRef(false);
 
-  // Channel switch happens without remount (the panel isn't keyed by id), so
-  // reset entry refs — otherwise the new channel inherits the previous
-  // channel's "already loaded" flag and never anchors or jumps to bottom.
-  // newMessageCount / isAtBottom self-correct on the first scroll event.
   useEffect(() => {
     initialLoadDone.current = false;
     wasLoadingMoreRef.current = false;
     prevStateRef.current = { length: 0 };
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (cancelled) return;
+      // Seed at-bottom ONLY when the cursor is resolved AND there is no unread.
+      // An unknown cursor must not seed `true`: a message streamed in during the
+      // unread-summary fetch would then auto-follow to the bottom, trip the entry
+      // hook's scroll listener (userInterrupted), and permanently defeat the
+      // divider once the cursor resolves. onEntryAnchor corrects this once an
+      // anchor actually lands.
+      setIsAtBottom(entryAnchorResolved && firstUnreadId == null);
+      setNewMessageCount(0);
+      setMentionBelowId(null);
+    });
+    return () => { cancelled = true; };
+    // firstUnreadId / entryAnchorResolved intentionally excluded: this seeds on
+    // channel switch only; a late resolve must not re-run and clobber a live
+    // isAtBottom.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [channelId]);
+
+  // When entry positioning lands an anchor, sync isAtBottom to where it actually
+  // landed so the FAB/pill and the append-follow decision agree with it — in
+  // particular a divider anchored at scrollTop 0 fires no scroll event to correct
+  // a stale seed, which would otherwise hide the FAB and let a stream yank down.
+  const onEntryAnchor = useCallback(() => {
+    setIsAtBottom(isScrolledToBottom(containerRef.current));
+  }, []);
+
+  useMessageEntryPosition({
+    channelId,
+    messages,
+    loading,
+    loadingMore,
+    firstUnreadId,
+    entryAnchorResolved,
+    containerRef,
+    contentRef,
+    bottomRef,
+    onAnchor: onEntryAnchor,
+  });
 
   useEffect(() => {
     if (loadingMore) wasLoadingMoreRef.current = true;
@@ -93,20 +144,13 @@ export function useMessageListScroll({
       }
     } else if (!initialLoadDone.current && messages.length > 0 && !loading) {
       initialLoadDone.current = true;
-      // On entry, position at the first unread (divider) when there is one;
-      // otherwise jump straight to the latest message. No early return — the
-      // prevStateRef sync below must run so the first post-entry message is
-      // counted (and scanned for an @me) instead of being swallowed.
-      const anchor = firstUnreadId != null
-        ? containerRef.current?.querySelector("[data-unread-anchor]")
-        : null;
-      if (anchor) {
-        anchor.scrollIntoView({ block: "start", behavior: "instant" as ScrollBehavior });
-      } else {
-        bottomRef.current?.scrollIntoView({ behavior: "instant" as ScrollBehavior });
-      }
     } else if (messages.length > prev.length && prev.length > 0) {
-      if (isAtBottom) {
+      // Follow the new message only if the user was at the bottom BEFORE it
+      // arrived (isAtBottomRef, kept current by scroll + entry-anchor). A live
+      // DOM read here would measure the post-append gap and wrongly strand a tall
+      // message; on an unread channel the divider anchor keeps this false so the
+      // message shows the pill instead of yanking down.
+      if (isAtBottomRef.current) {
         bottomRef.current?.scrollIntoView({
           behavior: prefersReducedMotion() ? "instant" : "smooth",
         });
@@ -118,7 +162,7 @@ export function useMessageListScroll({
     }
 
     prevStateRef.current = { length: messages.length, firstId };
-  }, [messages, loadingMore, loading, isAtBottom, firstUnreadId, currentUserId]);
+  }, [messages, loadingMore, loading, currentUserId]);
 
   const scrollToBottom = useCallback(() => {
     bottomRef.current?.scrollIntoView({
@@ -135,7 +179,7 @@ export function useMessageListScroll({
   }, []);
 
   return {
-    containerRef, bottomRef, isAtBottom, newMessageCount, mentionBelowId,
+    containerRef, contentRef, bottomRef, isAtBottom, newMessageCount, mentionBelowId,
     handleScroll, scrollToBottom, scrollToMessage,
   };
 }

--- a/clients/web/src/components/ide/BottomPanel.tsx
+++ b/clients/web/src/components/ide/BottomPanel.tsx
@@ -3,12 +3,11 @@
 import React, { useRef, useEffect, useState, useCallback } from "react";
 import { cn } from "@/lib/utils";
 import { useIDEStore, type BottomPanelTab } from "@/stores/ide";
-import { useChannelStore } from "@/stores/channel";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { ChevronDown, ChevronUp, X, MessageSquare, Activity, Bot, GitPullRequest, Info } from "lucide-react";
 import { AutopilotPanelContent } from "@/components/autopilot";
-import { useCurrentOrg, useAuthStore } from "@/stores/auth";
+import { useCurrentOrg } from "@/stores/auth";
 import { useBottomPanelData } from "./useBottomPanelData";
 import { ChannelsTabContent, ActivityTabContent, DeliveryTabContent, InfoTabContent } from "./BottomPanel/index";
 
@@ -37,8 +36,11 @@ export function BottomPanel({ className }: { className?: string }) {
     podChannels, incomingBindings, outgoingBindings, getPodInfo,
   } = useBottomPanelData();
 
+  // Channel selection here is panel-local — the docked panel is an ephemeral
+  // peek surface. Deliberately NOT wired to the app-global selectedChannelId
+  // (that drives /channels + the sidebar); closing/collapsing the panel must
+  // not wipe those. useChannelChat inside the detail view already marks-read.
   const [selectedChannelId, setSelectedChannelId] = useState<number | null>(null);
-  const setCurrentChannel = useChannelStore((s) => s.setCurrentChannel);
   const resizeRef = useRef<HTMLDivElement>(null);
   const [isResizing, setIsResizing] = useState(false);
 
@@ -56,8 +58,7 @@ export function BottomPanel({ className }: { className?: string }) {
   }, [isResizing, setBottomPanelHeight]);
 
   const handleChannelClick = useCallback((id: number) => setSelectedChannelId(id), []);
-  const handleBackToChannelList = useCallback(() => { setSelectedChannelId(null); setCurrentChannel(null); }, [setCurrentChannel]);
-  const handlePodsChanged = useCallback(() => fetchTopology(), [fetchTopology]);
+  const handleBackToChannelList = useCallback(() => setSelectedChannelId(null), []);
   const handleTabClick = useCallback((tabId: BottomPanelTab, shouldOpen = false) => {
     setBottomPanelTab(tabId);
     if (shouldOpen) setBottomPanelOpen(true);
@@ -105,7 +106,7 @@ export function BottomPanel({ className }: { className?: string }) {
         <Button variant="ghost" size="sm" className="h-6 w-6 p-0" onClick={() => setBottomPanelOpen(false)}><X className="w-4 h-4" /></Button>
       </div>
       <div className="flex-1 overflow-auto p-2">
-        {bottomPanelTab === "channels" && <ChannelsTabContent selectedPodKey={selectedPodKey} podChannels={podChannels} selectedChannelId={selectedChannelId} onChannelClick={handleChannelClick} onBackToList={handleBackToChannelList} onPodsChanged={handlePodsChanged} t={t} />}
+        {bottomPanelTab === "channels" && <ChannelsTabContent selectedPodKey={selectedPodKey} podChannels={podChannels} selectedChannelId={selectedChannelId} onChannelClick={handleChannelClick} onBackToList={handleBackToChannelList} t={t} />}
         {bottomPanelTab === "activity" && <ActivityTabContent selectedPodKey={selectedPodKey} incomingBindings={incomingBindings} outgoingBindings={outgoingBindings} getPodInfo={getPodInfo} t={t} />}
         {bottomPanelTab === "autopilot" && <AutopilotPanelContent podKey={selectedPodKey} />}
         {bottomPanelTab === "delivery" && <DeliveryTabContent selectedPodKey={selectedPodKey} pod={currentPod} t={t} />}

--- a/clients/web/src/components/ide/BottomPanel/ChannelDetailView.tsx
+++ b/clients/web/src/components/ide/BottomPanel/ChannelDetailView.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { ChannelHeader } from "@/components/channel/ChannelHeader";
 import { ChannelDocument } from "@/components/channel/ChannelDocument";
@@ -12,25 +11,17 @@ import { useChannelChat } from "@/hooks/useChannelChat";
 interface ChannelDetailViewProps {
   channelId: number;
   onBack: () => void;
-  onPodsChanged?: () => void;
   t: (key: string, params?: Record<string, string | number>) => string;
 }
 
 export function ChannelDetailView({
   channelId,
   onBack,
-  onPodsChanged,
   t,
 }: ChannelDetailViewProps) {
   const chat = useChannelChat({ channelId });
-  const { handlePodsChanged: chatPodsChanged } = chat;
   const isMember = chat.currentChannel?.is_member ?? true;
   const visibility = chat.currentChannel?.visibility ?? "public";
-
-  const handlePodsChanged = useCallback(() => {
-    chatPodsChanged();
-    onPodsChanged?.();
-  }, [chatPodsChanged, onPodsChanged]);
 
   return (
     <div className="flex flex-col h-full">
@@ -76,6 +67,7 @@ export function ChannelDetailView({
               currentUserId={chat.currentUserId}
               channelId={channelId}
               firstUnreadId={chat.firstUnreadId}
+              entryAnchorResolved={chat.entryAnchorResolved}
               roleByUserId={chat.roleByUserId}
               onEditMessage={chat.handleEditMessage}
               onDeleteMessage={chat.handleDeleteMessage}

--- a/clients/web/src/components/ide/BottomPanel/ChannelsTabContent.tsx
+++ b/clients/web/src/components/ide/BottomPanel/ChannelsTabContent.tsx
@@ -11,7 +11,6 @@ export function ChannelsTabContent({
   selectedChannelId,
   onChannelClick,
   onBackToList,
-  onPodsChanged,
   t,
 }: ChannelsTabContentProps) {
   if (selectedChannelId) {
@@ -19,7 +18,6 @@ export function ChannelsTabContent({
       <ChannelDetailView
         channelId={selectedChannelId}
         onBack={onBackToList}
-        onPodsChanged={onPodsChanged}
         t={t}
       />
     );

--- a/clients/web/src/components/ide/BottomPanel/types.ts
+++ b/clients/web/src/components/ide/BottomPanel/types.ts
@@ -13,7 +13,6 @@ export interface ChannelsTabContentProps extends TabContentProps {
   selectedChannelId: number | null;
   onChannelClick: (channelId: number) => void;
   onBackToList: () => void;
-  onPodsChanged?: () => void;
 }
 
 export interface ActivityTabContentProps extends TabContentProps {

--- a/clients/web/src/components/ide/__tests__/BottomPanel.channel-selection.test.tsx
+++ b/clients/web/src/components/ide/__tests__/BottomPanel.channel-selection.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { BottomPanel } from "../BottomPanel";
+import { useIDEStore } from "@/stores/ide";
+import { useChannelStore } from "@/stores/channel";
+
+vi.mock("next-intl", () => ({ useTranslations: () => (key: string) => key }));
+vi.mock("@/stores/auth", () => ({
+  useCurrentOrg: () => ({ slug: "test-org" }),
+  readCurrentOrg: () => ({ slug: "test-org" }),
+  readCurrentUser: () => ({ id: 1 }),
+}));
+vi.mock("@/components/autopilot", () => ({ AutopilotPanelContent: () => null }));
+vi.mock("../useBottomPanelData", () => ({
+  useBottomPanelData: () => ({
+    selectedPodKey: "pod-1",
+    currentPod: null,
+    activeAutopilot: null,
+    topology: { nodes: [], edges: [], channels: [] },
+    fetchTopology: vi.fn(),
+    podChannels: [{ id: 42, name: "general", pod_keys: ["pod-1"] }],
+    incomingBindings: [],
+    outgoingBindings: [],
+    getPodInfo: vi.fn(),
+  }),
+}));
+vi.mock("../BottomPanel/index", () => ({
+  ChannelsTabContent: ({ selectedChannelId, onChannelClick, onBackToList }: {
+    selectedChannelId: number | null;
+    onChannelClick: (id: number) => void;
+    onBackToList: () => void;
+  }) => selectedChannelId ? (
+    <button onClick={onBackToList}>back-to-list</button>
+  ) : (
+    <button onClick={() => onChannelClick(42)}>general</button>
+  ),
+  ActivityTabContent: () => null,
+  DeliveryTabContent: () => null,
+  InfoTabContent: () => null,
+}));
+
+describe("BottomPanel channel selection (panel-local)", () => {
+  beforeEach(() => {
+    useIDEStore.setState({ bottomPanelOpen: true, bottomPanelTab: "channels", bottomPanelHeight: 200 });
+    useChannelStore.setState({ selectedChannelId: null });
+  });
+
+  it("opens the channel detail view locally", () => {
+    render(<BottomPanel />);
+
+    fireEvent.click(screen.getByText("general"));
+
+    expect(screen.getByText("back-to-list")).toBeInTheDocument();
+  });
+
+  it("returns to the channel list on back", () => {
+    render(<BottomPanel />);
+    fireEvent.click(screen.getByText("general"));
+
+    fireEvent.click(screen.getByText("back-to-list"));
+
+    expect(screen.getByText("general")).toBeInTheDocument();
+  });
+
+  it("returns to the channel list when switching tabs", () => {
+    render(<BottomPanel />);
+    fireEvent.click(screen.getByText("general"));
+
+    fireEvent.click(screen.getByText("ide.bottomPanel.activity"));
+    fireEvent.click(screen.getByText("ide.bottomPanel.channels"));
+
+    expect(screen.getByText("general")).toBeInTheDocument();
+  });
+
+  it("never touches the app-global selectedChannelId", () => {
+    render(<BottomPanel />);
+
+    fireEvent.click(screen.getByText("general"));
+    fireEvent.click(screen.getByText("back-to-list"));
+
+    // The docked panel is a local peek surface; the /channels page and IDE
+    // sidebar selection must survive interacting with it.
+    expect(useChannelStore.getState().selectedChannelId).toBeNull();
+  });
+});

--- a/clients/web/src/hooks/__tests__/useChannelEntryMarkRead.test.tsx
+++ b/clients/web/src/hooks/__tests__/useChannelEntryMarkRead.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useChannelEntryMarkRead } from "../useChannelEntryMarkRead";
+
+describe("useChannelEntryMarkRead", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("marks read after the debounce once the anchor is resolved", () => {
+    const markRead = vi.fn().mockResolvedValue(undefined);
+    renderHook(() =>
+      useChannelEntryMarkRead({ channelId: 1, lastMessageId: 99, entryAnchorResolved: true, markRead }),
+    );
+
+    expect(markRead).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(300);
+    expect(markRead).toHaveBeenCalledWith(1, 99);
+  });
+
+  it("flushes on unmount even if the anchor never resolved (unknown cursor, quick leave)", () => {
+    const markRead = vi.fn().mockResolvedValue(undefined);
+    const { unmount } = renderHook(() =>
+      useChannelEntryMarkRead({ channelId: 1, lastMessageId: 99, entryAnchorResolved: false, markRead }),
+    );
+
+    // Left before fetchUnreadCounts resolved: the debounce has not even fired,
+    // but the pending mark-read must still flush so the channel is marked read.
+    unmount();
+    expect(markRead).toHaveBeenCalledWith(1, 99);
+  });
+
+  it("defers the cursor advance until the anchor resolves, then flushes", () => {
+    const markRead = vi.fn().mockResolvedValue(undefined);
+    const { rerender } = renderHook(
+      ({ resolved }) =>
+        useChannelEntryMarkRead({ channelId: 1, lastMessageId: 99, entryAnchorResolved: resolved, markRead }),
+      { initialProps: { resolved: false } },
+    );
+
+    // Debounce elapses while still unresolved → must NOT advance the cursor yet.
+    vi.advanceTimersByTime(300);
+    expect(markRead).not.toHaveBeenCalled();
+
+    // Anchor resolves → the parked pending flushes immediately.
+    rerender({ resolved: true });
+    expect(markRead).toHaveBeenCalledWith(1, 99);
+  });
+
+  it("does not double-mark when it resolves before the debounce fires", () => {
+    const markRead = vi.fn().mockResolvedValue(undefined);
+    const { rerender } = renderHook(
+      ({ resolved }) =>
+        useChannelEntryMarkRead({ channelId: 1, lastMessageId: 99, entryAnchorResolved: resolved, markRead }),
+      { initialProps: { resolved: false } },
+    );
+
+    // Resolves mid-debounce (before 300ms): the resolve effect must not flush
+    // early, and the timer must flush exactly once.
+    rerender({ resolved: true });
+    expect(markRead).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(300);
+    expect(markRead).toHaveBeenCalledTimes(1);
+    expect(markRead).toHaveBeenCalledWith(1, 99);
+  });
+});

--- a/clients/web/src/hooks/useChannelChat.ts
+++ b/clients/web/src/hooks/useChannelChat.ts
@@ -1,12 +1,13 @@
 "use client";
 
-import { useEffect, useCallback, useMemo, useRef } from "react";
-import { useCurrentUser, useAuthStore } from "@/stores/auth";
+import { useEffect, useCallback, useMemo, useState } from "react";
+import { useCurrentUser } from "@/stores/auth";
 import { useChannelStore, useChannelMessageStore, useCurrentChannel, useChannelMembers } from "@/stores/channel";
 import { EMPTY_CACHE, LOAD_MORE_MESSAGE_LIMIT, useChannelMessages } from "@/stores/channelMessageStore";
 import { useMeshStore, useTopology } from "@/stores/mesh";
 import { transformMessage } from "@/components/channel/transformMessage";
 import { useChannelEntryAnchor } from "@/components/channel/useChannelEntryAnchor";
+import { useChannelEntryMarkRead } from "./useChannelEntryMarkRead";
 import type { TransformedMessage } from "@/components/channel/types";
 import type { MessageSendPayload, MessageEditPayload } from "@/lib/viewModels/channelMessage";
 
@@ -25,6 +26,7 @@ interface UseChannelChatReturn {
   transformedMessages: TransformedMessage[];
   hasMore: boolean;
   firstUnreadId: number | null;
+  entryAnchorResolved: boolean;
   roleByUserId: Map<number, string>;
   currentUserId: number | undefined;
   handlePodsChanged: () => void;
@@ -56,6 +58,7 @@ export function useChannelChat({ channelId }: UseChannelChatOptions): UseChannel
   const editMessage = useChannelMessageStore((s) => s.editMessage);
   const deleteMessage = useChannelMessageStore((s) => s.deleteMessage);
   const markRead = useChannelMessageStore((s) => s.markRead);
+  const fetchUnreadCounts = useChannelMessageStore((s) => s.fetchUnreadCounts);
 
   const topology = useTopology();
   const fetchTopology = useMeshStore((s) => s.fetchTopology);
@@ -71,35 +74,16 @@ export function useChannelChat({ channelId }: UseChannelChatOptions): UseChannel
   }, [channelId, fetchChannel, fetchMessages, setCurrentChannel]);
 
   const lastMessageId = messages.length > 0 ? messages[messages.length - 1].id : null;
-  const prevLastMsgIdRef = useRef<number | null>(null);
-  const markReadTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const lastMessageIdRef = useRef(lastMessageId);
-  lastMessageIdRef.current = lastMessageId;
-
-  useEffect(() => {
-    if (lastMessageId !== null && lastMessageId !== prevLastMsgIdRef.current) {
-      prevLastMsgIdRef.current = lastMessageId;
-      if (markReadTimerRef.current) clearTimeout(markReadTimerRef.current);
-      markReadTimerRef.current = setTimeout(() => {
-        markRead(channelId, lastMessageId);
-      }, 300);
-    }
-    return () => {
-      if (markReadTimerRef.current) clearTimeout(markReadTimerRef.current);
-    };
-  }, [lastMessageId, channelId, markRead]);
-
-  useEffect(() => {
-    return () => {
-      if (markReadTimerRef.current) {
-        clearTimeout(markReadTimerRef.current);
-        if (lastMessageIdRef.current !== null) {
-          markRead(channelId, lastMessageIdRef.current);
-        }
-      }
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [channelId]);
+  // Tagged with channelId: `attempted` only counts for the channel it was set
+  // on, so switching away derives false without a reset effect. (A→B→A re-entry
+  // reuses a stale attempted=true, but only matters if the cursor is unknown
+  // again on return, which mark-read on the prior visit makes vanishingly rare.)
+  const [unreadSummaryState, setUnreadSummaryState] = useState({
+    channelId: null as number | null,
+    attempted: false,
+  });
+  const unreadSummaryAttempted =
+    unreadSummaryState.channelId === channelId && unreadSummaryState.attempted;
 
   const channelInfo = topology?.channels.find((c: { id: number }) => c.id === channelId);
   const agentCount = currentChannel?.agent_count ?? channelInfo?.pod_keys.length ?? 0;
@@ -149,7 +133,26 @@ export function useChannelChat({ channelId }: UseChannelChatOptions): UseChannel
     [messages]
   );
 
-  const firstUnreadId = useChannelEntryAnchor(channelId, transformedMessages);
+  const entryAnchor = useChannelEntryAnchor(channelId, transformedMessages, unreadSummaryAttempted);
+  const firstUnreadId = entryAnchor.firstUnreadId;
+
+  useEffect(() => {
+    if (!entryAnchor.needsUnreadSummary || unreadSummaryAttempted) return;
+    let cancelled = false;
+    fetchUnreadCounts().finally(() => {
+      if (!cancelled) setUnreadSummaryState({ channelId, attempted: true });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [channelId, entryAnchor.needsUnreadSummary, fetchUnreadCounts, unreadSummaryAttempted]);
+
+  useChannelEntryMarkRead({
+    channelId,
+    lastMessageId,
+    entryAnchorResolved: entryAnchor.resolved,
+    markRead,
+  });
 
   const members = useChannelMembers(channelId);
   const roleByUserId = useMemo(
@@ -168,6 +171,7 @@ export function useChannelChat({ channelId }: UseChannelChatOptions): UseChannel
     transformedMessages,
     hasMore,
     firstUnreadId,
+    entryAnchorResolved: entryAnchor.resolved,
     roleByUserId,
     currentUserId,
     handlePodsChanged,

--- a/clients/web/src/hooks/useChannelEntryMarkRead.ts
+++ b/clients/web/src/hooks/useChannelEntryMarkRead.ts
@@ -1,0 +1,79 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+interface UseChannelEntryMarkReadOptions {
+  channelId: number;
+  lastMessageId: number | null;
+  entryAnchorResolved: boolean;
+  markRead: (channelId: number, messageId: number) => Promise<void>;
+}
+
+interface PendingMarkRead {
+  channelId: number;
+  messageId: number;
+}
+
+export function useChannelEntryMarkRead({
+  channelId,
+  lastMessageId,
+  entryAnchorResolved,
+  markRead,
+}: UseChannelEntryMarkReadOptions) {
+  const prevLastMsgIdRef = useRef<number | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingRef = useRef<PendingMarkRead | null>(null);
+  // The 300ms debounce may elapse before the entry anchor is resolved; the
+  // timer parks the pending here so we don't advance the read cursor before the
+  // divider is frozen. A separate effect flushes it once resolved.
+  const debounceElapsedRef = useRef(false);
+  // Read the latest resolved state from the timer callback rather than its
+  // captured closure value, which may be stale by the time it fires.
+  const resolvedRef = useRef(entryAnchorResolved);
+  useEffect(() => { resolvedRef.current = entryAnchorResolved; }, [entryAnchorResolved]);
+
+  const flush = useCallback(() => {
+    const pending = pendingRef.current;
+    pendingRef.current = null;
+    debounceElapsedRef.current = false;
+    if (pending) markRead(pending.channelId, pending.messageId);
+  }, [markRead]);
+
+  useEffect(() => {
+    return () => {
+      // On unmount / channel switch, flush whatever is pending — even if the
+      // anchor never resolved (unknown cursor + quick leave) — so the channel
+      // still gets marked read.
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = null;
+      flush();
+    };
+  }, [channelId, flush]);
+
+  useEffect(() => {
+    prevLastMsgIdRef.current = null;
+    debounceElapsedRef.current = false;
+  }, [channelId]);
+
+  // Arm the pending mark-read as soon as a new last message appears — NOT gated
+  // on the anchor, so a quick leave still flushes. Advancing the cursor is what
+  // waits for resolution (see the timer callback + the resolve effect below).
+  useEffect(() => {
+    if (lastMessageId === null || lastMessageId === prevLastMsgIdRef.current) return;
+    prevLastMsgIdRef.current = lastMessageId;
+    if (timerRef.current) clearTimeout(timerRef.current);
+    pendingRef.current = { channelId, messageId: lastMessageId };
+    debounceElapsedRef.current = false;
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      debounceElapsedRef.current = true;
+      if (resolvedRef.current) flush();
+    }, 300);
+  }, [channelId, lastMessageId, flush]);
+
+  // If the debounce already elapsed while the anchor was still unresolved,
+  // flush the moment it resolves.
+  useEffect(() => {
+    if (entryAnchorResolved && debounceElapsedRef.current) flush();
+  }, [entryAnchorResolved, flush]);
+}


### PR DESCRIPTION
## What

Makes channel entry scroll / unread-divider positioning robust, without regressing the stick-to-bottom chat behavior.

- Entry positioning is resilient to cached / fresh / late-reflow message windows (ResizeObserver quiescence signal, not a one-shot). Scroll primitives extracted to `entryAnchorScroll.ts`; the entry state machine to `useMessageEntryPosition.ts`.
- **Follow-to-bottom** reads the **pre-append** at-bottom state, so a tall streamed message no longer strands the viewport.
- **Seed at-bottom only once the unread cursor resolves** — a message arriving during the unread-summary fetch can't yank an unread channel to the bottom and permanently lose the divider.
- A **load-more prepend** adopts the new window key without re-anchoring, instead of fighting the scroll-position restore.
- Freeze the unread cursor and **delay mark-read** until the entry anchor resolves.
- BottomPanel channel selection stays **panel-local** (ephemeral peek surface; never touches the app-global selection).

## Tests
- New unit specs: `MessageList.scroll`, `useChannelEntryMarkRead`, `BottomPanel.channel-selection`; extended `useChannelEntryAnchor`.
- Fixes a test-teardown global leak (fake RAF / ResizeObserver / scrollIntoView not restored in `afterEach`) that flaked unrelated dialog specs.

## Verification
- `bazel test //clients/web:unit` — green (deterministic)
- `bazel test //clients/web:lint` — green
- `tsc --noEmit` — touched files clean
- Web e2e (channel / read-state subset) — 18 passed
- Desktop Electron e2e — 386 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)