### PR TITLE
fix(channel): restore follow-to-bottom for new messages (v0.44.5 regression)

### DIFF
--- a/clients/web/src/components/channel/__tests__/MessageList.scroll.test.tsx
+++ b/clients/web/src/components/channel/__tests__/MessageList.scroll.test.tsx
@@ -204,21 +204,18 @@ describe("MessageList entry scroll", () => {
     expect(Element.prototype.scrollIntoView).not.toHaveBeenCalledWith({ block: "start", behavior: "instant" });
   });
 
-  it("does not follow a message that streams in before the unread cursor resolves", async () => {
-    // Unknown cursor: entryAnchorResolved false, firstUnreadId not yet known.
+  it("follows streamed messages by default (at-bottom seed), then anchors the divider on cursor resolve", async () => {
+    // Entry seeds isAtBottom=true so a streamed message follows into view rather
+    // than silently showing only a pill — the v0.44.5 regression was seeding it
+    // false and latching it there via a fragile post-anchor scroll read.
     const { rerender } = renderList({ messages: [msg(10), msg(11), msg(12)], firstUnreadId: null, entryAnchorResolved: false });
-    // Flush the channel-switch seed microtask (setIsAtBottom(false) for an
-    // unknown cursor). In the real app this microtask always runs before the
-    // next macrotask — i.e. before any streamed message can arrive.
-    await act(async () => { await Promise.resolve(); });
+    await act(async () => { await Promise.resolve(); }); // flush the channel-switch seed microtask
     vi.mocked(Element.prototype.scrollIntoView).mockClear();
 
-    // A message arrives during the fetchUnreadCounts window. It must NOT auto-
-    // follow to the bottom — that would trip userInterrupted and lose the divider.
     rerender(<MessageList messages={[msg(10), msg(11), msg(12), msg(13)]} loading={false} channelId={1} firstUnreadId={null} entryAnchorResolved={false} />);
-    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
 
-    // Cursor resolves to a divider — entry now anchors straight to it.
+    // Once the cursor resolves to an unread divider, entry positioning anchors it.
     rerender(<MessageList messages={[msg(10), msg(11), msg(12), msg(13)]} loading={false} channelId={1} firstUnreadId={11} entryAnchorResolved />);
     const divider = screen.getByRole("separator");
     expect(divider.scrollIntoView).toHaveBeenCalledWith({ block: "start", behavior: "instant" });

--- a/clients/web/src/components/channel/useMessageEntryPosition.ts
+++ b/clients/web/src/components/channel/useMessageEntryPosition.ts
@@ -15,9 +15,6 @@ interface UseMessageEntryPositionOptions {
   containerRef: RefObject<HTMLDivElement | null>;
   contentRef: RefObject<HTMLDivElement | null>;
   bottomRef: RefObject<HTMLDivElement | null>;
-  // Fires when an anchor lands, so the caller can sync at-bottom state to the
-  // real landed position (a divider at scrollTop 0 emits no correcting scroll).
-  onAnchor?: () => void;
 }
 
 // Entry "settles" once content height holds steady this long (a ResizeObserver
@@ -34,7 +31,6 @@ export function useMessageEntryPosition({
   containerRef,
   contentRef,
   bottomRef,
-  onAnchor,
 }: UseMessageEntryPositionOptions) {
   const firstId = messages[0]?.id ?? null;
   const lastId = messages[messages.length - 1]?.id ?? null;
@@ -110,8 +106,7 @@ export function useMessageEntryPosition({
     state.lastAppliedKey = anchorKey;
     state.anchoredLastId = lastId;
     state.target = target;
-    onAnchor?.();
-  }, [anchorKey, bottomRef, channelId, containerRef, entryAnchorResolved, firstUnreadId, lastId, loading, loadingMore, messages.length, onAnchor]);
+  }, [anchorKey, bottomRef, channelId, containerRef, entryAnchorResolved, firstUnreadId, lastId, loading, loadingMore, messages.length]);
 
   // Re-anchor on content growth (late images/embeds) and mark settled once the
   // reflow goes quiet — a debounced quiescence signal, reset on every resize.
@@ -132,10 +127,7 @@ export function useMessageEntryPosition({
         state.resizeFrame = null;
         if (state.userInterrupted || state.settled) return;
         const target = scrollToEntryAnchor(containerRef.current, bottomRef.current, liveRef.current.firstUnreadId, state);
-        if (target) {
-          state.target = target;
-          onAnchor?.();
-        }
+        if (target) state.target = target;
       });
     });
     observer.observe(content);
@@ -145,5 +137,5 @@ export function useMessageEntryPosition({
       if (state.resizeFrame != null) cancelAnimationFrame(state.resizeFrame);
       state.resizeFrame = null;
     };
-  }, [bottomRef, channelId, containerRef, contentRef, onAnchor]);
+  }, [bottomRef, channelId, containerRef, contentRef]);
 }

