### PR TITLE
feat: add Atlas Cloud AI provider support

### DIFF
--- a/backend/internal/domain/agentpod/settings.go
+++ b/backend/internal/domain/agentpod/settings.go
@@ -46,10 +46,13 @@ func (UserAIProvider) TableName() string {
 }
 
 const (
-	AIProviderTypeClaude = "claude"
-	AIProviderTypeGemini = "gemini"
-	AIProviderTypeCodex  = "codex"
-	AIProviderTypeOpenAI = "openai"
+	AIProviderTypeClaude     = "claude"
+	AIProviderTypeGemini     = "gemini"
+	AIProviderTypeCodex      = "codex"
+	AIProviderTypeOpenAI     = "openai"
+	AIProviderTypeAtlasCloud = "atlascloud"
+
+	AtlasCloudDefaultBaseURL = "https://api.atlascloud.ai/v1"
 )
 
 type ClaudeCredentials struct {
@@ -66,6 +69,11 @@ type OpenAICredentials struct {
 
 type GeminiCredentials struct {
 	APIKey string `json:"api_key"`
+}
+
+type AtlasCloudCredentials struct {
+	APIKey  string `json:"api_key"`
+	BaseURL string `json:"base_url,omitempty"`
 }
 
 var ProviderEnvVarMapping = map[string]map[string]string{
@@ -85,5 +93,9 @@ var ProviderEnvVarMapping = map[string]map[string]string{
 	AIProviderTypeCodex: {
 		"api_key":      "OPENAI_API_KEY",
 		"organization": "OPENAI_ORG_ID",
+	},
+	AIProviderTypeAtlasCloud: {
+		"api_key":  "ATLASCLOUD_API_KEY",
+		"base_url": "ATLASCLOUD_BASE_URL",
 	},
 }

--- a/backend/internal/domain/agentpod/settings_test.go
+++ b/backend/internal/domain/agentpod/settings_test.go
@@ -16,6 +16,7 @@ func TestAIProviderTypeConstants(t *testing.T) {
 		{AIProviderTypeGemini, "gemini"},
 		{AIProviderTypeCodex, "codex"},
 		{AIProviderTypeOpenAI, "openai"},
+		{AIProviderTypeAtlasCloud, "atlascloud"},
 	}
 
 	for _, tt := range tests {
@@ -143,7 +144,13 @@ func TestUserAIProviderStruct(t *testing.T) {
 }
 
 func TestUserAIProviderWithAllProviderTypes(t *testing.T) {
-	types := []string{AIProviderTypeClaude, AIProviderTypeGemini, AIProviderTypeCodex, AIProviderTypeOpenAI}
+	types := []string{
+		AIProviderTypeClaude,
+		AIProviderTypeGemini,
+		AIProviderTypeCodex,
+		AIProviderTypeOpenAI,
+		AIProviderTypeAtlasCloud,
+	}
 
 	for _, pt := range types {
 		p := UserAIProvider{ProviderType: pt}
@@ -201,6 +208,20 @@ func TestGeminiCredentialsStruct(t *testing.T) {
 	}
 }
 
+func TestAtlasCloudCredentialsStruct(t *testing.T) {
+	creds := AtlasCloudCredentials{
+		APIKey:  "atlas-key",
+		BaseURL: AtlasCloudDefaultBaseURL,
+	}
+
+	if creds.APIKey != "atlas-key" {
+		t.Errorf("expected APIKey 'atlas-key', got %s", creds.APIKey)
+	}
+	if creds.BaseURL != AtlasCloudDefaultBaseURL {
+		t.Errorf("expected BaseURL '%s', got %s", AtlasCloudDefaultBaseURL, creds.BaseURL)
+	}
+}
+
 // --- Test ProviderEnvVarMapping ---
 
 func TestProviderEnvVarMappingClaude(t *testing.T) {
@@ -250,8 +271,25 @@ func TestProviderEnvVarMappingCodex(t *testing.T) {
 	}
 }
 
+func TestProviderEnvVarMappingAtlasCloud(t *testing.T) {
+	mapping := ProviderEnvVarMapping[AIProviderTypeAtlasCloud]
+
+	if mapping["api_key"] != "ATLASCLOUD_API_KEY" {
+		t.Errorf("expected 'ATLASCLOUD_API_KEY', got %s", mapping["api_key"])
+	}
+	if mapping["base_url"] != "ATLASCLOUD_BASE_URL" {
+		t.Errorf("expected 'ATLASCLOUD_BASE_URL', got %s", mapping["base_url"])
+	}
+}
+
 func TestProviderEnvVarMappingAllProviders(t *testing.T) {
-	providers := []string{AIProviderTypeClaude, AIProviderTypeOpenAI, AIProviderTypeGemini, AIProviderTypeCodex}
+	providers := []string{
+		AIProviderTypeClaude,
+		AIProviderTypeOpenAI,
+		AIProviderTypeGemini,
+		AIProviderTypeCodex,
+		AIProviderTypeAtlasCloud,
+	}
 
 	for _, provider := range providers {
 		mapping, exists := ProviderEnvVarMapping[provider]

--- a/backend/internal/service/agentpod/ai_provider_crypto.go
+++ b/backend/internal/service/agentpod/ai_provider_crypto.go
@@ -58,6 +58,22 @@ func (s *AIProviderService) formatEnvVars(providerType string, credentials map[s
 		}
 	}
 
+	if providerType == agentpod.AIProviderTypeAtlasCloud {
+		if apiKey := credentials["api_key"]; apiKey != "" {
+			envVars["ATLAS_CLOUD_API_KEY"] = apiKey
+			envVars["OPENAI_API_KEY"] = apiKey
+		}
+
+		baseURL := credentials["base_url"]
+		if baseURL == "" {
+			baseURL = agentpod.AtlasCloudDefaultBaseURL
+		}
+		envVars["ATLASCLOUD_BASE_URL"] = baseURL
+		envVars["ATLASCLOUD_API_BASE"] = baseURL
+		envVars["ATLAS_CLOUD_API_BASE"] = baseURL
+		envVars["OPENAI_BASE_URL"] = baseURL
+	}
+
 	return envVars
 }
 
@@ -74,6 +90,10 @@ func (s *AIProviderService) ValidateCredentials(providerType string, credentials
 	case agentpod.AIProviderTypeGemini:
 		if credentials["api_key"] == "" {
 			return errors.New("gemini provider requires api_key")
+		}
+	case agentpod.AIProviderTypeAtlasCloud:
+		if credentials["api_key"] == "" {
+			return errors.New("atlascloud provider requires api_key")
 		}
 	}
 	return nil

--- a/backend/internal/service/agentpod/ai_provider_service_credentials_test.go
+++ b/backend/internal/service/agentpod/ai_provider_service_credentials_test.go
@@ -138,6 +138,18 @@ func TestValidateCredentials(t *testing.T) {
 			credentials:  map[string]string{},
 			expectError:  true,
 		},
+		{
+			name:         "atlascloud with api_key",
+			providerType: agentpod.AIProviderTypeAtlasCloud,
+			credentials:  map[string]string{"api_key": "atlas-test"},
+			expectError:  false,
+		},
+		{
+			name:         "atlascloud without api_key",
+			providerType: agentpod.AIProviderTypeAtlasCloud,
+			credentials:  map[string]string{},
+			expectError:  true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/backend/internal/service/agentpod/ai_provider_service_envvars_test.go
+++ b/backend/internal/service/agentpod/ai_provider_service_envvars_test.go
@@ -70,6 +70,56 @@ func TestFormatEnvVars_Gemini(t *testing.T) {
 	}
 }
 
+func TestFormatEnvVars_AtlasCloud(t *testing.T) {
+	service := newTestAIProviderService(nil, nil)
+
+	t.Run("default OpenAI-compatible base URL", func(t *testing.T) {
+		creds := map[string]string{
+			"api_key": "atlas-test-key",
+		}
+
+		envVars := service.formatEnvVars(agentpod.AIProviderTypeAtlasCloud, creds)
+
+		if envVars["ATLASCLOUD_API_KEY"] != "atlas-test-key" {
+			t.Errorf("expected ATLASCLOUD_API_KEY 'atlas-test-key', got '%s'", envVars["ATLASCLOUD_API_KEY"])
+		}
+		if envVars["ATLAS_CLOUD_API_KEY"] != "atlas-test-key" {
+			t.Errorf("expected ATLAS_CLOUD_API_KEY 'atlas-test-key', got '%s'", envVars["ATLAS_CLOUD_API_KEY"])
+		}
+		if envVars["OPENAI_API_KEY"] != "atlas-test-key" {
+			t.Errorf("expected OPENAI_API_KEY 'atlas-test-key', got '%s'", envVars["OPENAI_API_KEY"])
+		}
+		if envVars["OPENAI_BASE_URL"] != agentpod.AtlasCloudDefaultBaseURL {
+			t.Errorf("expected OPENAI_BASE_URL '%s', got '%s'", agentpod.AtlasCloudDefaultBaseURL, envVars["OPENAI_BASE_URL"])
+		}
+		if envVars["ATLASCLOUD_BASE_URL"] != agentpod.AtlasCloudDefaultBaseURL {
+			t.Errorf("expected ATLASCLOUD_BASE_URL '%s', got '%s'", agentpod.AtlasCloudDefaultBaseURL, envVars["ATLASCLOUD_BASE_URL"])
+		}
+		if envVars["ATLASCLOUD_API_BASE"] != agentpod.AtlasCloudDefaultBaseURL {
+			t.Errorf("expected ATLASCLOUD_API_BASE '%s', got '%s'", agentpod.AtlasCloudDefaultBaseURL, envVars["ATLASCLOUD_API_BASE"])
+		}
+		if envVars["ATLAS_CLOUD_API_BASE"] != agentpod.AtlasCloudDefaultBaseURL {
+			t.Errorf("expected ATLAS_CLOUD_API_BASE '%s', got '%s'", agentpod.AtlasCloudDefaultBaseURL, envVars["ATLAS_CLOUD_API_BASE"])
+		}
+	})
+
+	t.Run("custom base URL", func(t *testing.T) {
+		creds := map[string]string{
+			"api_key":  "atlas-test-key",
+			"base_url": "https://atlas.example/v1",
+		}
+
+		envVars := service.formatEnvVars(agentpod.AIProviderTypeAtlasCloud, creds)
+
+		if envVars["OPENAI_BASE_URL"] != "https://atlas.example/v1" {
+			t.Errorf("expected OPENAI_BASE_URL custom value, got '%s'", envVars["OPENAI_BASE_URL"])
+		}
+		if envVars["ATLASCLOUD_BASE_URL"] != "https://atlas.example/v1" {
+			t.Errorf("expected ATLASCLOUD_BASE_URL custom value, got '%s'", envVars["ATLASCLOUD_BASE_URL"])
+		}
+	})
+}
+
 func TestGetAIProviderEnvVars(t *testing.T) {
 	db := setupTestDB(t)
 	service := newTestAIProviderService(db, nil)
@@ -128,6 +178,33 @@ func TestGetAIProviderEnvVarsByID(t *testing.T) {
 
 	if envVars["ANTHROPIC_API_KEY"] != "by-id-key" {
 		t.Errorf("expected ANTHROPIC_API_KEY 'by-id-key', got '%s'", envVars["ANTHROPIC_API_KEY"])
+	}
+}
+
+func TestGetAIProviderEnvVarsByID_AtlasCloud(t *testing.T) {
+	db := setupTestDB(t)
+	service := newTestAIProviderService(db, nil)
+	ctx := context.Background()
+
+	creds := map[string]string{"api_key": "atlas-by-id-key"}
+	provider, err := service.CreateUserProvider(ctx, 1, agentpod.AIProviderTypeAtlasCloud, "Atlas Cloud", creds, true)
+	if err != nil {
+		t.Fatalf("failed to create provider: %v", err)
+	}
+
+	envVars, err := service.GetAIProviderEnvVarsByID(ctx, provider.ID)
+	if err != nil {
+		t.Fatalf("failed to get env vars by ID: %v", err)
+	}
+
+	if envVars["ATLASCLOUD_API_KEY"] != "atlas-by-id-key" {
+		t.Errorf("expected ATLASCLOUD_API_KEY 'atlas-by-id-key', got '%s'", envVars["ATLASCLOUD_API_KEY"])
+	}
+	if envVars["OPENAI_API_KEY"] != "atlas-by-id-key" {
+		t.Errorf("expected OPENAI_API_KEY 'atlas-by-id-key', got '%s'", envVars["OPENAI_API_KEY"])
+	}
+	if envVars["OPENAI_BASE_URL"] != agentpod.AtlasCloudDefaultBaseURL {
+		t.Errorf("expected OPENAI_BASE_URL '%s', got '%s'", agentpod.AtlasCloudDefaultBaseURL, envVars["OPENAI_BASE_URL"])
 	}
 }
 

--- a/backend/internal/service/agentpod/mock_ai_provider_service.go
+++ b/backend/internal/service/agentpod/mock_ai_provider_service.go
@@ -181,6 +181,10 @@ func (m *MockAIProviderService) ValidateCredentials(providerType string, credent
 		if _, ok := credentials["api_key"]; !ok {
 			return ErrMissingAPIKey
 		}
+	case domain.AIProviderTypeAtlasCloud:
+		if _, ok := credentials["api_key"]; !ok {
+			return ErrMissingAPIKey
+		}
 	}
 	return nil
 }

--- a/proto/gen/ts/pod/v1/agentpod_settings_pb.ts
+++ b/proto/gen/ts/pod/v1/agentpod_settings_pb.ts
@@ -74,7 +74,7 @@ export type AIProvider = Message<"proto.pod.v1.AIProvider"> & {
   id: bigint;
 
   /**
-   * claude | gemini | codex | openai
+   * claude | gemini | codex | openai | atlascloud
    *
    * @generated from field: string provider_type = 2;
    */

--- a/proto/pod/v1/agentpod_settings.proto
+++ b/proto/pod/v1/agentpod_settings.proto
@@ -54,7 +54,7 @@ message AIProvider {
   };
 
   int64 id = 1 [(amesh.codegen.v1.field_rename) = "ID"];
-  // claude | gemini | codex | openai
+  // claude | gemini | codex | openai | atlascloud
   string provider_type = 2;
   string name = 3;
   bool is_default = 4;


### PR DESCRIPTION
## Summary
- add `atlascloud` as a first-class user AI provider type
- export Atlas Cloud credentials through `ATLASCLOUD_*` aliases and OpenAI-compatible `OPENAI_*` environment variables
- default Atlas Cloud requests to `https://api.atlascloud.ai/v1` and cover credential/env-var behavior with focused tests

## Validation
- `git diff --cached --check`
- `git diff --check`
- Atlas Cloud live model catalog returned 436 models and confirmed `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`

Not run locally:
- `gofmt` / focused `go test`: Go is not installed in this environment, and downloading the official darwin/arm64 Go SDK failed with `SSL_ERROR_SYSCALL` from `dl.google.com`.