--- a/clients/web/src/components/channel/useMessageListScroll.ts
+++ b/clients/web/src/components/channel/useMessageListScroll.ts
@@ -83,30 +83,16 @@ export function useMessageListScroll({
     let cancelled = false;
     queueMicrotask(() => {
       if (cancelled) return;
-      // Seed at-bottom ONLY when the cursor is resolved AND there is no unread.
-      // An unknown cursor must not seed `true`: a message streamed in during the
-      // unread-summary fetch would then auto-follow to the bottom, trip the entry
-      // hook's scroll listener (userInterrupted), and permanently defeat the
-      // divider once the cursor resolves. onEntryAnchor corrects this once an
-      // anchor actually lands.
-      setIsAtBottom(entryAnchorResolved && firstUnreadId == null);
+      // Default to at-bottom so a streamed message follows into view; real scroll
+      // events (handleScroll) flip it to false once the user scrolls up. Entry
+      // positioning owns WHERE the viewport lands (divider vs bottom); it must not
+      // also suppress follow-to-bottom, or new messages silently stop appearing.
+      setIsAtBottom(true);
       setNewMessageCount(0);
       setMentionBelowId(null);
     });
     return () => { cancelled = true; };
-    // firstUnreadId / entryAnchorResolved intentionally excluded: this seeds on
-    // channel switch only; a late resolve must not re-run and clobber a live
-    // isAtBottom.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [channelId]);
-
-  // When entry positioning lands an anchor, sync isAtBottom to where it actually
-  // landed so the FAB/pill and the append-follow decision agree with it — in
-  // particular a divider anchored at scrollTop 0 fires no scroll event to correct
-  // a stale seed, which would otherwise hide the FAB and let a stream yank down.
-  const onEntryAnchor = useCallback(() => {
-    setIsAtBottom(isScrolledToBottom(containerRef.current));
-  }, []);
 
   useMessageEntryPosition({
     channelId,
@@ -118,7 +104,6 @@ export function useMessageListScroll({
     containerRef,
     contentRef,
     bottomRef,
-    onAnchor: onEntryAnchor,
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Problem (v0.44.5 regression, reported on Desktop)

- New messages in an open channel didn't appear (only a pill), not following into view.
- Suspected related: entry sometimes not landing on the latest message.

## Cause

The v0.44.5 entry-scroll refactor made `isAtBottom` depend on the unread cursor (seed) and re-derived it after every anchor via a live `isScrolledToBottom(container)` DOM read (`onEntryAnchor`). In real layout that read can run **before** content settles and latch at-bottom to `false`, so the append-follow shows a pill instead of scrolling the new message into view.

## Fix

Restore the proven v0.44.4 semantics: **`isAtBottom` defaults `true` and is updated only by real scroll events** (`handleScroll`). Entry positioning still owns *where* the viewport lands (unread divider vs bottom) — it just no longer suppresses follow-to-bottom. Removes the fragile `onEntryAnchor` callback and the now-unused `onAnchor` plumbing. Net −26 lines.

## Verification

- `bazel test //clients/web:unit` + `:lint` — green
- `tsc --noEmit` — touched files clean
- Real browser (dev stack): read-channel entry lands at bottom; sending follows to bottom; unread channel shows the divider.

Note: the exact reported symptoms could not be fully reproduced in the web dev env with the seed (short, text-only) channels; this restores the known-good at-bottom behavior and will be verified on a Desktop build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)